### PR TITLE
Fix image viewer resizing

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1783,7 +1783,7 @@ class MetadataViewer(QWidget):
         img_container = QWidget()
         ic_layout = QVBoxLayout(img_container)
         ic_layout.setContentsMargins(0, 0, 0, 0)
-        ic_layout.addWidget(self.img_label, alignment=Qt.AlignCenter)
+        ic_layout.addWidget(self.img_label)
 
         self.splitter = QSplitter(Qt.Vertical)
         self.splitter.addWidget(img_container)


### PR DESCRIPTION
## Summary
- allow image label to expand when container resizes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480498badc8326ae18823a3d6334eb