### PR TITLE
Disable Qt auto scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ After installation the following commands become available:
 
 All utilities provide `-h/--help` for details.
 
+The GUI disables automatic high-DPI scaling by default so it looks the same on
+systems that use display scaling (e.g. 125%). To re-enable Qt's auto scaling set
+the environment variable `QT_AUTO_SCREEN_SCALE_FACTOR=1` before launching.
+
 ### Recent updates
 
 - The TSV produced by `dicom-inventory` can now be loaded directly in the GUI and

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -58,7 +58,7 @@ from PyQt5.QtWidgets import (
     QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider, QSpinBox,
     QCheckBox, QStyledItemDelegate, QDialogButtonBox, QListWidget, QListWidgetItem)
 from PyQt5.QtWebEngineWidgets import QWebEngineView
-from PyQt5.QtCore import Qt, QModelIndex, QTimer, QProcess, QUrl
+from PyQt5.QtCore import Qt, QModelIndex, QTimer, QProcess, QUrl, QCoreApplication
 from PyQt5.QtGui import (
     QPalette,
     QColor,
@@ -3090,6 +3090,8 @@ def main() -> None:
             )
         except Exception:
             pass
+    os.environ.setdefault("QT_AUTO_SCREEN_SCALE_FACTOR", "0")
+    QCoreApplication.setAttribute(Qt.AA_DisableHighDpiScaling)
     app = QApplication(sys.argv)
     app.setStyle('Fusion')
     if ICON_FILE.exists():


### PR DESCRIPTION
## Summary
- ensure consistent scaling across systems by setting `QT_AUTO_SCREEN_SCALE_FACTOR=0` and disabling Qt high DPI handling
- document the new behaviour and environment variable in README

## Testing
- `python -m py_compile bids_manager/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686507a5138883269f837d90e491a5c2