### PR TITLE
Fix image viewer resize response

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -790,6 +790,7 @@ class MetadataViewer(QWidget):
         vlay.addLayout(self.toolbar)
         self.viewer = None
         self.current_path = None
+        self.data = None  # holds loaded NIfTI data when viewing images
 
     def clear(self):
         """Clear the toolbar and viewer when switching files."""
@@ -819,6 +820,18 @@ class MetadataViewer(QWidget):
             self._setup_nifti_toolbar()
             self.viewer = self._nifti_view(path)
         self.layout().addWidget(self.viewer)
+
+    def resizeEvent(self, event):
+        """Ensure images rescale when the window size decreases."""
+        super().resizeEvent(event)
+        # If a NIfTI image is currently loaded, update the displayed slice
+        if (
+            self.data is not None
+            and self.current_path
+            and _get_ext(self.current_path) in ['.nii', '.nii.gz']
+            and hasattr(self, 'img_label')
+        ):
+            self._update_slice()
 
     def _setup_json_toolbar(self):
         """Add buttons for JSON editing: Add Field, Delete Field, Save."""


### PR DESCRIPTION
## Summary
- keep NIfTI image data around in `MetadataViewer`
- trigger a slice update on widget resize so the pixmap scales when the window is made smaller

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416c6bacbc8326b4321b5b0fbe48a1