### PR TITLE
Fix MRI graph display size

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1743,6 +1743,9 @@ class MetadataViewer(QWidget):
         self.ax = self.graph_canvas.figure.subplots()
         self.graph_canvas.setVisible(False)
         self.splitter.addWidget(self.graph_canvas)
+        # Allow the image and graph to share space evenly when the graph is shown
+        self.splitter.setStretchFactor(0, 1)
+        self.splitter.setStretchFactor(1, 1)
 
         vlay.addWidget(self.splitter)
 


### PR DESCRIPTION
## Summary
- allow NIfTI viewer splitter to allocate space evenly for the graph

## Testing
- `python -m compileall -q bids_manager`

------
https://chatgpt.com/codex/tasks/task_e_68470487b37083268689117223da845c