### PR TITLE
Handle conversion of DICOM root folders

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -74,16 +74,44 @@ def heudi_cmd(raw_root: Path,
               depth: int) -> List[str]:
     """Build the ``heudiconv`` command for the given parameters."""
     wild = "*/" * depth
+
+    if len(phys_folders) == 1 and phys_folders[0] == "":
+        files = sorted(str(p) for p in raw_root.glob(wild + "*.dcm"))
+        subj = clean_name(raw_root.name) or "root"
+        return [
+            "heudiconv",
+            "--files",
+            *files,
+            "-s",
+            subj,
+            "-f",
+            str(heuristic),
+            "-c",
+            "dcm2niix",
+            "-o",
+            str(bids_out),
+            "-b",
+            "--minmeta",
+            "--overwrite",
+        ]
+
     template = f"{raw_root}/" + "{subject}/" + wild + "*.dcm"
-    subjects = [p or "." for p in phys_folders]
+    subjects = [p or clean_name(raw_root.name) for p in phys_folders]
     return [
         "heudiconv",
-        "-d", template,
-        "-s", *subjects,
-        "-f", str(heuristic),
-        "-c", "dcm2niix",
-        "-o", str(bids_out),
-        "-b", "--minmeta", "--overwrite",
+        "-d",
+        template,
+        "-s",
+        *subjects,
+        "-f",
+        str(heuristic),
+        "-c",
+        "dcm2niix",
+        "-o",
+        str(bids_out),
+        "-b",
+        "--minmeta",
+        "--overwrite",
     ]
 
 


### PR DESCRIPTION
## Summary
- handle conversion when DICOM files are located directly in the selected folder
- fall back to `--files` mode of heudiconv and generate a sanitized subject name

## Testing
- `python -m py_compile bids_manager/run_heudiconv_from_heuristic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db346ce08832697d255287f615d7e