### PR TITLE
Improve BIDS Manager usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,11 @@ After installation the following commands become available:
 
 All utilities provide `-h/--help` for details.
 
+### Recent updates
+
+- The TSV produced by `dicom-inventory` can now be loaded directly in the GUI and
+  its file name customised before generation.
+- The Batch Rename tool previews changes and allows restricting the scope to
+  specific subjects.
+
 

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -17,7 +17,7 @@ Why you want this
 Output columns (ordered as they appear)
 ---------------------------------------
 subject        – GivenName shown only on the first row of each subject block
-BIDS_name      – auto-assigned `sub-001`, `sub-002`, …
+BIDS_name      – auto-assigned `sub-001`, `sub-002`, … (same GivenName → same ID)
 session        – `ses-<label>` if exactly one unique session tag is present in
                  that folder, otherwise blank
 source_folder  – relative path under *root_dir* where the DICOM series was found
@@ -145,7 +145,7 @@ def scan_dicoms_long(root_dir: str,
             )
             study = str(study).strip()
 
-            subj_key = f"{subj}||{study}"
+            subj_key = subj
 
             # ---- source folder  (first dir under root)
             rel = os.path.relpath(root, root_dir)


### PR DESCRIPTION
## Summary
- assign BIDS IDs by GivenName so repeated names map to the same sub-XXX
- allow naming or loading the TSV in the GUI
- fix modality tree crash due to signal duplication
- extend Batch Rename with scope selector
- document new features

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68403c4132088326b5e6ae8bae982505