### PR TITLE
Fix heudiconv invocation on Windows

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -76,12 +76,11 @@ def heudi_cmd(raw_root: Path,
     wild = "*/" * depth
 
     if len(phys_folders) == 1 and phys_folders[0] == "":
-        files = sorted(str(p) for p in raw_root.glob(wild + "*.dcm"))
         subj = clean_name(raw_root.name) or "root"
         return [
             "heudiconv",
             "--files",
-            *files,
+            str(raw_root),
             "-s",
             subj,
             "-f",


### PR DESCRIPTION
## Summary
- avoid generating huge heudiconv command when dicoms are in root folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68638776fb808326a3d613d4bb994d45