### PR TITLE
Handle repeated runs in dicom inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ All utilities provide `-h/--help` for details.
   specific subjects.
 - `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
   and generates a clean `participants.tsv` using demographics from that file.
+- `dicom-inventory` distinguishes repeated runs by adding `series_uid` and `run`
+  columns to `subject_summary.tsv`.
 
 
 


### PR DESCRIPTION
## Summary
- track DICOM `SeriesInstanceUID` while scanning
- use `(series, UID)` as key when counting series
- add `series_uid` and `run` columns to the generated table
- mention the new behaviour in the README

## Testing
- `python -m py_compile bids_manager/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685023df05a08326b6073afdaf3bc21f