### PR TITLE
Improve Windows path normalization

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -94,11 +94,11 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
         stem = safe_stem(row.sequence)
 
         base = dedup_parts(bids, ses, stem)
-        path = "/".join(p for p in [bids, ses, container] if p)
-        template = f"{path}/{base}"
+        template_parts = [p for p in [bids, ses, container] if p]
+        template = Path(*template_parts, base).as_posix()
 
-        parts = [bids, ses, stem]
-        key_var = "key_" + clean("_".join(p for p in parts if p))
+        key_parts = [bids, ses, stem]
+        key_var = "key_" + clean("_".join(p for p in key_parts if p))
         seq2key[key_id] = key_var
         key_defs.append((key_var, template))
 
@@ -123,7 +123,7 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
         buf.append(f"            {var}_list.append(s.series_id)\n")
     buf.append("    return info\n")
 
-    dst.write_text("".join(buf))
+    dst.write_text("".join(buf), encoding="utf-8")
     print("Heuristic written →", dst.resolve())
 
 
@@ -132,6 +132,9 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
 # -----------------------------------------------------------------------------
 
 def generate(tsv: Path, out_dir: Path) -> None:
+    tsv = Path(tsv).expanduser().resolve()
+    out_dir = Path(out_dir).expanduser().resolve()
+
     df = pd.read_csv(tsv, sep="\t")
 
     # Drop rows with unwanted modalities
@@ -149,8 +152,14 @@ def generate(tsv: Path, out_dir: Path) -> None:
         heur = out_dir / f"heuristic_{fname}.py"
         write_heuristic(sub_df, heur)
         folders = " ".join(sorted({clean(f) for f in sub_df.source_folder.unique()}))
-        print(dedent(f"""
-        heudiconv -d "<RAW_ROOT>/{{subject}}/**/*.dcm" -s {folders} -f {heur.name} -c dcm2niix -o <BIDS_OUT>/{fname} -b --minmeta --overwrite"""))
+        cmd = dedent(
+            f"""
+            heudiconv -d "<RAW_ROOT>/{{subject}}/**/*.dcm" \
+            -s {folders} \
+            -f {heur.as_posix()} -c dcm2niix \
+            -o <BIDS_OUT>/{fname} -b --minmeta --overwrite"""
+        )
+        print(cmd)
 
 
 def main() -> None:
@@ -161,7 +170,7 @@ def main() -> None:
     parser.add_argument("out_dir", help="Directory to write heuristic files")
     args = parser.parse_args()
 
-    generate(Path(args.tsv), Path(args.out_dir))
+    generate(args.tsv, args.out_dir)
 
 
 if __name__ == "__main__":

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -653,6 +653,10 @@ class BIDSManager(QMainWindow):
         self.preview_button.clicked.connect(self.generatePreview)
         preview_layout.addWidget(self.preview_button)
 
+        self.skip_nipype_box = QCheckBox("Run dcm2niix separately")
+        self.skip_nipype_box.setToolTip("Use heudiconv with -c none and convert with dcm2niix")
+        preview_layout.addWidget(self.skip_nipype_box)
+
         btn_row = QHBoxLayout()
         self.run_button = QPushButton("Run")
         self.run_button.clicked.connect(self.runFullConversion)
@@ -1368,6 +1372,8 @@ class BIDSManager(QMainWindow):
             self.conv_stage = 1
             self.log_text.append("Running HeuDiConv…")
             args = [self.run_script, self.dicom_dir, self.heuristic_dir, self.bids_out_dir, '--subject-tsv', self.tsv_path]
+            if self.skip_nipype_box.isChecked():
+                args.append('--no-nipype')
             self.conv_process.start(sys.executable, args)
         elif self.conv_stage == 1:
             if exitCode != 0:

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -14,6 +14,7 @@ import os
 from typing import Dict, List, Optional
 import pandas as pd
 import re
+import json
 
 
 # ────────────────── helpers ──────────────────
@@ -62,18 +63,55 @@ def heudi_cmd(raw_root: Path,
               phys_folders: List[str],
               heuristic: Path,
               bids_out: Path,
-              depth: int) -> List[str]:
+              depth: int,
+              use_nipype: bool) -> List[str]:
+    """Return argument list for invoking heudiconv."""
+
     wild = "*/" * depth
-    template = f"{raw_root}/" + "{subject}/" + wild + "*.dcm"
+    template = raw_root.as_posix() + "/{subject}/" + wild + "*.dcm"
+
+    phys_posix = [Path(p).as_posix() for p in phys_folders]
+
+    converter = "dcm2niix" if use_nipype else "none"
+
     return [
         "heudiconv",
         "-d", template,
-        "-s", *phys_folders,
-        "-f", str(heuristic),
-        "-c", "dcm2niix",
-        "-o", str(bids_out),
+        "-s", *phys_posix,
+        "-f", heuristic.as_posix(),
+        "-c", converter,
+        "-o", bids_out.as_posix(),
         "-b", "--minmeta", "--overwrite",
     ]
