### PR TITLE
Fix heuristic encoding

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -123,7 +123,7 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
         buf.append(f"            {var}_list.append(s.series_id)\n")
     buf.append("    return info\n")
 
-    dst.write_text("".join(buf))
+    dst.write_text("".join(buf), encoding="utf-8")
     print("Heuristic written →", dst.resolve())
 
 


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding when writing generated heuristics

## Testing
- `python -m py_compile bids_manager/build_heuristic_from_tsv.py`
- `python -m compileall -q bids_manager/build_heuristic_from_tsv.py`


------
https://chatgpt.com/codex/tasks/task_e_68496fd310788326acae92d5734e4c99