### PR TITLE
Improve repeated sequence naming and TSV handling

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1024,7 +1024,7 @@ class BIDSManager(QMainWindow):
         """
         if not self.tsv_path or not os.path.isfile(self.tsv_path):
             return
-        df = pd.read_csv(self.tsv_path, sep="\t")
+        df = pd.read_csv(self.tsv_path, sep="\t", keep_default_na=False)
 
         self.study_set.clear()
         self.modb_rows.clear()
@@ -1480,7 +1480,7 @@ class BIDSManager(QMainWindow):
 
         # 1) Save updated TSV from table
         try:
-            df_orig = pd.read_csv(self.tsv_path, sep="\t")
+            df_orig = pd.read_csv(self.tsv_path, sep="\t", keep_default_na=False)
             df_conv = df_orig.copy()
             for i in range(self.mapping_table.rowCount()):
                 include = 1 if self.mapping_table.item(i, 0).checkState() == Qt.Checked else 0
@@ -2372,7 +2372,7 @@ class MetadataViewer(QWidget):
 
     def _tsv_view(self, path: Path) -> QTableWidget:
         """Create a table widget to show and edit TSV data."""
-        df = pd.read_csv(path, sep="\t")
+        df = pd.read_csv(path, sep="\t", keep_default_na=False)
         tbl = QTableWidget(df.shape[0], df.shape[1])
         tbl.setAlternatingRowColors(True)
         hdr = tbl.horizontalHeader()

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -211,7 +211,7 @@ def main() -> None:
 
     mapping_df = None
     if args.subject_tsv:
-        mapping_df = pd.read_csv(args.subject_tsv, sep="\t")
+        mapping_df = pd.read_csv(args.subject_tsv, sep="\t", keep_default_na=False)
 
     heur_path = Path(args.heuristic)
     heuristics = [heur_path] if heur_path.is_file() else sorted(heur_path.glob("heuristic_*.py"))


### PR DESCRIPTION
## Summary
- calculate repetition numbers dynamically in `build_heuristic_from_tsv`
- keep empty session fields when reading TSV files
- ensure CLI utilities use the updated TSV parsing

## Testing
- `python -m py_compile bids_manager/build_heuristic_from_tsv.py bids_manager/run_heudiconv_from_heuristic.py bids_manager/gui.py`
- `python -m py_compile bids_manager/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685147de65348326a4ed88893f973fcb