### PR TITLE
Add parallel conversion by subject

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1568,7 +1568,16 @@ class BIDSManager(QMainWindow):
             self.log_text.append(f"Heuristics written to {self.heuristic_dir}")
             self.conv_stage = 1
             self.log_text.append("Running HeuDiConv…")
-            args = [self.run_script, self.dicom_dir, self.heuristic_dir, self.bids_out_dir, '--subject-tsv', self.tsv_path]
+            args = [
+                self.run_script,
+                self.dicom_dir,
+                self.heuristic_dir,
+                self.bids_out_dir,
+                '--subject-tsv',
+                self.tsv_path,
+                '--jobs',
+                str(self.num_cpus),
+            ]
             self.conv_process.start(sys.executable, args)
         elif self.conv_stage == 1:
             if exitCode != 0:


### PR DESCRIPTION
## Summary
- allow run-heudiconv to spawn parallel jobs per subject
- expose CPU count option in CLI (`--jobs`)
- connect GUI parallel setting to run-heudiconv script

## Testing
- `python -m py_compile bids_manager/run_heudiconv_from_heuristic.py bids_manager/gui.py`
- `python bids_manager/run_heudiconv_from_heuristic.py -h | head`


------
https://chatgpt.com/codex/tasks/task_e_68541e1df1f08326863fc3a6611e1c6f