### PR TITLE
Fix fieldmap phase UID handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ All utilities provide `-h/--help` for details.
 - `dicom-inventory` distinguishes repeated sequences by adding `series_uid` and `rep`
   columns and records `acq_time` for each series in `subject_summary.tsv`.
 - Fieldmap rows for magnitude and phase images are now merged so each acquisition
-  appears once with the combined file count.
+  appears once with the combined file count, and their `series_uid` values are
+  stored as a pipe-separated list so both sequences are converted.
 
 
 

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -303,6 +303,8 @@ def scan_dicoms_long(root_dir: str,
         fmap_df["acq_group"] = fmap_df["acq_time"].apply(lambda t: str(t)[:4])
         group_cols = base_cols + ["acq_group"]
         fmap_df["uid_list"] = fmap_df["series_uid"]
+        # keep all UIDs within each group so both magnitude and phase series
+        # are converted; they will be joined with '|' below
         fmap_df["img_set"] = fmap_df["image_type"]
         fmap_df = (
             fmap_df.groupby(group_cols, as_index=False)
@@ -314,7 +316,7 @@ def scan_dicoms_long(root_dir: str,
                     "source_folder": "first",
                     "include": "max",
                     "sequence": "first",
-                    "uid_list": "first",
+                    "uid_list": lambda x: "|".join(sorted(set(str(v) for v in x))),
                     "img_set": lambda x: "".join(sorted(set(str(v) for v in x))),
                     "acq_time": "first",
                     "modality": "first",


### PR DESCRIPTION
## Summary
- preserve all series UIDs when merging fieldmap rows
- split multiple UIDs when building heuristics so every series is converted
- document new UID behaviour in README

## Testing
- `python -m py_compile bids_manager/*.py`
- `flake8 bids_manager` *(fails: E302, E501, W391, E203)*

------
https://chatgpt.com/codex/tasks/task_e_685172a20e348326980500d797411110