### PR TITLE
Fix participants TSV generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,7 @@ All utilities provide `-h/--help` for details.
   its file name customised before generation.
 - The Batch Rename tool previews changes and allows restricting the scope to
   specific subjects.
+- `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
+  and generates a clean `participants.tsv` using demographics from that file.
 
 


### PR DESCRIPTION
## Summary
- create `participants.tsv` from TSV demographics after conversion
- keep a copy of the original `subject_summary.tsv`
- document the new behaviour in README

## Testing
- `python -m py_compile bids_manager/run_heudiconv_from_heuristic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f3907fa88326b02c028a3f3a8638