### PR TITLE
Fix vertical shift when resizing NIfTI viewer

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1778,8 +1778,15 @@ class MetadataViewer(QWidget):
         self.img_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)
         self.img_label.setMinimumSize(1, 1)
 
+        # Center the image label within a container so resizing doesn't shift
+        # it vertically when the splitter changes size.
+        img_container = QWidget()
+        ic_layout = QVBoxLayout(img_container)
+        ic_layout.setContentsMargins(0, 0, 0, 0)
+        ic_layout.addWidget(self.img_label, alignment=Qt.AlignCenter)
+
         self.splitter = QSplitter(Qt.Vertical)
-        self.splitter.addWidget(self.img_label)
+        self.splitter.addWidget(img_container)
 
         # Graph panel with scope selector
         self.graph_panel = QWidget()


### PR DESCRIPTION
## Summary
- keep the image label centered so its position doesn't jump when resizing

## Testing
- `python -m py_compile bids_manager/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684802da2bbc83269663d151566a85b7