### PR TITLE
Add GUI tools to update scans.tsv and .bidsignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ All utilities provide `-h/--help` for details.
 - `post-conv-renamer` now adds an `IntendedFor` list to each fieldmap JSON so
   fMRI preprocessing tools can automatically match fieldmaps with the relevant
   functional runs.
+- The GUI's Tools menu gained actions to refresh `_scans.tsv` files and edit
+  `.bidsignore` entries.
 
 
 

--- a/bids_manager/scans_utils.py
+++ b/bids_manager/scans_utils.py
@@ -42,3 +42,39 @@ def _update_single_scans(tsv: Path, rename_map: dict[str, str]) -> None:
     if changed:
         df.to_csv(tsv, sep="\t", index=False)
         print(f"Updated {tsv}")
+
+
+def refresh_scans_filenames(bids_root: Path) -> None:
+    """Refresh ``filename`` columns in all ``*_scans.tsv`` files.
+
+    This walks through the dataset and ensures each entry matches an
+    existing file within the corresponding subject or session.
+    """
+
+    for sub in bids_root.glob("sub-*"):
+        if not sub.is_dir():
+            continue
+        sessions = [s for s in sub.glob("ses-*") if s.is_dir()]
+        roots = sessions or [sub]
+        for root in roots:
+            files = {f.name: f.relative_to(root).as_posix() for f in root.rglob('*') if f.is_file()}
+            for tsv in root.glob("*_scans.tsv"):
+                _refresh_single(tsv, files, bids_root)
+
+
+def _refresh_single(tsv: Path, file_map: dict[str, str], bids_root: Path) -> None:
+    df = pd.read_csv(tsv, sep="\t")
+    if "filename" not in df.columns:
+        return
+
+    changed = False
+    for idx, fname in enumerate(df["filename"]):
+        base = Path(fname).name
+        new = file_map.get(base)
+        if new and new != fname:
+            df.at[idx, "filename"] = new
+            changed = True
+
+    if changed:
+        df.to_csv(tsv, sep="\t", index=False)
+        print(f"Refreshed {tsv.relative_to(bids_root)}")


### PR DESCRIPTION
## Summary
- refresh filenames inside `_scans.tsv` by walking the dataset
- extend the GUI Tools menu with actions to update scans and edit `.bidsignore`
- implement a simple `.bidsignore` editor dialog
- document new tools in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861394da38c8326af57f23ea1442bf6