### PR TITLE
Fix heuristic application when skipping Nipype

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -189,6 +189,8 @@ def run_heudiconv(raw_root: Path,
             subprocess.run(cmd, check=True)
             if not use_nipype:
                 _manual_convert(bids_out, clean_name(phys))
+                print("Re-applying heuristic to converted data …")
+                subprocess.run(cmd, check=True)
             print()
     else:
         cmd = heudi_cmd(raw_root, phys_folders, heuristic, bids_out, depth, use_nipype)
@@ -197,6 +199,8 @@ def run_heudiconv(raw_root: Path,
         if not use_nipype:
             for phys in phys_folders:
                 _manual_convert(bids_out, clean_name(phys))
+            print("Re-applying heuristic to converted data …")
+            subprocess.run(cmd, check=True)
 
     if mapping_df is not None:
         dataset = bids_out.name


### PR DESCRIPTION
## Summary
- run heudiconv a second time after manual conversion

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684957202654832683795438a1b22a27