### PR TITLE
Add NIfTI viewer and adjustable panels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "pandas",
     "PyQt5",
     "heudiconv",
+    "nibabel",
+    "numpy",
 ]
 
 


### PR DESCRIPTION
## Summary
- remove Non‑BIDS column from the modalities tree
- wrap preview and log panels in a splitter for resizing
- show images when NIfTI files are selected in Edit tab
- add nibabel/numpy dependencies

## Testing
- `python -m py_compile bids_manager/gui.py`
- `python -m py_compile bids_manager/bids_editor_ancpbids.py`


------
https://chatgpt.com/codex/tasks/task_e_68415302a8f8832692ad53e50270718d