### PR TITLE
Add html viewer, logo, and scale fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pydicom",
     "pandas",
     "PyQt5",
+    "PyQtWebEngine",
     "heudiconv",
     "nibabel",
     "numpy",
@@ -35,4 +36,8 @@ post-conv-renamer = "bids_manager.post_conv_renamer:main"
 
 [tool.setuptools]
 packages = ["bids_manager"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"bids_manager" = ["miscellaneous/images/Logo.png"]
 


### PR DESCRIPTION
## Summary
- enable rich HTML rendering using QWebEngineView
- show project logo next to the configuration panel
- adjust scaling graph to actually reflect the chosen scale factor
- package the logo and depend on PyQtWebEngine

## Testing
- `python -m py_compile bids_manager/*.py`
- `pip install PyQt5 PyQtWebEngine`

------
https://chatgpt.com/codex/tasks/task_e_6848165d82d0832691c8b7e5fcaa51c6