+
+
+def _manual_convert(bids_root: Path, clean_id: str) -> None:
+    """Run dcm2niix on filegroup.json results for *clean_id*."""
+    info_dir = bids_root / ".heudiconv" / clean_id / "info"
+    fg = info_dir / "filegroup.json"
+    if not fg.exists():
+        return
+
+    with fg.open("r", encoding="utf-8") as f:
+        mapping = json.load(f)
+
+    for prefix, dicoms in mapping.items():
+        if not dicoms:
+            continue
+        out_prefix = bids_root / prefix
+        out_dir = out_prefix.parent
+        out_dir.mkdir(parents=True, exist_ok=True)
+        dcm_dir = os.path.dirname(dicoms[0])
+        cmd = [
+            "dcm2niix",
+            "-z", "y",
+            "-b", "y",
+            "-f", out_prefix.name,
+            "-o", str(out_dir),
+            dcm_dir,
+        ]
+        print(" ".join(cmd))
+        subprocess.run(cmd, check=True)
 
 
 def _parse_age(value: str) -> str:
@@ -113,34 +151,52 @@ def run_heudiconv(raw_root: Path,
                   heuristic: Path,
                   bids_out: Path,
                   per_folder: bool = True,
-                  mapping_df: Optional[pd.DataFrame] = None) -> None:
+                  mapping_df: Optional[pd.DataFrame] = None,
+                  use_nipype: bool = True) -> None:
 
-    sid_map          = load_sid_map(heuristic)          # cleaned → sub-XXX
-    clean2phys       = physical_by_clean(raw_root)
-    cleaned_ids      = sorted(sid_map.keys())
-    phys_folders     = [clean2phys[c] for c in cleaned_ids]
+    sid_map     = load_sid_map(heuristic)  # cleaned → sub-XXX
+    clean2phys  = physical_by_clean(raw_root)
+    cleaned_ids = sorted(sid_map.keys())
+
+    missing = [c for c in cleaned_ids if c not in clean2phys]
+    if missing:
+        hint = (
+            "Ensure --dicom-root matches the directory used to generate "
+            "subject_summary.tsv"
+        )
+        raise KeyError(
+            "Folders listed in heuristic not found under "
+            f"{raw_root}: {', '.join(missing)}. {hint}"
+        )
+
+    phys_folders = [clean2phys[c] for c in cleaned_ids]
 
     depth = detect_depth(raw_root / phys_folders[0])
 
-    print("Raw root    :", raw_root)
-    print("Heuristic   :", heuristic)
-    print("Output BIDS :", bids_out)
-    print("Folders     :", phys_folders)
+    print("Raw root    :", raw_root.as_posix())
+    print("Heuristic   :", heuristic.as_posix())
+    print("Output BIDS :", bids_out.as_posix())
+    print("Folders     :", [Path(p).as_posix() for p in phys_folders])
     print("Depth       :", depth, "\n")
 
     bids_out.mkdir(parents=True, exist_ok=True)
 
     if per_folder:
         for phys in phys_folders:
-            print(f"── {phys} ──")
-            cmd = heudi_cmd(raw_root, [phys], heuristic, bids_out, depth)
+            print(f"── {Path(phys).as_posix()} ──")
+            cmd = heudi_cmd(raw_root, [phys], heuristic, bids_out, depth, use_nipype)
             print(" ".join(cmd))
             subprocess.run(cmd, check=True)
+            if not use_nipype:
+                _manual_convert(bids_out, clean_name(phys))
             print()
     else:
-        cmd = heudi_cmd(raw_root, phys_folders, heuristic, bids_out, depth)
+        cmd = heudi_cmd(raw_root, phys_folders, heuristic, bids_out, depth, use_nipype)
         print(" ".join(cmd))
         subprocess.run(cmd, check=True)
+        if not use_nipype:
+            for phys in phys_folders:
+                _manual_convert(bids_out, clean_name(phys))
 
     if mapping_df is not None:
         dataset = bids_out.name
@@ -165,18 +221,35 @@ def main() -> None:
     parser.add_argument("bids_out", help="Output BIDS directory")
     parser.add_argument("--subject-tsv", help="Path to subject_summary.tsv", default=None)
     parser.add_argument("--single-run", action="store_true", help="Use one heudiconv call for all subjects")
+    parser.add_argument("--no-nipype", action="store_true", help="Skip Nipype and run dcm2niix separately")
     args = parser.parse_args()
 
     mapping_df = None
     if args.subject_tsv:
         mapping_df = pd.read_csv(args.subject_tsv, sep="\t")
 
-    heur_path = Path(args.heuristic)
-    heuristics = [heur_path] if heur_path.is_file() else sorted(heur_path.glob("heuristic_*.py"))
+    raw_root = Path(args.dicom_root).expanduser().resolve()
+    heur_path = Path(args.heuristic).expanduser().resolve()
+    bids_root = Path(args.bids_out).expanduser().resolve()
+
+    heuristics = (
+        [heur_path]
+        if heur_path.is_file()
+        else sorted(heur_path.glob("heuristic_*.py"))
+    )
+
     for heur in heuristics:
+        heur = heur.resolve()
         dataset = heur.stem.replace("heuristic_", "")
-        out_dir = Path(args.bids_out) / dataset
-        run_heudiconv(Path(args.dicom_root), heur, out_dir, per_folder=not args.single_run, mapping_df=mapping_df)
+        out_dir = bids_root / dataset
+        run_heudiconv(
+            raw_root,
+            heur,
+            out_dir,
+            per_folder=not args.single_run,
+            mapping_df=mapping_df,
+            use_nipype=not args.no_nipype,
+        )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "numpy",
     "psutil",
     "matplotlib",
+    "dcm2niix",
 ]
 
 


### PR DESCRIPTION
## Summary
- normalize path separators when building HeuDiConv command
- print paths using POSIX form
- add option to bypass Nipype and run dcm2niix manually
- expose new flag in GUI and make dcm2niix a dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68485e706a9c83269a94466d6a251545