### PR TITLE
Improve stop buttons to kill process tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "heudiconv",
     "nibabel",
     "numpy",
+    "psutil",
 ]
 
 


### PR DESCRIPTION
## Summary
- add `psutil` dependency
- terminate process tree when stopping inventory or conversion
- add helper to kill process tree across platforms

## Testing
- `python -m pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6842e54aefac8326a362090f0767e5e7