### PR TITLE
Show acquisition time in tree views

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All utilities provide `-h/--help` for details.
 - `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
   and generates a clean `participants.tsv` using demographics from that file.
 - `dicom-inventory` distinguishes repeated runs by adding `series_uid` and `run`
-  columns to `subject_summary.tsv`.
+  columns and records `acq_time` for each series in `subject_summary.tsv`.
 
 
 


### PR DESCRIPTION
## Summary
- document new `acq_time` column in dicom inventory
- capture acquisition time during DICOM scan
- display file count and acquisition time in the General and Specific tree views

## Testing
- `python -m py_compile bids_manager/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685029315cc88326ba6ff5b34f21fa4b