### PR TITLE
Handle DICOM root folders without subdirs

### DIFF
--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -150,7 +150,7 @@ def scan_dicoms_long(root_dir: str,
 
             # ---- source folder  (relative path under root_dir)
             rel = os.path.relpath(root, root_dir)
-            folder = "" if rel == "." else rel
+            folder = root_dir.name if rel == "." else rel
 
             series = getattr(ds, "SeriesDescription", "n/a").strip()
             counts[subj_key][folder][series] += 1

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -39,7 +39,12 @@ def safe_stem(text: str) -> str:
 
 def physical_by_clean(raw_root: Path) -> Dict[str, str]:
     """Return mapping cleaned_name → relative folder path for all subdirs."""
-    mapping: Dict[str, str] = {}
+    mapping: Dict[str, str] = {
+        "": "",
+        ".": "",
+        raw_root.name: "",
+        clean_name(raw_root.name): "",
+    }
     for p in raw_root.rglob("*"):
         if not p.is_dir():
             continue
@@ -70,10 +75,11 @@ def heudi_cmd(raw_root: Path,
     """Build the ``heudiconv`` command for the given parameters."""
     wild = "*/" * depth
     template = f"{raw_root}/" + "{subject}/" + wild + "*.dcm"
+    subjects = [p or "." for p in phys_folders]
     return [
         "heudiconv",
         "-d", template,
-        "-s", *phys_folders,
+        "-s", *subjects,
         "-f", str(heuristic),
         "-c", "dcm2niix",
         "-o", str(bids_out),


### PR DESCRIPTION
## Summary
- support selecting DICOM root folders that contain the series directly
- propagate root folder name into subject summary
- generate heuristics and commands with placeholder '.'
- ensure `run-heudiconv` can resolve the root folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dabcbe1908326a705af7193eb01bd