### PR TITLE
Implement rep-based naming logic and UI cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All utilities provide `-h/--help` for details.
   specific subjects.
 - `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
   and generates a clean `participants.tsv` using demographics from that file.
-- `dicom-inventory` distinguishes repeated runs by adding `series_uid` and `run`
+- `dicom-inventory` distinguishes repeated sequences by adding `series_uid` and `rep`
   columns and records `acq_time` for each series in `subject_summary.tsv`.
 
 

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -24,8 +24,8 @@ source_folder  – relative path from the DICOM root to the folder containing th
                  series
 include        – defaults to 1 but scout/report/physlog rows start at 0
 sequence       – original SeriesDescription
-series_uid     – DICOM SeriesInstanceUID identifying a specific run
-run            – 1, 2, … if multiple SeriesInstanceUIDs share the same description
+series_uid     – DICOM SeriesInstanceUID identifying a specific acquisition
+rep            – 1, 2, … if multiple SeriesInstanceUIDs share the same description
 acq_time       – AcquisitionTime of the first file in that series
 modality       – fine label inferred from patterns (T1w, bold, dwi, …)
 modality_bids  – top-level container (anat, func, dwi, fmap) derived from
@@ -212,13 +212,13 @@ def scan_dicoms_long(root_dir: str,
             ses_labels = sorted(sessset[subj_key][folder])
             session = ses_labels[0] if len(ses_labels) == 1 else ""
 
-            run_counter = defaultdict(int)
+            rep_counter = defaultdict(int)
             for (series, uid), n_files in sorted(counts[subj_key][folder].items()):
                 fine_mod = mods[subj_key][folder][(series, uid)]
                 include = 1
                 if fine_mod in {"scout", "report"} or "physlog" in series.lower():
                     include = 0
-                run_counter[series] += 1
+                rep_counter[series] += 1
                 rows.append({
                     "subject"       : demo[subj_key]["GivenName"] if first_row else "",
                     "BIDS_name"     : bids_map[subj_key],
@@ -227,7 +227,7 @@ def scan_dicoms_long(root_dir: str,
                     "include"       : include,
                     "sequence"      : series,
                     "series_uid"    : uid,
-                    "run"           : run_counter[series] if run_counter[series] > 1 else "",
+                    "rep"           : rep_counter[series] if rep_counter[series] > 1 else "",
                     "acq_time"      : acq_times[subj_key][folder].get((series, uid), ""),
                     "modality"      : fine_mod,
                     "modality_bids" : modality_to_container(fine_mod),
@@ -239,7 +239,7 @@ def scan_dicoms_long(root_dir: str,
     # Final column order
     columns = [
         "subject", "BIDS_name", "session", "source_folder",
-        "include", "sequence", "series_uid", "run", "acq_time",
+        "include", "sequence", "series_uid", "rep", "acq_time",
         "modality", "modality_bids", "n_files",
         "GivenName", "FamilyName", "PatientID",
         "PatientSex", "PatientAge", "StudyDescription",


### PR DESCRIPTION
## Summary
- update docs for new `rep` column in dicom inventory
- rename `run` column to `rep` in inventory and heuristic builder
- ensure repeated sequences only get `rep-<n>` suffix when multiple reps selected
- simplify general view columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68513f5c31508326a7b405cb4dae7a44