### PR TITLE
Handle multiple studies and record subject mapping

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -920,7 +920,7 @@ class BIDSManager(QMainWindow):
             self.log_text.append(f"Heuristics written to {self.heuristic_dir}")
             self.conv_stage = 1
             self.log_text.append("Running HeuDiConv…")
-            args = [self.run_script, self.dicom_dir, self.heuristic_dir, self.bids_out_dir]
+            args = [self.run_script, self.dicom_dir, self.heuristic_dir, self.bids_out_dir, '--subject-tsv', self.tsv_path]
             self.conv_process.start(sys.executable, args)
         elif self.conv_stage == 1:
             if exitCode != 0:


### PR DESCRIPTION
## Summary
- reset BIDS subject numbering per study and sort inventory output accordingly
- create `.bids_manager/subject_mapping.tsv` after conversion of each study
- pass TSV path from the GUI to `run-heudiconv` so mapping can be generated

## Testing
- `python -m py_compile bids_manager/dicom_inventory.py`
- `python -m py_compile bids_manager/run_heudiconv_from_heuristic.py`
- `python -m py_compile bids_manager/gui.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_6846b8aeca0c8326a992ab8b69adbbed