### PR TITLE
Fix subject naming, heudiconv path lookup and preview layout

### DIFF
--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -177,8 +177,9 @@ def scan_dicoms_long(root_dir: str,
                        for folder, seq_dict in subj.items())
     print(f"Unique SeriesDescriptions : {total_series}")
 
-    # PASS 2: assign BIDS subject numbers
-    bids_map = {sid: f"sub-{i+1:03d}" for i, sid in enumerate(sorted(demo))}
+    # PASS 2: assign BIDS subject numbers based only on GivenName/PatientID
+    subj_ids = sorted({k.split("||")[0] for k in demo})
+    bids_map = {sid: f"sub-{i+1:03d}" for i, sid in enumerate(subj_ids)}
     print("Assigned BIDS IDs:", bids_map)
 
     # PASS 3: build DataFrame rows
@@ -198,7 +199,7 @@ def scan_dicoms_long(root_dir: str,
                     include = 0
                 rows.append({
                     "subject"       : demo[subj_key]["GivenName"] if first_row else "",
-                    "BIDS_name"     : bids_map[subj_key],
+                    "BIDS_name"     : bids_map[subj_key.split("||")[0]],
                     "session"       : session,
                     "source_folder" : folder,
                     "include"       : include,

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -154,10 +154,8 @@ class BIDSManager(QMainWindow):
         self.preview_button.clicked.connect(self.generatePreview)
         preview_layout.addWidget(self.preview_button)
 
-        splitter.addWidget(preview_group)
-        splitter.setStretchFactor(2, 1)
-
         main_layout.addWidget(splitter, 1)
+        main_layout.addWidget(preview_group)
 
         btn_row = QHBoxLayout()
         self.run_button = QPushButton("Run")

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -28,11 +28,15 @@ def clean_name(raw: str) -> str:
 
 
 def physical_by_clean(raw_root: Path) -> Dict[str, str]:
-    """
-    Return mapping folder_name → folder_name  (no cleaning),
-    only first-level dirs under *raw_root*.
-    """
-    return {p.name: p.name for p in raw_root.iterdir() if p.is_dir()}
+    """Return mapping cleaned_name → relative folder path for all subdirs."""
+    mapping: Dict[str, str] = {}
+    for p in raw_root.rglob("*"):
+        if not p.is_dir():
+            continue
+        rel = str(p.relative_to(raw_root))
+        mapping[rel] = rel
+        mapping[clean_name(rel)] = rel
+    return mapping
 
 
 


### PR DESCRIPTION
## Summary
- assign BIDS ids using only the subject name so studies share the same id
- map cleaned and nested folder paths when running HeuDiConv
- place preview pane below TSV viewer and modalities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407417c2908326854ab406afe99cfe