### PR TITLE
Add IntendedFor to fieldmap JSONs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ All utilities provide `-h/--help` for details.
 - Fieldmap rows for magnitude and phase images are now merged so each acquisition
   appears once with the combined file count, and their `series_uid` values are
   stored as a pipe-separated list so both sequences are converted.
+- `post-conv-renamer` now adds an `IntendedFor` list to each fieldmap JSON so
+  fMRI preprocessing tools can automatically match fieldmaps with the relevant
+  functional runs.
 
 
 


### PR DESCRIPTION
## Summary
- extend post-conv renamer to fill IntendedFor in fieldmap sidecars
- document IntendedFor update step

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d52129008832697f70d60562f9aaa