### PR TITLE
Connect CPU spinner to dicom inventory

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -277,7 +277,7 @@ class BIDSManager(QMainWindow):
         container = QWidget()
         layout = QHBoxLayout()
         layout.setContentsMargins(8, 2, 0, 6)  # left, top, right, bottom
-        layout.setSpacing(0)
+        layout.setSpacing(8)
         layout.addWidget(self.theme_btn)
         layout.addWidget(self.cpu_btn)
         container.setLayout(layout)
@@ -1005,7 +1005,14 @@ class BIDSManager(QMainWindow):
             self.inventory_process.setStandardOutputFile(QProcess.nullDevice())
             self.inventory_process.setStandardErrorFile(QProcess.nullDevice())
         self.inventory_process.finished.connect(self._inventoryFinished)
-        args = ["-m", "bids_manager.dicom_inventory", self.dicom_dir, self.tsv_path]
+        args = [
+            "-m",
+            "bids_manager.dicom_inventory",
+            self.dicom_dir,
+            self.tsv_path,
+            "--jobs",
+            str(self.num_cpus),
+        ]
         self.inventory_process.start(sys.executable, args)
 
     def _inventoryFinished(self):


### PR DESCRIPTION
## Summary
- connect CPU selector widget to dicom inventory QProcess
- add spacing between theme and CPU buttons

## Testing
- `python -m py_compile bids_manager/dicom_inventory.py bids_manager/gui.py`
- `pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_685412088204832688ab30d978486037