### PR TITLE
Improve IntendedFor, .bidsignore editor and participants

### DIFF
--- a/bids_manager/post_conv_renamer.py
+++ b/bids_manager/post_conv_renamer.py
@@ -118,7 +118,11 @@ def _update_intended_for(root: Path, bids_root: Path) -> None:
 
     # Collect paths of all functional images relative to the subject/session
     # directory so that ``IntendedFor`` entries omit the ``sub-*`` prefix.
-    func_files = sorted(func_dir.glob("*.nii*"))
+    # Skip reference volumes (e.g. ``*_sbref``) as they should not appear in the
+    # ``IntendedFor`` lists.
+    func_files = [
+        f for f in sorted(func_dir.glob("*.nii*")) if "ref" not in f.name.lower()
+    ]
     if not func_files:
         return
 


### PR DESCRIPTION
## Summary
- skip reference volumes when generating fieldmap `IntendedFor`
- redesign `.bidsignore` editor with dual panels and multi-select
- always rebuild `participants.tsv` from `.bids_manager/subject_summary.tsv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686149203304832689e379f2aed7c7f3