### PR TITLE
Add __main__ entry point for GUI

### DIFF
--- a/bids_manager/__main__.py
+++ b/bids_manager/__main__.py
@@ -1,0 +1,4 @@
+from .gui import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `python -m bids_manager` to launch the GUI

## Testing
- `python -m bids_manager --help` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -e .` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684ae10343748326b4cf8889421bea74