### PR TITLE
Fix path handling in dicom inventory

### DIFF
--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -35,6 +35,7 @@ import os
 import re
 from collections import defaultdict
 from typing import Optional
+from pathlib import Path
 
 import pandas as pd
 import pydicom
@@ -111,6 +112,7 @@ def scan_dicoms_long(root_dir: str,
         Inventory as described in module docstring.
     """
 
+    root_dir = Path(root_dir)
     print(f"Scanning DICOM headers under: {root_dir}")
 
     # in-memory stores


### PR DESCRIPTION
## Summary
- fix `dicom_inventory` crash when providing a string root directory

## Testing
- `python bids_manager/dicom_inventory.py empty_dicom_dir output.tsv`

------
https://chatgpt.com/codex/tasks/task_e_684dafaff6588326965df4956fc2b7b0