### PR TITLE
Fix heudiconv invocation in helper script

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import importlib.util
 import subprocess
 import os
+import sys
 from typing import Dict, List, Optional
 import pandas as pd
 import re
@@ -75,13 +76,22 @@ def heudi_cmd(raw_root: Path,
     converter = "dcm2niix" if use_nipype else "none"
 
     return [
+        sys.executable,
+        "-m",
         "heudiconv",
-        "-d", template,
-        "-s", *phys_posix,
-        "-f", heuristic.as_posix(),
-        "-c", converter,
-        "-o", bids_out.as_posix(),
-        "-b", "--minmeta", "--overwrite",
+        "-d",
+        template,
+        "-s",
+        *phys_posix,
+        "-f",
+        heuristic.as_posix(),
+        "-c",
+        converter,
+        "-o",
+        bids_out.as_posix(),
+        "-b",
+        "--minmeta",
+        "--overwrite",
     ]
 
 


### PR DESCRIPTION
## Summary
- call heudiconv using `sys.executable -m` to avoid PATH issues

## Testing
- `python -m py_compile bids_manager/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68495a8d09e08326a1c672a9c83a5847