### PR TITLE
Enhance DPI scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ All utilities provide `-h/--help` for details.
   functional runs.
 - The GUI's Tools menu gained actions to refresh `_scans.tsv` files and edit
   `.bidsignore` entries.
+- The DPI scale dialog now adjusts values in 25% increments and the DPI button
+  appears between the CPU and Authorship buttons.
+- On startup the GUI detects the system DPI and applies the matching scale.
 
 
 

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -208,7 +208,14 @@ class BIDSManager(QMainWindow):
 
         app = QApplication.instance()
         self._base_font = app.font()
-        self.dpi_scale = 100
+        screen = app.primaryScreen()
+        if screen is not None:
+            try:
+                self.dpi_scale = round(screen.logicalDotsPerInch() / 96 * 100)
+            except Exception:
+                self.dpi_scale = 100
+        else:
+            self.dpi_scale = 100
 
         # Paths
         self.dicom_dir = ""         # Raw DICOM directory
@@ -303,8 +310,8 @@ class BIDSManager(QMainWindow):
         layout.setSpacing(8)
         layout.addWidget(self.theme_btn)
         layout.addWidget(self.cpu_btn)
-        layout.addWidget(self.authorship_btn)
         layout.addWidget(self.dpi_btn)
+        layout.addWidget(self.authorship_btn)
         container.setLayout(layout)
         # Add the container to the status bar (left-aligned)
         self.statusBar().addWidget(container)
@@ -2056,6 +2063,7 @@ class DpiSettingsDialog(QDialog):
         row.addWidget(QLabel("Scale (%):"))
         self.spin = QSpinBox()
         self.spin.setRange(50, 200)
+        self.spin.setSingleStep(25)
         self.spin.setValue(current)
         row.addWidget(self.spin)
         layout.addLayout(row)


### PR DESCRIPTION
## Summary
- detect system DPI and apply scaling at startup
- adjust DPI increment step to 25%
- reorder DPI button between CPU and Authorship buttons
- document DPI improvements in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686776b81368832683cd5cffa6e2cd71