### PR TITLE
Improve nested DICOM folder handling

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -62,7 +62,7 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
     )
 
     # 2 ─ SID_MAP ----------------------------------------------------------
-    sid_pairs = {(r.source_folder, r.BIDS_name) for r in df.itertuples()}
+    sid_pairs = {(clean(str(r.source_folder)), r.BIDS_name) for r in df.itertuples()}
     buf.append("\nSID_MAP = {\n")
     for folder, bids in sorted(sid_pairs):
         buf.append(f"    '{folder}': '{bids}',\n")
@@ -74,7 +74,7 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
 
     for row in df.itertuples():
         ses = str(row.session).strip() if pd.notna(row.session) and str(row.session).strip() else ""
-        folder = str(row.source_folder)
+        folder = Path(str(row.source_folder)).name
         key_id = (row.sequence, row.BIDS_name, ses, folder)
         if key_id in seq2key:
             continue

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -20,7 +20,8 @@ subject        – GivenName shown only on the first row of each subject block
 BIDS_name      – auto-assigned `sub-001`, `sub-002`, … (same GivenName → same ID)
 session        – `ses-<label>` if exactly one unique session tag is present in
                  that folder, otherwise blank
-source_folder  – name of the deepest folder containing the DICOM series
+source_folder  – relative path from the DICOM root to the folder containing the
+                 series
 include        – defaults to 1 but scout/report/physlog rows start at 0
 sequence       – original SeriesDescription
 modality       – fine label inferred from patterns (T1w, bold, dwi, …)
@@ -147,9 +148,9 @@ def scan_dicoms_long(root_dir: str,
 
             subj_key = f"{subj}||{study}"
 
-            # ---- source folder  (final folder name only)
+            # ---- source folder  (relative path under root_dir)
             rel = os.path.relpath(root, root_dir)
-            folder = "" if rel == "." else os.path.basename(rel)
+            folder = "" if rel == "." else rel
 
             series = getattr(ds, "SeriesDescription", "n/a").strip()
             counts[subj_key][folder][series] += 1

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -34,8 +34,11 @@ def physical_by_clean(raw_root: Path) -> Dict[str, str]:
         if not p.is_dir():
             continue
         rel = str(p.relative_to(raw_root))
-        mapping[rel] = rel
-        mapping[clean_name(rel)] = rel
+        base = p.name
+        mapping.setdefault(rel, rel)
+        mapping.setdefault(clean_name(rel), rel)
+        mapping.setdefault(base, rel)
+        mapping.setdefault(clean_name(base), rel)
     return mapping
 
 


### PR DESCRIPTION
## Summary
- store the relative folder path in the TSV inventory
- generate heuristics using cleaned folder IDs
- resolve nested folder names when running heudiconv

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842a0798c9083269cef9bd082481b10