### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/bidsmgr/gui/main_window.py
+++ b/bidsmgr/gui/main_window.py
@@ -320,7 +320,7 @@ class MainWindow(QMainWindow):
         self._header.view_changed.connect(self._on_view_changed)
         self._header.about_requested.connect(self._show_about_dialog)
 
-        # Restore the user's last view. Pills are syncronised silently
+        # Restore the user's last view. Pills are synchronized silently
         # so we don't fire a redundant ``view_changed`` on startup.
         from .app_settings import AppSettings
         settings = AppSettings.load()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,10 @@ markers = [
     "real_data: requires real datasets at /Users/karelo/Development/datasets/BIDS_Manager/raw_data, gated on env vars BIDS_MANAGER_REAL_{MRI,MEG,EEG}_DATA",
     "gui: pytest-qt smoke tests, headless OK with QT_QPA_PLATFORM=offscreen",
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.svg,vendor'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ markers = [
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.svg,vendor'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.svg,vendor'
 check-hidden = true
 # ignore-regex = ''
 # ND: DICOM ImageType code (M/P/ND for magnitude/phase/normalized)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,4 +143,8 @@ markers = [
 skip = '.git,.gitignore,.gitattributes,*.svg,vendor'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# ND: DICOM ImageType code (M/P/ND for magnitude/phase/normalized)
+# puls: Philips physio file extension (.puls), mentioned in docstrings
+# dmaging: intentional mock task name in docs/gui_mockups.html
+# re-use, re-uses, pre-selected: hyphenated forms preferred by authors
+ignore-words-list = 'ND,puls,dmaging,re-use,re-uses,pre-selected'


### PR DESCRIPTION
## Summary

Introduce [codespell](https://github.com/codespell-project/codespell) for
automated spell-checking on push / PR to `main`. CI workflow has
`permissions: contents: read` only, so it is safe.

I have introduced codespell to over a hundred projects already, mostly
with positive feedback — see the
[improveit-dashboard reference](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md).

The diff is tiny — just one real typo fix on top of the config and CI
scaffolding (`syncronised` → `synchronized` in a `MainWindow` comment).
All other terms codespell flagged are either domain-specific
(DICOM `ND`, Philips `.puls`), intentional mock data (`dmaging` in
`docs/gui_mockups.html`), or hyphenation choices the authors made
deliberately (`re-use`, `re-uses`, `pre-selected`) — those are added
to `ignore-words-list` with explanatory comments rather than being
silently rewritten.

## Commits

- 3b9def3 `Add GitHub Actions workflow for codespell on main`
- 9f9d9c1 `Add rudimentary codespell config`
- 94c34bf `codespell: whitelist domain terms and author's hyphenation style`
- 54456ab `Fix syncronised -> synchronized typo in MainWindow comment`
- 19eb620 `codespell: skip .git-meta working directory`

<details><summary>Per-commit details</summary>

### 3b9def3 `Add GitHub Actions workflow for codespell on main`

Adds `.github/workflows/codespell.yml`. Triggers on `push` and
`pull_request` to `main`. Uses the pinned
`codespell-project/actions-codespell@8f01853` (v2.2). `permissions:
contents: read` only.

### 9f9d9c1 `Add rudimentary codespell config`

Adds `[tool.codespell]` section to `pyproject.toml` with a baseline
`skip` list (`.git`, `.gitignore`, `.gitattributes`, `*.svg`, `vendor`)
and `check-hidden = true`.

### 94c34bf `codespell: whitelist domain terms and author's hyphenation style`

Populates `ignore-words-list` with reasons for each entry:

- `ND` — DICOM `ImageType` code (M / P / ND for magnitude / phase /
  normalized) used in `bidsmgr/inventory/{mri_dicom.py,types.py}` and
  referenced in `bidsmgr/cli/scan.py`.
- `puls` — Philips physio file extension (`.puls`), mentioned in
  the `bidsmgr/converter/backends/physio_dcm.py` docstring.
- `dmaging` — intentional mock task name in `docs/gui_mockups.html`
  (the mockup itself flags it back to the user as "is 'dmaging' the
  right task?", so it is deliberately misspelled to demo the wizard).
- `re-use`, `re-uses`, `pre-selected` — hyphenated forms the authors
  chose over codespell's unhyphenated suggestions. Kept as-is.

### 54456ab `Fix syncronised -> synchronized typo in MainWindow comment`

codespell suggested `syncronised → synchronised` (British), but the
rest of the project uses American spelling (`synchronize_onsets`,
`synchronized` in `bidsmgr/vendor/bidsphysio/...`), so normalized to
`synchronized`.

### 19eb620 `codespell: skip .git-meta working directory`

`.git-meta/` is in `.git/info/exclude` as a per-clone scratch area for
commit messages / PR bodies — adding it to `skip` so transient typo
discussions in those files don't fail CI.

</details>

## Test plan

- [x] `codespell` exits 0 on the working tree at HEAD of this branch
- [x] CI workflow `permissions: contents: read` only — no write scopes
- [x] Workflow action pinned to a specific SHA (v2.2)
- [ ] CI run on this PR shows the workflow passing
