### PR TITLE
Fix scaling to enlarge or shrink signal only

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -2022,10 +2022,10 @@ class MetadataViewer(QWidget):
                     ax.axis("off")
                     continue
 
-                ts = self.data[i, j, k, :]
-                ts = ts * self.scale_spin.value()
-                global_min = min(global_min, ts.min())
-                global_max = max(global_max, ts.max())
+                ts_orig = self.data[i, j, k, :]
+                global_min = min(global_min, ts_orig.min())
+                global_max = max(global_max, ts_orig.max())
+                ts = ts_orig * self.scale_spin.value()
                 ax.set_facecolor(bg_color)
                 ax.plot(ts, color=line_color, linewidth=1)
                 ax.set_xticks([])


### PR DESCRIPTION
## Summary
- adjust graph scaling so axis limits come from unscaled data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847fec466cc8326b04038711005b3a0