### PR TITLE
Fix DPI scaling for tab labels

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -631,6 +631,12 @@ class BIDSManager(QMainWindow):
             font.setPointSize(scaled)
         app.setFont(font)
 
+        # Ensure the tab labels also scale with the selected DPI
+        if hasattr(self, "tabs"):
+            tab_font = QFont(font)
+            tab_font.setPointSize(font.pointSize() + 1)
+            self.tabs.setFont(tab_font)
+
     def _update_logo(self) -> None:
         """Update logo pixmap based on current theme."""
         if not hasattr(self, "logo_label"):


### PR DESCRIPTION
## Summary
- ensure tab labels follow custom DPI setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866bbc92c0c83268ba5136f5c5bf0d3