### PR TITLE
Fix IntendedFor dialog crash

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -54,7 +54,7 @@ from PyQt5.QtWidgets import (
     QTextEdit, QTextBrowser, QTreeView, QFileSystemModel, QTreeWidget, QTreeWidgetItem,
     QHeaderView, QMessageBox, QAction, QSplitter, QDialog, QAbstractItemView,
     QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider, QSpinBox,
-    QCheckBox, QStyledItemDelegate, QDialogButtonBox)
+    QCheckBox, QStyledItemDelegate, QDialogButtonBox, QListWidget)
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtCore import Qt, QModelIndex, QTimer, QProcess, QUrl
 from PyQt5.QtGui import (


### PR DESCRIPTION
## Summary
- import QListWidget in gui
- fix NameError when opening "Set IntendedFor" dialog

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb09315f08326b98269113245624a