### PR TITLE
Fix subject mapping in parallel heudiconv

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -207,7 +207,8 @@ def run_heudiconv(
         def _convert_one(phys: str, cid: str) -> None:
             print(f"── {phys} ──")
             files = sorted(str(p) for p in (raw_root / phys).rglob("*.dcm"))
-            cmd = heudi_cmd_files(files, cid, heuristic, bids_out)
+            subj = sid_map.get(cid, cid)
+            cmd = heudi_cmd_files(files, subj, heuristic, bids_out)
             print(" ".join(cmd))
             subprocess.run(cmd, check=True)
             print()


### PR DESCRIPTION
## Summary
- map cleaned folder IDs to BIDS subject names when constructing per-subject commands

## Testing
- `python -m compileall -q bids_manager`

------
https://chatgpt.com/codex/tasks/task_e_685536a6b6e08326a58cd30f0a26264d