### PR TITLE
Handle repeated runs in heuristics

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -838,7 +838,10 @@ class BIDSManager(QMainWindow):
             if multi_study:
                 path_parts.append(study)
             path_parts.extend([subj, ses, modb])
-            base = _dedup_parts(subj, ses, seq)
+            base_parts = [subj, ses, seq]
+            if info['run']:
+                base_parts.append(f"run-{info['run']}")
+            base = _dedup_parts(*base_parts)
 
             if modb == "fmap":
                 # Fieldmaps generate several derivative files with specific


### PR DESCRIPTION
## Summary
- disambiguate repeated sequences in `build_heuristic_from_tsv.py`
- include run information in preview names

## Testing
- `python -m compileall -q bids_manager`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68513043cdfc8326b3d868b7c2a7b4d9