### PR TITLE
Fix GUI crash when viewing NIfTI images

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
     QTableWidget, QTableWidgetItem, QGroupBox, QFormLayout, QGridLayout,
     QTextEdit, QTreeView, QFileSystemModel, QTreeWidget, QTreeWidgetItem,
     QHeaderView, QMessageBox, QAction, QSplitter, QDialog, QAbstractItemView,
-    QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider)
+    QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider, QSpinBox)
 from PyQt5.QtCore import Qt, QModelIndex, QTimer, QProcess
 from PyQt5.QtGui import (
     QPalette,


### PR DESCRIPTION
## Summary
- import `QSpinBox` for NIfTI graph scope control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470d3fcfdc832694385aba4205afdd