### PR TITLE
Fix sequential conversion overwrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ All utilities provide `-h/--help` for details.
   if the automatic matching needs adjustment.
 - `run-heudiconv` now keeps a copy of `subject_summary.tsv` under `.bids_manager`
   and generates a clean `participants.tsv` using demographics from that file.
+- Re-running `run-heudiconv` on the same dataset now appends new subjects to
+  the existing `.bids_manager` records and updates `participants.tsv` instead of
+  overwriting them.
 - `dicom-inventory` distinguishes repeated sequences by adding `series_uid` and `rep`
   columns and records `acq_time` for each series in `subject_summary.tsv`.
 - Fieldmap rows for magnitude and phase images are now merged so each acquisition


### PR DESCRIPTION
## Summary
- keep existing participants.tsv content when converting new subjects
- merge subject_summary.tsv and subject_mapping.tsv with prior runs
- document that `run-heudiconv` now appends subject info instead of overwriting

## Testing
- `python -m py_compile bids_manager/run_heudiconv_from_heuristic.py`

------
https://chatgpt.com/codex/tasks/task_e_686141e1ee6c832681277715067b9c19