### PR TITLE
Fix scans.tsv refresh and .bidsignore dialog

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -54,7 +54,7 @@ from PyQt5.QtWidgets import (
     QTextEdit, QTextBrowser, QTreeView, QFileSystemModel, QTreeWidget, QTreeWidgetItem,
     QHeaderView, QMessageBox, QAction, QSplitter, QDialog, QAbstractItemView,
     QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider, QSpinBox,
-    QCheckBox, QStyledItemDelegate, QDialogButtonBox, QListWidget)
+    QCheckBox, QStyledItemDelegate, QDialogButtonBox, QListWidget, QListWidgetItem)
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtCore import Qt, QModelIndex, QTimer, QProcess, QUrl
 from PyQt5.QtGui import (
@@ -1757,9 +1757,9 @@ class BIDSManager(QMainWindow):
             )
             return
         try:
-            from .scans_utils import refresh_scans_filenames
+            from .post_conv_renamer import update_scans_tsv
 
-            refresh_scans_filenames(self.bids_root)
+            update_scans_tsv(self.bids_root)
             QMessageBox.information(self, "Refresh", "Updated scans.tsv files")
         except Exception as exc:
             QMessageBox.warning(self, "Error", f"Failed to update: {exc}")

--- a/bids_manager/post_conv_renamer.py
+++ b/bids_manager/post_conv_renamer.py
@@ -176,7 +176,7 @@ def _rename_in_scans(tsv: Path, bids_root: Path) -> None:
                 new_name = _move_rep_suffix(new_name)
 
         if new_name != path.name:
-            candidate = bids_root / path.parent / new_name
+            candidate = tsv.parent / path.parent / new_name
             if candidate.exists():
                 df.at[idx, "filename"] = (path.parent / new_name).as_posix()
                 changed = True


### PR DESCRIPTION
## Summary
- fix candidate path when updating filenames inside scans.tsv
- update the GUI to call post_conv_renamer for refreshing scans.tsv
- import `QListWidgetItem` so the .bidsignore dialog opens

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68613d153f5c83269c3df8123484b589