### PR TITLE
Add metadata to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "bids-manager"
 version = "0.1.0"
 description = "GUI application to manage BIDS datasets"
+readme = "README.md"
+license = {text = "MIT"}
 authors = [{name="BIDS Manager"}]
 requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
 dependencies = [
     "pydicom",
     "pandas",


### PR DESCRIPTION
## Summary
- set README and license metadata in `pyproject.toml`
- advertise Python 3 compatibility via classifier

## Testing
- `python -m build --wheel`
- `python -m pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_684013a0db508326a18867a91d561ed2