### PR TITLE
Integrate ancpbids for BIDS stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ All utilities provide `-h/--help` for details.
   specific subjects.
 - `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
   and generates a clean `participants.tsv` using demographics from that file.
+- Dataset statistics in the Edit tab are now computed using `ancpbids` for
+  BIDS Schema compliance.
 
 

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -7,6 +7,8 @@ import pandas as pd
 import numpy as np
 import nibabel as nib
 from pathlib import Path
+from ancpbids import load_dataset, DatasetOptions
+from ancpbids.query import query, query_entities
 from PyQt5.QtWidgets import (
     QApplication, QMainWindow, QWidget, QTabWidget, QVBoxLayout,
     QHBoxLayout, QLabel, QLineEdit, QPushButton, QFileDialog,
@@ -158,6 +160,7 @@ class BIDSManager(QMainWindow):
         self.conv_process = None
         self.conv_stage = 0
         self.heurs_to_rename = []
+        self.bids_ds = None  # ancpbids dataset object
 
         # Spinner for long-running tasks
         self.spinner_label = None
@@ -1436,6 +1439,12 @@ class BIDSManager(QMainWindow):
         p = QFileDialog.getExistingDirectory(self, "Select BIDS dataset")
         if p:
             self.bids_root = Path(p)
+            try:
+                opts = DatasetOptions(infer_artifact_datatype=True)
+                self.bids_ds = load_dataset(p, opts)
+            except Exception as exc:
+                logging.warning(f"ancpbids load failed: {exc}")
+                self.bids_ds = None
             self.model.setRootPath(p)
             self.tree.setRootIndex(self.model.index(p))
             self.viewer.clear()
@@ -1449,9 +1458,40 @@ class BIDSManager(QMainWindow):
             self.viewer.load_file(p)
 
     def updateStats(self):
-        """Compute and display BIDS stats: total subjects, files, modalities."""
-        root = self.bids_root
+        """Compute and display BIDS stats using ancpbids if available."""
         self.stats.clear()
+        if self.bids_ds is not None:
+            ents = query_entities(self.bids_ds)
+            subs = sorted(ents.get('subject', []))
+            self.stats.addTopLevelItem(QTreeWidgetItem(["Total subjects", str(len(subs))]))
+            file_count = len(query(self.bids_ds, return_type='files'))
+            self.stats.addTopLevelItem(QTreeWidgetItem(["Total files", str(file_count)]))
+            for sub in subs:
+                si = QTreeWidgetItem([f"sub-{sub}", ""])
+                ses_dirs = query(self.bids_ds, return_type='dir', subject=sub, target='session')
+                ses_labels = {Path(p).parts[1] for p in ses_dirs}
+                if ses_labels:
+                    for ses in sorted(ses_labels):
+                        s2 = QTreeWidgetItem([ses, ""])
+                        mod_dirs = query(self.bids_ds, return_type='dir', subject=sub, session=ses, extension='nii.gz')
+                        mods = {Path(p).parts[-1] for p in mod_dirs}
+                        s2.addChild(QTreeWidgetItem(["Modalities", str(len(mods))]))
+                        for m in sorted(mods):
+                            s2.addChild(QTreeWidgetItem([m, ""]))
+                        si.addChild(s2)
+                else:
+                    mod_dirs = query(self.bids_ds, return_type='dir', subject=sub, extension='nii.gz')
+                    mods = {Path(p).parts[-1] for p in mod_dirs}
+                    si.addChild(QTreeWidgetItem(["Sessions", "1"]))
+                    si.addChild(QTreeWidgetItem(["Modalities", str(len(mods))]))
+                    for m in sorted(mods):
+                        si.addChild(QTreeWidgetItem([m, ""]))
+                self.stats.addTopLevelItem(si)
+            self.stats.expandAll()
+            return
+
+        # Fallback: simple filesystem walk
+        root = self.bids_root
         subs = [d for d in root.iterdir() if d.is_dir() and d.name.startswith('sub-')]
         self.stats.addTopLevelItem(QTreeWidgetItem(["Total subjects", str(len(subs))]))
         files = list(root.rglob('*.*'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "numpy",
     "psutil",
     "matplotlib",
+    "ancpbids",
 ]
 
 


### PR DESCRIPTION
## Summary
- add `ancpbids` dependency
- show dataset stats using ancpbids in the Edit tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68482e38fdac8326a02577907c080444