### PR TITLE
Set default CPU usage to 80% and update acknowledgements

### DIFF
--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -384,7 +384,7 @@ def main() -> None:
     parser.add_argument(
         "--jobs",
         type=int,
-        default=1,
+        default=max(1, round((os.cpu_count() or 1) * 0.8)),
         help="Number of parallel workers to use",
     )
     args = parser.parse_args()

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -267,7 +267,8 @@ class BIDSManager(QMainWindow):
         self._spinner_message = ""
 
         # Parallel settings
-        self.num_cpus = 1
+        total_cpu = os.cpu_count() or 1
+        self.num_cpus = max(1, round(total_cpu * 0.8))
 
         # Main widget and layout
         main_widget = QWidget()
@@ -2155,6 +2156,7 @@ class AuthorshipDialog(QDialog):
             "Dr. Jorge Bosch-Bayard\n"
             "Msc. Erdal Karaca\n"
             "Bsc. Pablo Alexis Olguín Baxman\n"
+            "Dr. Amirhussein Abdolalizadeh Saleh\n"
             "Dr. Tina Schmitt\n"
             "Dr.-Ing. Andreas Spiegler"
         )


### PR DESCRIPTION
## Summary
- use 80% of available CPUs by default
- add Dr. Amirhussein Abdolalizadeh Saleh to acknowledgements

## Testing
- `pytest -q`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_68677d2455008326b6fa5f1a352c52f6