### PR TITLE
BIDS Manager: project-first workspace, EEG/MEG metadata enrichment, recording viewers, and incremental conversion (v1.1.4 to v1.2.3)

### DIFF
--- a/bidsmgr/classifier/sequence_dict.py
+++ b/bidsmgr/classifier/sequence_dict.py
@@ -26,6 +26,7 @@ from typing import Iterable, Optional
 
 from ..inventory.types import InventoryRow
 from .types import Classification
+from .user_rules import UserHint, hint_matches
 
 
 _WORD_RE = re.compile(r"[0-9A-Za-z]+")
@@ -340,6 +341,63 @@ def looks_like_b0_reference(sequence: Optional[str]) -> bool:
     return bool(_B0_REFERENCE_RE.search(sequence))
 
 
+def _classification_from_user_hint(row: InventoryRow, hint: UserHint) -> Classification:
+    """Build a Classification from a matched user hint.
+
+    Confidence: ``0.95`` when ``hint.force`` (overrides even dcm2niix
+    BidsGuess), else ``0.60`` (beats the built-in regex fallback at 0.40/0.45
+    but loses to BidsGuess). The chain in ``cli/scan`` applies the priority.
+    """
+    sequence = row.series_description or ""
+    entities: dict[str, str] = {}
+    direction = extract_direction_token(sequence)
+    if direction:
+        entities["direction"] = direction.upper()
+    acq = extract_acq_token(sequence)
+    if acq:
+        entities["acquisition"] = acq
+    if hint.task:
+        entities["task"] = hint.task
+    for k, v in hint.entities:  # explicit user overrides win
+        entities[k] = v
+    conf = 0.95 if hint.force else 0.60
+    return Classification(
+        row_id=row.row_id,
+        classifier="user_hint",
+        datatype=hint.datatype,
+        suffix=hint.suffix,
+        candidate_entities=entities,
+        confidence=conf,
+        rationale=(
+            f"user hint matched {list(hint.patterns)!r} -> "
+            f"{hint.datatype}/{hint.suffix}" + (" (force)" if hint.force else "")
+        ),
+        skip=False,
+    )
+
+
+def classify_user_hints(
+    rows: Iterable[InventoryRow],
+    user_hints: Optional[list[UserHint]],
+) -> list[Classification]:
+    """Emit a Classification ONLY for rows matching a user hint.
+
+    Unlike :func:`classify`, this does no regex/modality fallback - it is the
+    user-hint layer the chain in ``cli/scan`` seeds / overlays with priority.
+    The first matching hint (document order) wins for a given row.
+    """
+    if not user_hints:
+        return []
+    out: list[Classification] = []
+    for row in rows:
+        sequence = row.series_description or ""
+        for hint in user_hints:
+            if hint_matches(hint, sequence):
+                out.append(_classification_from_user_hint(row, hint))
+                break
+    return out
+
+
 def classify(rows: Iterable[InventoryRow]) -> list[Classification]:
     """Legacy regex/sequence-dictionary classifier — architecture.md §4.2 layer 3.
 
@@ -453,4 +511,5 @@ __all__ = [
     "detect_dwi_derivative",
     "looks_like_b0_reference",
     "classify",
+    "classify_user_hints",
 ]

--- a/bidsmgr/classifier/user_rules.py
+++ b/bidsmgr/classifier/user_rules.py
@@ -1,0 +1,181 @@
+"""User-supplied scan rules: classifier hints + series exclusions.
+
+Pure data + matchers, Qt-free, so the scan engine consumes them without
+importing the GUI / settings (architecture guard: the classifier imports
+nothing from ``gui/``). The GUI persists these as JSON in QSettings and
+converts to/from these dataclasses at the boundary; the CLI loads the same
+JSON via ``bidsmgr-scan --rules-file``. :func:`from_json` / :func:`to_json`
+are the single shared (de)serialiser so the GUI and CLI can never drift.
+
+* :class:`UserHint` extends the regex-fallback classifier: when one of its
+  ``patterns`` matches a series description, the series is classified to the
+  hint's ``datatype`` / ``suffix`` (see ``cli/scan`` for the priority rule -
+  a hint beats the built-in regex layer; ``force`` makes it beat dcm2niix
+  BidsGuess too).
+* :class:`ExclusionRule` marks matching series excluded from conversion
+  (``cli/scan._apply_user_exclusions`` sets ``include=0`` + a note).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+MATCH_MODES: tuple[str, ...] = ("substring", "regex")
+EXCLUSION_TARGETS: tuple[str, ...] = ("sequence", "path")
+
+
+@dataclass(frozen=True)
+class UserHint:
+    """A user-defined classifier hint: pattern(s) -> datatype / suffix [/ task]."""
+
+    patterns: tuple[str, ...]
+    datatype: str
+    suffix: str
+    task: Optional[str] = None
+    entities: tuple[tuple[str, str], ...] = ()   # extra entity overrides (acq, dir, ...)
+    match_mode: str = "substring"                # "substring" | "regex"
+    force: bool = False                          # override even dcm2niix BidsGuess
+
+
+@dataclass(frozen=True)
+class ExclusionRule:
+    """A user-defined exclusion: matching series are dropped from conversion."""
+
+    pattern: str
+    target: str = "sequence"      # "sequence" (SeriesDescription) | "path"
+    match_mode: str = "substring"  # "substring" | "regex"
+
+
+# ---------------------------------------------------------------------------
+# Matching
+# ---------------------------------------------------------------------------
+
+
+def validate_regex(pattern: str) -> Optional[str]:
+    """Return an error string if ``pattern`` is not a compilable regex, else None."""
+    try:
+        re.compile(pattern)
+        return None
+    except re.error as exc:
+        return str(exc)
+
+
+def _matches(text: Optional[str], pattern: str, mode: str) -> bool:
+    if not pattern:
+        return False
+    text = text or ""
+    if mode == "regex":
+        try:
+            return re.search(pattern, text, re.IGNORECASE) is not None
+        except re.error:
+            # A bad regex never aborts a scan; it simply doesn't match.
+            return False
+    return pattern.lower() in text.lower()
+
+
+def hint_matches(hint: UserHint, sequence: Optional[str]) -> bool:
+    """True if any of ``hint``'s patterns match ``sequence``."""
+    return any(_matches(sequence, p, hint.match_mode) for p in hint.patterns)
+
+
+def exclusion_matches(rule: ExclusionRule, *, sequence: Optional[str], path: Optional[str]) -> bool:
+    """True if ``rule`` matches the row's sequence description or path."""
+    target = sequence if rule.target == "sequence" else path
+    return _matches(target, rule.pattern, rule.match_mode)
+
+
+# ---------------------------------------------------------------------------
+# JSON (de)serialisation - the single shared form used by the GUI + CLI
+# ---------------------------------------------------------------------------
+
+
+def hint_to_dict(h: UserHint) -> dict:
+    return {
+        "patterns": list(h.patterns),
+        "datatype": h.datatype,
+        "suffix": h.suffix,
+        "task": h.task or "",
+        "entities": {k: v for k, v in h.entities},
+        "match_mode": h.match_mode,
+        "force": bool(h.force),
+    }
+
+
+def hint_from_dict(d: dict) -> UserHint:
+    raw_patterns = d.get("patterns", [])
+    if isinstance(raw_patterns, str):
+        raw_patterns = [raw_patterns]
+    patterns = tuple(str(p).strip() for p in raw_patterns if str(p).strip())
+    ents = d.get("entities", {}) or {}
+    entities = tuple((str(k), str(v)) for k, v in ents.items()) if isinstance(ents, dict) else ()
+    mode = str(d.get("match_mode", "substring"))
+    if mode not in MATCH_MODES:
+        mode = "substring"
+    task = str(d.get("task", "") or "").strip() or None
+    return UserHint(
+        patterns=patterns,
+        datatype=str(d.get("datatype", "")).strip(),
+        suffix=str(d.get("suffix", "")).strip(),
+        task=task,
+        entities=entities,
+        match_mode=mode,
+        force=bool(d.get("force", False)),
+    )
+
+
+def exclusion_to_dict(e: ExclusionRule) -> dict:
+    return {"pattern": e.pattern, "target": e.target, "match_mode": e.match_mode}
+
+
+def exclusion_from_dict(d: dict) -> ExclusionRule:
+    target = str(d.get("target", "sequence"))
+    if target not in EXCLUSION_TARGETS:
+        target = "sequence"
+    mode = str(d.get("match_mode", "substring"))
+    if mode not in MATCH_MODES:
+        mode = "substring"
+    return ExclusionRule(
+        pattern=str(d.get("pattern", "")).strip(),
+        target=target,
+        match_mode=mode,
+    )
+
+
+def from_json(obj: Optional[dict]) -> tuple[list[UserHint], list[ExclusionRule]]:
+    """Parse ``{"user_hints": [...], "scan_exclusions": [...]}`` into dataclasses.
+
+    Tolerant of missing keys / malformed entries (skips blanks); never raises
+    on shape, so a hand-edited rules file degrades gracefully.
+    """
+    obj = obj or {}
+    hints = [hint_from_dict(d) for d in obj.get("user_hints", []) if isinstance(d, dict)]
+    hints = [h for h in hints if h.patterns and h.datatype and h.suffix]
+    excl = [exclusion_from_dict(d) for d in obj.get("scan_exclusions", []) if isinstance(d, dict)]
+    excl = [e for e in excl if e.pattern]
+    return hints, excl
+
+
+def to_json(hints: list[UserHint], exclusions: list[ExclusionRule]) -> dict:
+    return {
+        "user_hints": [hint_to_dict(h) for h in hints],
+        "scan_exclusions": [exclusion_to_dict(e) for e in exclusions],
+    }
+
+
+__all__ = [
+    "MATCH_MODES",
+    "EXCLUSION_TARGETS",
+    "UserHint",
+    "ExclusionRule",
+    "validate_regex",
+    "hint_matches",
+    "exclusion_matches",
+    "hint_to_dict",
+    "hint_from_dict",
+    "exclusion_to_dict",
+    "exclusion_from_dict",
+    "from_json",
+    "to_json",
+]

--- a/bidsmgr/cli/_scaffold.py
+++ b/bidsmgr/cli/_scaffold.py
@@ -1,0 +1,168 @@
+"""Shared BIDS dataset scaffolding (cli layer, no Qt).
+
+Single home for creating the minimal valid BIDS skeleton and the files that keep
+a BIDS-Manager dataset clean under the official bids-validator. Used by the
+convert verb today; reused by the project "create dataset" flow later, so the
+BIDS-version string, the ``GeneratedBy`` de-dup, and ``.bidsignore`` all live in
+ONE place instead of being hardcoded per call site.
+
+``.bidsmgr/`` layout convention (the single source of truth for the hidden
+working dir, resolving the historical overlap of the name):
+
+    <bids_root>/
+    |-- dataset_description.json      # ensure_dataset_description()
+    |-- .bidsignore                   # ensure_bidsignore() -> exempts the below
+    |-- .bidsmgr/                     # BM working dir (NOT valid BIDS; bids-ignored)
+    |   |-- errors/                   #   convert per-subject failure logs
+    |   |-- backup/                   #   --overwrite subject backups
+    |   `-- project/                  #   (reserved) event-sourced project bundle:
+    |       |-- events.jsonl          #     meta.json + events.jsonl + scans/<version>/
+    |       `-- meta.json
+    |-- sub-XXX/.bidsmgr/provenance.json   # per-subject convert provenance
+    `-- .tmp_bidsmgr/                 # per-run staging (wiped on success)
+
+The event-sourced project bundle (``bidsmgr.project``) will live under
+``<bids_root>/.bidsmgr/project/`` rather than as a sibling ``<name>.bidsmgr/``
+directory, so it cannot collide with convert's ``errors/`` + ``backup/`` + the
+per-subject ``provenance.json`` that already live in ``.bidsmgr/``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+from ..schema import bids_version as schema_bids_version
+
+_SLUG_BAD_RE = re.compile(r"[^A-Za-z0-9_-]+")
+_SLUG_DASH_RE = re.compile(r"-{2,}")
+
+
+def slugify_name(name: str) -> str:
+    """Turn a human dataset name into a safe folder/dataset slug.
+
+    Mirrors the scan verb's slug rules (non-alphanumerics -> ``-``, repeated
+    dashes collapsed, trimmed) so the folder a project is created in matches the
+    ``dataset`` slug scan/convert use. Falls back to ``"dataset"`` when empty.
+    """
+    slug = _SLUG_BAD_RE.sub("-", (name or "").strip())
+    slug = _SLUG_DASH_RE.sub("-", slug).strip("-_")
+    return slug or "dataset"
+
+# gitignore-style globs written to ``.bidsignore`` so the official
+# bids-validator skips BM's hidden working dirs. A pattern without a leading
+# slash matches at any depth, so ``.bidsmgr/`` also covers the per-subject
+# ``sub-XXX/.bidsmgr/`` provenance dirs.
+BIDSIGNORE_LINES: tuple[str, ...] = (".bidsmgr/", ".tmp_bidsmgr/")
+
+
+def project_bundle_dir(bids_root: Path) -> Path:
+    """Return the event-sourced project bundle dir for a dataset.
+
+    ``<bids_root>/.bidsmgr/project`` (see the module docstring): nested under the
+    hidden working dir so it cannot collide with convert's ``errors/`` /
+    ``backup/`` / per-subject ``provenance.json``.
+    """
+    return Path(bids_root) / ".bidsmgr" / "project"
+
+
+def ensure_dataset_description(
+    bids_root: Path,
+    *,
+    name: Optional[str] = None,
+    generated_by: Optional[dict] = None,
+) -> None:
+    """Create or update ``<bids_root>/dataset_description.json``.
+
+    Sets the minimal valid fields (``Name`` + ``BIDSVersion`` sourced from the
+    bundled schema + ``DatasetType``) without overwriting existing values, and
+    appends one ``GeneratedBy`` entry idempotently (matched on
+    Name/Version/Description, so re-running never piles up duplicates). ``name``
+    seeds ``Name`` on first write (defaults to the folder name); an existing
+    ``Name`` is never overwritten. ``generated_by`` is the backend stamp to
+    record; pass ``None`` to scaffold a dataset without adding a generator entry.
+    """
+    p = bids_root / "dataset_description.json"
+    if p.exists():
+        try:
+            data = json.loads(p.read_text())
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    else:
+        data = {}
+
+    data.setdefault("Name", name or bids_root.name)
+    data.setdefault("BIDSVersion", schema_bids_version())
+    data.setdefault("DatasetType", "raw")
+
+    if generated_by is not None:
+        existing = data.get("GeneratedBy")
+        if not isinstance(existing, list):
+            existing = []
+        already = any(
+            isinstance(g, dict)
+            and g.get("Name") == generated_by.get("Name")
+            and g.get("Version") == generated_by.get("Version")
+            and g.get("Description") == generated_by.get("Description")
+            for g in existing
+        )
+        if not already:
+            existing.append(generated_by)
+        data["GeneratedBy"] = existing
+
+    p.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def ensure_bidsignore(bids_root: Path) -> None:
+    """Ensure ``<bids_root>/.bidsignore`` exempts BM's hidden working dirs.
+
+    BM keeps non-BIDS state inside the dataset (``.bidsmgr/`` for convert error
+    logs, per-subject provenance, overwrite backups, and later the project
+    bundle; ``.tmp_bidsmgr/`` for per-run staging). The official bids-validator
+    would flag these unless they are listed in ``.bidsignore``. Existing user
+    lines are preserved; only the missing BM lines are appended (idempotent).
+    """
+    p = bids_root / ".bidsignore"
+    existing_lines: list[str] = []
+    if p.exists():
+        try:
+            existing_lines = p.read_text().splitlines()
+        except OSError:
+            existing_lines = []
+    have = {ln.strip() for ln in existing_lines}
+    missing = [ln for ln in BIDSIGNORE_LINES if ln not in have]
+    if not missing:
+        return
+    out = list(existing_lines) + missing
+    p.write_text("\n".join(out) + "\n")
+
+
+def ensure_readme(bids_root: Path, name: str) -> None:
+    """Write a minimal README scaffold. Never overwrites a hand-edited file.
+
+    Matches the metadata engine's README byte-for-byte so a workspace scaffolded
+    by ``bidsmgr create`` and one later touched by ``bidsmgr-metadata`` look
+    identical (and metadata's never-overwrite leaves this one in place).
+    """
+    out = bids_root / "README"
+    if out.exists():
+        return
+    out.write_text(
+        f"# {name}\n\n"
+        "This BIDS dataset was generated by bidsmgr.\n\n"
+        "Edit this README to describe acquisition details, study design,\n"
+        "and any deviations from the standard BIDS layout.\n",
+        encoding="utf-8",
+    )
+
+
+__all__ = [
+    "BIDSIGNORE_LINES",
+    "slugify_name",
+    "project_bundle_dir",
+    "ensure_dataset_description",
+    "ensure_bidsignore",
+    "ensure_readme",
+]

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -102,6 +102,7 @@ def run_convert(
     recording_meta: Optional[Path] = None,
     raw_root: Optional[Path] = None,
     skip_residuals: bool = True,
+    force_edf: bool = False,
     cancel_check=None,
 ) -> int:
     """Convert every commit-ready row in ``tsv`` to BIDS under ``bids_parent``.
@@ -259,6 +260,7 @@ def run_convert(
                 subject_df, bids_root, files_by_uid,
                 source_search_roots=source_search_roots,
                 skip_residuals=skip_residuals,
+                force_edf=force_edf,
                 spec=spec,
             )
             if not tasks:
@@ -701,6 +703,7 @@ def _build_tasks_for_subject(
     *,
     source_search_roots: tuple[Path, ...] = (),
     skip_residuals: bool = True,
+    force_edf: bool = False,
     spec: Optional[RecordingMetaSpec] = None,
 ) -> list[ConvertTask]:
     tasks: list[ConvertTask] = []
@@ -709,6 +712,7 @@ def _build_tasks_for_subject(
             row, bids_root, files_by_uid,
             source_search_roots=source_search_roots,
             skip_residuals=skip_residuals,
+            force_edf=force_edf,
             spec=spec,
         )
         if task is not None:
@@ -723,6 +727,7 @@ def _row_to_task(
     *,
     source_search_roots: tuple[Path, ...] = (),
     skip_residuals: bool = True,
+    force_edf: bool = False,
     spec: Optional[RecordingMetaSpec] = None,
 ) -> Optional[ConvertTask]:
     """Detect MRI vs EEG/MEG row shape and dispatch to the right builder.
@@ -740,7 +745,8 @@ def _row_to_task(
     source_file = str(row.get("source_file", "")).strip()
     if source_file:
         return _row_to_task_eeg_meg(
-            row, bids_root, source_search_roots=source_search_roots, spec=spec,
+            row, bids_root, source_search_roots=source_search_roots,
+            force_edf=force_edf, spec=spec,
         )
 
     return None
@@ -880,6 +886,7 @@ def _row_to_task_eeg_meg(
     bids_root: Path,
     *,
     source_search_roots: tuple[Path, ...] = (),
+    force_edf: bool = False,
     spec: Optional[RecordingMetaSpec] = None,
 ) -> Optional[ConvertTask]:
     """Build a :class:`ConvertTask` for an EEG/MEG/iEEG/NIRS row.
@@ -1006,6 +1013,7 @@ def _row_to_task_eeg_meg(
         montage=montage,
         eeg_reference=eeg_reference,
         eeg_ground=eeg_ground,
+        force_edf=force_edf,
         companion_files=_parse_companion(row),
     )
 
@@ -1267,6 +1275,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
+        "--force-edf", action="store_true",
+        help=(
+            "Re-encode EEG / iEEG recordings to EDF on write instead of "
+            "keeping the source format. Harmonises a study to one BIDS-native "
+            "format, and makes a non-BIDS-native but mne-readable source "
+            "(GDF, EGI, ...) convertible. MEG / NIRS are unaffected."
+        ),
+    )
+    parser.add_argument(
         "-v", "--verbose", action="count", default=0,
         help="Increase log verbosity (-v INFO, -vv DEBUG)",
     )
@@ -1287,6 +1304,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         recording_meta=args.recording_meta,
         raw_root=args.raw_root,
         skip_residuals=not args.keep_residuals,
+        force_edf=args.force_edf,
     )
 
 

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -55,11 +55,29 @@ from ..converter import (
     dispatch,
     select_backend,
 )
-from ..fixups import apply_fieldmap_renames, populate_intended_for, update_scans_tsv
+from ..fixups import (
+    apply_fieldmap_renames,
+    attach_companion_files,
+    enrich_recording_sidecars,
+    populate_intended_for,
+    update_scans_tsv,
+)
+from ..recording_meta import (
+    RecordingMetaSpec,
+    default_spec,
+    load_spec,
+    resolve_effective,
+    scaffold_sidecar_path,
+)
 from ..util.cancel import OperationCancelled, is_cancelled
 from ..util.paths import long_path, safe_path_component
 
 log = logging.getLogger(__name__)
+
+# Datatypes converted by the mne-bids backend. These rows are run
+# sequentially in Phase 1 because ``write_raw_bids`` mutates shared
+# dataset files (participants.tsv / scans.tsv) on every call.
+_MNE_BIDS_DATATYPES: frozenset[str] = frozenset({"eeg", "meg", "ieeg", "nirs"})
 
 
 # ---------------------------------------------------------------------------
@@ -76,8 +94,7 @@ def run_convert(
     overwrite: bool = False,
     dry_run: bool = False,
     dcm2niix_bin: Optional[Path] = None,
-    line_freq: Optional[float] = 50.0,
-    montage: Optional[str] = None,
+    recording_meta: Optional[Path] = None,
     raw_root: Optional[Path] = None,
     skip_residuals: bool = True,
     cancel_check=None,
@@ -86,9 +103,12 @@ def run_convert(
 
     Returns 0 on success, non-zero if any subject failed.
 
-    ``line_freq`` and ``montage`` are EEG/MEG-only knobs passed to the
-    mne-bids backend; they fill in metadata (``PowerLineFrequency``,
-    ``electrodes.tsv``) that recording files don't always carry.
+    ``recording_meta`` points at an optional recording-metadata JSON. Its
+    dataset defaults supply EEG/MEG ``line_freq`` / ``montage`` when the
+    inventory cell is blank, and its richer fields (reference, ground,
+    filters, device, institution, event maps, ...) are folded into the BIDS
+    sidecars after the write. When omitted, a default spec is used
+    (``PowerLineFrequency = 50``), preserving prior behaviour.
 
     ``skip_residuals`` (default True) drops the dcm2niix residual/secondary
     outputs -- derived single-volume duplicates split off one input series
@@ -161,11 +181,21 @@ def run_convert(
         log.warning("no rows to convert (after filtering)")
         return 0
 
-    backends = default_backends(
-        dcm2niix_bin=dcm2niix_bin,
-        line_freq=line_freq,
-        montage=montage,
-    )
+    # Recording-metadata spec for EEG/MEG enrichment. Precedence: an explicit
+    # --recording-meta path, else the scaffold the scan wrote next to the TSV
+    # (auto-discovered), else a default spec (keeps PowerLineFrequency=50).
+    if recording_meta is not None:
+        spec = load_spec(Path(recording_meta))
+        log.info("loaded recording metadata from %s", recording_meta)
+    else:
+        auto_meta = scaffold_sidecar_path(tsv)
+        if auto_meta.exists():
+            spec = load_spec(auto_meta)
+            log.info("auto-loaded recording-metadata scaffold %s", auto_meta)
+        else:
+            spec = default_spec()
+
+    backends = default_backends(dcm2niix_bin=dcm2niix_bin)
     # Capture dcm2niix version once for provenance — it's still the
     # primary backend for MRI rows.
     primary = select_backend("mri", dcm2niix_bin=dcm2niix_bin)
@@ -200,6 +230,7 @@ def run_convert(
                 subject_df, bids_root, files_by_uid,
                 source_search_roots=source_search_roots,
                 skip_residuals=skip_residuals,
+                spec=spec,
             )
             if not tasks:
                 continue
@@ -214,6 +245,7 @@ def run_convert(
                     n_jobs=n_jobs, overwrite=overwrite,
                     dcm2niix_version=dcm2niix_version,
                     cancel_check=cancel_check,
+                    spec=spec,
                 )
             except OperationCancelled:
                 log.warning("conversion stopped by user (sub-%s not committed)", subject)
@@ -243,6 +275,7 @@ def _convert_subject(
     overwrite: bool,
     dcm2niix_version: str,
     cancel_check=None,
+    spec: Optional[RecordingMetaSpec] = None,
 ) -> None:
     """Run Phases 1–3 for a single (dataset, subject, session) group."""
     subject = tasks[0].subject
@@ -269,6 +302,12 @@ def _convert_subject(
         n_intended_for = populate_intended_for(
             staging, subject=subject, session=tasks[0].session,
         )
+        # EEG/MEG sidecar/channels/events enrichment from the recording-
+        # metadata spec (no-op for MRI-only subjects or when spec is None).
+        n_enriched = enrich_recording_sidecars(staging, tasks, spec)
+        # Copy any per-row curated companion files (events/beh/stim/...) into
+        # the staged tree (place + name only; no conversion).
+        n_enriched += attach_companion_files(staging, tasks)
         _prune_empty_dirs(staging)
 
         # Phase 3: atomic commit. Use the same sanitised segment we
@@ -278,7 +317,7 @@ def _convert_subject(
         _atomic_commit(staging, target, overwrite=overwrite)
         _write_provenance(
             target, results, rename_map, n_intended_for, n_scans_tsv,
-            dcm2niix_version=dcm2niix_version,
+            dcm2niix_version=dcm2niix_version, n_enriched=n_enriched,
         )
         log.info("committed sub-%s to %s", subject, target)
 
@@ -372,23 +411,40 @@ def _phase1_parallel_dcm2niix(
     if is_cancelled(cancel_check):
         raise OperationCancelled("conversion cancelled by user")
 
-    if n_jobs == 1 or len(tasks) == 1:
-        out: list[ConvertResult] = []
-        for t in tasks:
-            if is_cancelled(cancel_check):
-                raise OperationCancelled("conversion cancelled by user")
-            out.append(_phase1_one(backends, t, staging))
-        return out
+    # mne-bids' ``write_raw_bids`` rewrites shared dataset files
+    # (``participants.tsv`` and the subject's ``*_scans.tsv``) on *every*
+    # call. Running several EEG/MEG recordings for one subject in parallel
+    # therefore races on those files: one worker truncates+rewrites while
+    # another reads, and mne-bids blows up ("loadtxt: input contained no
+    # data" -> IndexError). dcm2niix (MRI) and physio tasks write only their
+    # own independent outputs and are safe to parallelise. So split the work:
+    # mne-bids-backed tasks run sequentially, the rest run in the pool.
+    serial = [t for t in tasks if t.datatype in _MNE_BIDS_DATATYPES]
+    parallel_tasks = [t for t in tasks if t.datatype not in _MNE_BIDS_DATATYPES]
 
-    parallel_backend = "threading" if len(tasks) < 4 else "loky"
-    gen = Parallel(n_jobs=n_jobs, backend=parallel_backend, return_as="generator")(
-        delayed(_phase1_one)(backends, t, staging) for t in tasks
-    )
-    out = []
-    for res in gen:
-        out.append(res)
+    out: list[ConvertResult] = []
+
+    for t in serial:
         if is_cancelled(cancel_check):
             raise OperationCancelled("conversion cancelled by user")
+        out.append(_phase1_one(backends, t, staging))
+
+    if parallel_tasks:
+        if n_jobs == 1 or len(parallel_tasks) == 1:
+            for t in parallel_tasks:
+                if is_cancelled(cancel_check):
+                    raise OperationCancelled("conversion cancelled by user")
+                out.append(_phase1_one(backends, t, staging))
+        else:
+            parallel_backend = "threading" if len(parallel_tasks) < 4 else "loky"
+            gen = Parallel(
+                n_jobs=n_jobs, backend=parallel_backend, return_as="generator",
+            )(delayed(_phase1_one)(backends, t, staging) for t in parallel_tasks)
+            for res in gen:
+                out.append(res)
+                if is_cancelled(cancel_check):
+                    raise OperationCancelled("conversion cancelled by user")
+
     return out
 
 
@@ -498,6 +554,7 @@ def _build_tasks_for_subject(
     *,
     source_search_roots: tuple[Path, ...] = (),
     skip_residuals: bool = True,
+    spec: Optional[RecordingMetaSpec] = None,
 ) -> list[ConvertTask]:
     tasks: list[ConvertTask] = []
     for _, row in subject_df.iterrows():
@@ -505,6 +562,7 @@ def _build_tasks_for_subject(
             row, bids_root, files_by_uid,
             source_search_roots=source_search_roots,
             skip_residuals=skip_residuals,
+            spec=spec,
         )
         if task is not None:
             tasks.append(task)
@@ -518,6 +576,7 @@ def _row_to_task(
     *,
     source_search_roots: tuple[Path, ...] = (),
     skip_residuals: bool = True,
+    spec: Optional[RecordingMetaSpec] = None,
 ) -> Optional[ConvertTask]:
     """Detect MRI vs EEG/MEG row shape and dispatch to the right builder.
 
@@ -534,7 +593,7 @@ def _row_to_task(
     source_file = str(row.get("source_file", "")).strip()
     if source_file:
         return _row_to_task_eeg_meg(
-            row, bids_root, source_search_roots=source_search_roots,
+            row, bids_root, source_search_roots=source_search_roots, spec=spec,
         )
 
     return None
@@ -626,7 +685,32 @@ def _row_to_task_mri(
         expected_outputs=expected_outputs,
         repetition_type=str(row.get("repetition_type", "")).strip(),
         skip_residuals=skip_residuals,
+        companion_files=_parse_companion(row),
     )
+
+
+def _parse_companion(row: pd.Series) -> tuple[tuple[str, str], ...]:
+    """Parse the row's ``companion_files`` JSON column into (suffix, path) pairs.
+
+    Format: a JSON list of ``{"suffix": "events", "path": "/abs/file.tsv"}``.
+    Returns ``()`` on missing/malformed input.
+    """
+    raw = str(row.get("companion_files", "") or "").strip()
+    if not raw:
+        return ()
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return ()
+    out: list[tuple[str, str]] = []
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                suffix = str(item.get("suffix", "")).strip()
+                path = str(item.get("path", "")).strip()
+                if suffix and path:
+                    out.append((suffix, path))
+    return tuple(out)
 
 
 def _parse_entities_json(row: pd.Series) -> dict[str, str]:
@@ -649,6 +733,7 @@ def _row_to_task_eeg_meg(
     bids_root: Path,
     *,
     source_search_roots: tuple[Path, ...] = (),
+    spec: Optional[RecordingMetaSpec] = None,
 ) -> Optional[ConvertTask]:
     """Build a :class:`ConvertTask` for an EEG/MEG/iEEG/NIRS row.
 
@@ -730,13 +815,31 @@ def _row_to_task_eeg_meg(
     # extension — the backend collects whatever lands in the datatype dir.
     expected_outputs: tuple[str, ...] = (".json",)
 
-    # Per-row EEG/MEG knobs (if the user filled them in the TSV).
+    # Resolve EEG/MEG line_freq + montage. Precedence: the inventory cell
+    # wins; else the recording-metadata dataset default (resolved per row by
+    # source path); line_freq finally falls back to 50 Hz so
+    # PowerLineFrequency is always populated (preserves prior behaviour now
+    # that the dataset-wide --line-freq flag is gone).
+    eff_acq = resolve_effective(spec, source_file).acquisition if spec is not None else None
+
     line_freq_raw = str(row.get("line_freq", "")).strip()
     try:
         line_freq = float(line_freq_raw) if line_freq_raw else None
     except ValueError:
         line_freq = None
+    if line_freq is None and eff_acq is not None:
+        line_freq = eff_acq.power_line_freq
+    if line_freq is None:
+        line_freq = 50.0
+
     montage = str(row.get("montage", "")).strip() or None
+    if montage is None and eff_acq is not None:
+        montage = eff_acq.montage
+
+    # Per-row reference/ground overrides (the spec default applies in the
+    # enrichment fixup when these are blank).
+    eeg_reference = str(row.get("eeg_reference", "")).strip() or None
+    eeg_ground = str(row.get("eeg_ground", "")).strip() or None
 
     return ConvertTask(
         row_id=source_file,  # source path is unique per recording
@@ -754,6 +857,9 @@ def _row_to_task_eeg_meg(
         repetition_type=str(row.get("repetition_type", "")).strip(),
         line_freq=line_freq,
         montage=montage,
+        eeg_reference=eeg_reference,
+        eeg_ground=eeg_ground,
+        companion_files=_parse_companion(row),
     )
 
 
@@ -833,6 +939,7 @@ def _write_provenance(
     n_scans_tsv: int,
     *,
     dcm2niix_version: str,
+    n_enriched: int = 0,
 ) -> None:
     """Per-subject provenance at ``<target>/.bidsmgr/provenance.json``."""
     prov_dir = target / ".bidsmgr"
@@ -863,6 +970,7 @@ def _write_provenance(
         ],
         "intended_for_updated": n_intended_for,
         "scans_tsv_rewritten": n_scans_tsv,
+        "recording_sidecars_enriched": n_enriched,
     }
     (prov_dir / "provenance.json").write_text(json.dumps(record, indent=2) + "\n")
 
@@ -998,22 +1106,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Path to a specific dcm2niix binary (defaults to bundled).",
     )
     parser.add_argument(
-        "--line-freq", default=50.0, type=float,
+        "--recording-meta", default=None, type=Path,
         help=(
-            "Power-line frequency in Hz, written to PowerLineFrequency in "
-            "EEG/MEG/iEEG JSON sidecars (BIDS-required). Default 50; use 60 "
-            "in the Americas / parts of Asia. Pass --line-freq 0 to leave "
-            "unset and let the recording's own value apply."
-        ),
-    )
-    parser.add_argument(
-        "--montage", default=None,
-        help=(
-            "Apply a built-in mne montage to every EEG/MEG row before "
-            "writing (e.g. standard_1020, biosemi64, easycap-M1). Fills "
-            "electrodes.tsv + coordsystem.json. Use only if all rows in "
-            "the inventory share the same channel layout. See "
-            "`mne.channels.get_builtin_montages()` for the full list."
+            "Path to a recording-metadata JSON (EEG/MEG enrichment). Its "
+            "dataset defaults supply line_freq / montage for blank inventory "
+            "cells, and its richer fields fill sidecar reference / ground / "
+            "filters / device / institution, retype auxiliary channels, and "
+            "map event codes to labels. Optional; omitting it leaves "
+            "PowerLineFrequency=50 by default. Set per-row line_freq / montage "
+            "in the inventory TSV columns to override per recording."
         ),
     )
     parser.add_argument(
@@ -1053,8 +1154,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         overwrite=args.overwrite,
         dry_run=args.dry_run,
         dcm2niix_bin=args.dcm2niix,
-        line_freq=args.line_freq if args.line_freq > 0 else None,
-        montage=args.montage,
+        recording_meta=args.recording_meta,
         raw_root=args.raw_root,
         skip_residuals=not args.keep_residuals,
     )

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -71,6 +71,7 @@ from ..recording_meta import (
 )
 from ..util.cancel import OperationCancelled, is_cancelled
 from ..util.paths import long_path, safe_path_component
+from ._scaffold import ensure_bidsignore, ensure_dataset_description
 
 log = logging.getLogger(__name__)
 
@@ -213,7 +214,14 @@ def run_convert(
         bids_root = bids_parent / str(dataset_name)
         if not dry_run:
             bids_root.mkdir(parents=True, exist_ok=True)
-            _ensure_dataset_description(bids_root, dcm2niix_version)
+            ensure_dataset_description(bids_root, generated_by={
+                "Name": "bidsmgr",
+                "Version": bidsmgr.__version__,
+                "Description": "dcm2niix-direct backend",
+                "Container": {"Type": "binary", "Tag": dcm2niix_version},
+            })
+            # Keep .bidsmgr/ + .tmp_bidsmgr/ out of the official bids-validator.
+            ensure_bidsignore(bids_root)
 
         for subject, subject_df in dataset_df.groupby("BIDS_name", sort=True):
             # Stop here if the user requested it. Subjects committed before
@@ -900,35 +908,6 @@ def _load_files_by_uid_sidecar(
 # ---------------------------------------------------------------------------
 # Provenance + error log
 # ---------------------------------------------------------------------------
-
-
-def _ensure_dataset_description(bids_root: Path, dcm2niix_version: str) -> None:
-    """Create or append-update ``dataset_description.json`` ``GeneratedBy``."""
-    p = bids_root / "dataset_description.json"
-    if p.exists():
-        try:
-            data = json.loads(p.read_text())
-        except (OSError, json.JSONDecodeError):
-            data = {}
-    else:
-        data = {}
-
-    data.setdefault("Name", bids_root.name)
-    data.setdefault("BIDSVersion", "1.10.0")
-    data.setdefault("DatasetType", "raw")
-
-    generated_by = data.get("GeneratedBy")
-    if not isinstance(generated_by, list):
-        generated_by = []
-    generated_by.append({
-        "Name": "bidsmgr",
-        "Version": bidsmgr.__version__,
-        "Description": "dcm2niix-direct backend",
-        "Container": {"Type": "binary", "Tag": dcm2niix_version},
-    })
-    data["GeneratedBy"] = generated_by
-
-    p.write_text(json.dumps(data, indent=2) + "\n")
 
 
 def _write_provenance(

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import filecmp
 import gzip
 import json
 import logging
@@ -95,6 +96,7 @@ def run_convert(
     dataset: Optional[str] = None,
     n_jobs: int = 1,
     overwrite: bool = False,
+    on_existing: Optional[str] = None,
     dry_run: bool = False,
     dcm2niix_bin: Optional[Path] = None,
     recording_meta: Optional[Path] = None,
@@ -119,6 +121,17 @@ def run_convert(
     """
     tsv = Path(tsv)
     bids_parent = Path(bids_parent)
+
+    # Resolve the existing-subject policy. ``--overwrite`` is the back-compat
+    # alias for ``replace``; the default is the safe-by-default ``skip`` (merge
+    # new files, never touch existing ones).
+    if on_existing is None:
+        on_existing = "replace" if overwrite else "skip"
+    if on_existing not in ("skip", "update", "replace", "error"):
+        raise ValueError(
+            f"invalid on_existing {on_existing!r}; "
+            "expected skip / update / replace / error"
+        )
 
     # One-line version banner so a user's conversion log unambiguously
     # records which copy of the package executed (matters when the same
@@ -205,6 +218,9 @@ def run_convert(
     dcm2niix_version = _dcm2niix_version_string(primary.binary)
 
     n_failed = 0
+    n_new = 0
+    n_merged = 0
+    n_collision = 0
     cancelled = False
     for dataset_name, dataset_df in df.groupby("dataset"):
         if cancelled:
@@ -224,6 +240,9 @@ def run_convert(
             })
             # Keep .bidsmgr/ + .tmp_bidsmgr/ out of the official bids-validator.
             ensure_bidsignore(bids_root)
+            # Pre-convert collision summary: which incoming subjects already
+            # exist on disk (incremental add into an existing dataset).
+            _log_existing_subject_summary(bids_root, dataset_df, on_existing)
 
         for subject, subject_df in dataset_df.groupby("BIDS_name", sort=True):
             # Stop here if the user requested it. Subjects committed before
@@ -249,21 +268,44 @@ def run_convert(
                 _print_tasks(tasks)
                 continue
 
+            # Target dir derives from the task's subject entity (e.g. "001"),
+            # the same way _convert_subject builds subj_segment.
+            existed = (
+                bids_root / f"sub-{safe_path_component(tasks[0].subject)}"
+            ).exists()
             try:
                 _convert_subject(
                     tasks, bids_root, backends,
-                    n_jobs=n_jobs, overwrite=overwrite,
+                    n_jobs=n_jobs, on_existing=on_existing,
                     dcm2niix_version=dcm2niix_version,
                     cancel_check=cancel_check,
                     spec=spec,
                 )
+                if existed:
+                    n_merged += 1
+                else:
+                    n_new += 1
             except OperationCancelled:
                 log.warning("conversion stopped by user (sub-%s not committed)", subject)
                 cancelled = True
                 break
+            except CollisionAbort as exc:
+                # Expected stop under on_existing="error": clean message, no
+                # forensic traceback. Counts as a failure so rc is non-zero.
+                log.warning("collision: %s", exc)
+                n_collision += 1
+                n_failed += 1
             except Exception:
                 log.exception("subject %s failed during conversion", subject)
                 n_failed += 1
+
+    # Results summary.
+    parts = [f"{n_new} new", f"{n_merged} merged into existing"]
+    if n_collision:
+        parts.append(f"{n_collision} collision(s)")
+    if n_failed:
+        parts.append(f"{n_failed} failed")
+    log.info("convert summary: %s", ", ".join(parts))
 
     if cancelled:
         log.warning("conversion stopped by user before all subjects were processed")
@@ -282,7 +324,7 @@ def _convert_subject(
     backends: list,
     *,
     n_jobs: int,
-    overwrite: bool,
+    on_existing: str,
     dcm2niix_version: str,
     cancel_check=None,
     spec: Optional[RecordingMetaSpec] = None,
@@ -324,7 +366,7 @@ def _convert_subject(
         # built for the staging dir so the commit target name is
         # consistent across OSes.
         target = bids_root / subj_segment
-        _merge_commit(staging, target, overwrite=overwrite)
+        _merge_commit(staging, target, on_existing=on_existing)
         _write_provenance(
             target, results, rename_map, n_intended_for, n_scans_tsv,
             dcm2niix_version=dcm2niix_version, n_enriched=n_enriched,
@@ -335,6 +377,11 @@ def _convert_subject(
         # User Stop, not a failure: no forensic error log. The ``finally``
         # wipes staging so this subject leaves nothing half-written; the
         # caller (run_convert) stops the subject loop.
+        raise
+    except CollisionAbort:
+        # on_existing="error" tripped: collision detected before anything was
+        # moved, so the target is intact. Not a crash; re-raise without a
+        # forensic error log (the caller logs the message).
         raise
     except Exception as exc:
         # Determine which phase blew up: results being non-empty means
@@ -511,54 +558,121 @@ def _prune_empty_dirs(root: Path) -> None:
                 pass
 
 
-def _merge_commit(staging_subject: Path, target: Path, *, overwrite: bool) -> None:
+class CollisionAbort(Exception):
+    """Raised by :func:`_merge_commit` under ``on_existing="error"`` when the
+    staged subject has files that already exist on disk. The caller logs the
+    message (no forensic error log) and counts the subject as failed.
+    """
+
+
+_ON_EXISTING_VERB = {
+    "skip": "merge new files, keep existing",
+    "update": "merge, replace changed files",
+    "replace": "merge, replace colliding files (backed up)",
+    "error": "abort on any file collision",
+}
+
+
+def _log_existing_subject_summary(bids_root: Path, dataset_df, on_existing: str) -> None:
+    """Pre-convert heads-up: which incoming subjects already exist on disk.
+
+    Awareness for incremental conversion: a subject already on disk will be
+    merged into per ``on_existing``. Informational only (the per-subject merge
+    counts + the final summary report the actual outcome). ``BIDS_name`` values
+    (``sub-XXX``) match the on-disk subject dir names for the common case.
+    """
+    if "BIDS_name" not in dataset_df.columns:
+        return
+    incoming = sorted({str(s).strip() for s in dataset_df["BIDS_name"] if str(s).strip()})
+    on_disk = {p.name for p in bids_root.glob("sub-*") if p.is_dir()}
+    if not incoming or not on_disk:
+        return  # brand-new dataset (or no subjects): nothing to flag
+    already = [s for s in incoming if s in on_disk]
+    new = [s for s in incoming if s not in on_disk]
+    msg = (
+        f"converting into existing dataset '{bids_root.name}' "
+        f"({len(on_disk)} subject(s) present): {len(new)} new"
+    )
+    if already:
+        shown = ", ".join(already[:8]) + ("" if len(already) <= 8 else " ...")
+        msg += (
+            f", {len(already)} already present ({shown}) "
+            f"-> {_ON_EXISTING_VERB[on_existing]}"
+        )
+    log.info(msg)
+
+
+def _merge_commit(
+    staging_subject: Path, target: Path, *, on_existing: str,
+) -> tuple[int, int, int]:
     """Commit a staged subject into the dataset, merging into an existing one.
 
     A brand-new subject is moved in wholesale via the atomic ``os.rename`` fast
     path. When the subject already exists, the staged tree is merged FILE BY FILE
     so adding a new session or datatype lands beside the existing data instead of
-    replacing the whole subject (the incremental-conversion case):
+    replacing the whole subject (the incremental-conversion case). Returns
+    ``(added, replaced, kept)`` file counts.
 
-    * a staged file with no counterpart on disk is always moved in (the add);
-    * a staged file that collides with an existing one is left untouched when
-      ``overwrite`` is False (existing data is never overwritten), or backed up to
-      ``<bids_root>/.bidsmgr/backup/<sub>_<utcstamp>/<relpath>`` and replaced when
-      ``overwrite`` is True.
+    ``on_existing`` governs a staged file that collides with one already on disk:
 
-    Atomicity drops from subject-level to per-file on the merge path; any replaced
-    file is backed up first, so an interrupted merge can be reconstructed.
+    * ``"skip"``    keep the existing file (default; existing data never lost);
+    * ``"update"``  replace it only if the content differs (identical files kept);
+    * ``"replace"`` always back it up then replace it;
+    * ``"error"``   abort the whole subject (commit nothing) if ANY file collides.
+
+    A replaced file is first moved to
+    ``<bids_root>/.bidsmgr/backup/<sub>_<utcstamp>/<relpath>``, so the merge path
+    is reconstructable even though atomicity drops from subject- to file-level.
     """
+    staged = [p for p in sorted(staging_subject.rglob("*")) if p.is_file()]
+
     if not target.exists():
         target.parent.mkdir(parents=True, exist_ok=True)
         os.rename(staging_subject, target)
-        return
+        return (len(staged), 0, 0)
+
+    colliding = [p for p in staged if (target / p.relative_to(staging_subject)).exists()]
+    if colliding and on_existing == "error":
+        rels = ", ".join(str(p.relative_to(staging_subject)) for p in colliding[:5])
+        more = "" if len(colliding) <= 5 else f" (+{len(colliding) - 5} more)"
+        raise CollisionAbort(
+            f"{target.name}: {len(colliding)} file(s) already exist ({rels}{more}); "
+            f"aborted (use --on-existing skip/update/replace to proceed)"
+        )
 
     backup_dir = target.parent / ".bidsmgr" / "backup" / f"{target.name}_{_utc_stamp()}"
     added = replaced = kept = 0
-    for src in sorted(staging_subject.rglob("*")):
-        if not src.is_file():
-            continue
+    for src in staged:
         rel = src.relative_to(staging_subject)
         dst = target / rel
-        if dst.exists():
-            if overwrite:
-                bdst = backup_dir / rel
-                bdst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(dst), str(bdst))
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                shutil.move(str(src), str(dst))
-                replaced += 1
-            else:
-                kept += 1  # existing file wins; staged copy dropped with staging
-        else:
+        if not dst.exists():
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(src), str(dst))
             added += 1
-    log.info(
-        "merged into existing %s: %d added, %d replaced, %d kept%s",
-        target, added, replaced, kept,
-        "" if not kept else " (use --overwrite to replace the kept files)",
-    )
+            continue
+        # Colliding file.
+        if on_existing == "skip":
+            kept += 1
+            continue
+        if on_existing == "update" and filecmp.cmp(str(src), str(dst), shallow=False):
+            kept += 1  # identical content; leave the existing file in place
+            continue
+        bdst = backup_dir / rel
+        bdst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(dst), str(bdst))
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+        replaced += 1
+    if added or replaced or kept:
+        tail = (
+            " (use --on-existing replace to overwrite the kept files)"
+            if kept and on_existing == "skip" else ""
+        )
+        log.info(
+            "merged into existing %s: %d added, %d replaced, %d kept%s",
+            target, added, replaced, kept, tail,
+        )
+    return (added, replaced, kept)
 
 
 # ---------------------------------------------------------------------------
@@ -1097,10 +1211,19 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--overwrite", action="store_true",
         help=(
-            "When a subject already exists, replace colliding files (each is "
-            "backed up to <bids_root>/.bidsmgr/backup/ first). Without this, an "
-            "existing subject is merged into: new sessions/datatypes are added "
-            "and colliding files are kept untouched."
+            "Alias for --on-existing replace: when a subject already exists, back "
+            "up and replace colliding files (new sessions/datatypes still merge in)."
+        ),
+    )
+    parser.add_argument(
+        "--on-existing", choices=("skip", "update", "replace", "error"),
+        default=None,
+        help=(
+            "Policy when an incoming subject already exists on disk. New "
+            "sessions/datatypes always merge in; this governs colliding files: "
+            "'skip' keep existing (default), 'update' replace only changed files, "
+            "'replace' back up + replace colliding files, 'error' abort the "
+            "subject if anything would collide. --overwrite is an alias for replace."
         ),
     )
     parser.add_argument(
@@ -1158,6 +1281,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         dataset=args.dataset,
         n_jobs=args.jobs,
         overwrite=args.overwrite,
+        on_existing=args.on_existing,
         dry_run=args.dry_run,
         dcm2niix_bin=args.dcm2niix,
         recording_meta=args.recording_meta,

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -1199,12 +1199,32 @@ def main(argv: Optional[list[str]] = None) -> int:
             "sibling BIDS root under <bids_parent>."
         ),
     )
-    parser.add_argument("tsv", help="Inventory TSV produced by `bidsmgr-scan`")
     parser.add_argument(
-        "bids_parent",
+        "tsv", nargs="?", default=None,
+        help="Inventory TSV produced by `bidsmgr-scan` (omit when using --project)",
+    )
+    parser.add_argument(
+        "bids_parent", nargs="?", default=None,
         help=(
             "Parent directory; each `dataset` value becomes a sibling BIDS "
-            "root underneath."
+            "root underneath. Omit when using --project (output is the project)."
+        ),
+    )
+    parser.add_argument(
+        "--project", default=None, type=Path,
+        help=(
+            "Convert the project dataset's active (latest) scan version into "
+            "its locked root. Resolves the inventory + output + recording "
+            "metadata from <project>/.bidsmgr/project, replaying the curation "
+            "edits recorded in the GUI. Supersedes the positional tsv / "
+            "bids_parent."
+        ),
+    )
+    parser.add_argument(
+        "--version", default=None,
+        help=(
+            "With --project, convert a specific scan version instead of the "
+            "latest. Accepts the version id or its index (see bidsmgr-project)."
         ),
     )
     parser.add_argument(
@@ -1291,6 +1311,53 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
     level = logging.WARNING - 10 * min(args.verbose, 2)
     logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
+
+    if args.project is not None:
+        # Project mode: convert a scan version into the locked root.
+        from ..project.orchestration import (
+            find_version, latest_version, version_dataframe,
+        )
+
+        bids_root = Path(args.project)
+        if args.version:
+            version = find_version(bids_root, args.version)
+            if version is None:
+                parser.error(
+                    f"no scan version {args.version!r} in {bids_root} "
+                    f"(see `bidsmgr-project {bids_root}`)"
+                )
+        else:
+            version = latest_version(bids_root)
+        if version is None:
+            parser.error(
+                f"no scans in project {bids_root}; run `bidsmgr-scan "
+                f"<raw> --project {bids_root}` first"
+            )
+        # Replay the GUI curation edits onto the inventory, keep the dataset
+        # column in lock-step with the (possibly renamed) folder, and bake it
+        # back into the version inventory so dcm2niix's files_by_uid sidecar
+        # (which sits next to it) stays aligned.
+        df = version_dataframe(version, apply_edits=True)
+        if "dataset" in df.columns:
+            df["dataset"] = bids_root.name
+        df.to_csv(version.inventory, sep="\t", index=False)
+        return run_convert(
+            version.inventory,
+            bids_root.parent,
+            dataset=bids_root.name,
+            n_jobs=args.jobs,
+            overwrite=args.overwrite,
+            on_existing=args.on_existing,
+            dry_run=args.dry_run,
+            dcm2niix_bin=args.dcm2niix,
+            recording_meta=args.recording_meta,
+            raw_root=Path(version.raw_root) if version.raw_root else args.raw_root,
+            skip_residuals=not args.keep_residuals,
+            force_edf=args.force_edf,
+        )
+
+    if not args.tsv or not args.bids_parent:
+        parser.error("provide tsv and bids_parent, or use --project <dataset>")
 
     return run_convert(
         Path(args.tsv),

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -13,8 +13,10 @@ Pipeline per (dataset, subject, session)::
               - fixups.scans_tsv.update_scans_tsv (no-op today)
               - fixups.intended_for.populate_intended_for
 
-    Phase 3   sequential per-subject atomic commit:
-              os.rename(<staging>/sub-<id>, <bids_root>/sub-<id>)
+    Phase 3   sequential per-subject merge commit:
+              new subject  -> os.rename(<staging>/sub-<id>, <bids_root>/sub-<id>)
+              existing subject -> merge staged files in (add new ses/datatype;
+              keep or, with --overwrite, back-up-and-replace colliding files)
 
 Failure handling: per-series failures don't abort the subject; per-subject
 post-conv or atomic-commit failures write a JSON error log to
@@ -322,7 +324,7 @@ def _convert_subject(
         # built for the staging dir so the commit target name is
         # consistent across OSes.
         target = bids_root / subj_segment
-        _atomic_commit(staging, target, overwrite=overwrite)
+        _merge_commit(staging, target, overwrite=overwrite)
         _write_provenance(
             target, results, rename_map, n_intended_for, n_scans_tsv,
             dcm2niix_version=dcm2niix_version, n_enriched=n_enriched,
@@ -509,31 +511,54 @@ def _prune_empty_dirs(root: Path) -> None:
                 pass
 
 
-def _atomic_commit(staging_subject: Path, target: Path, *, overwrite: bool) -> None:
-    """Move ``staging_subject`` onto ``target`` atomically.
+def _merge_commit(staging_subject: Path, target: Path, *, overwrite: bool) -> None:
+    """Commit a staged subject into the dataset, merging into an existing one.
 
-    POSIX ``os.rename`` is atomic within a filesystem and refuses to
-    overwrite a non-empty target. When the target exists:
+    A brand-new subject is moved in wholesale via the atomic ``os.rename`` fast
+    path. When the subject already exists, the staged tree is merged FILE BY FILE
+    so adding a new session or datatype lands beside the existing data instead of
+    replacing the whole subject (the incremental-conversion case):
 
-    * ``overwrite=False`` → log + skip (staging gets wiped by caller).
-    * ``overwrite=True``  → move existing target aside to
-      ``<bids_root>/.bidsmgr/backup/sub-<id>_<utcstamp>/`` then rename.
+    * a staged file with no counterpart on disk is always moved in (the add);
+    * a staged file that collides with an existing one is left untouched when
+      ``overwrite`` is False (existing data is never overwritten), or backed up to
+      ``<bids_root>/.bidsmgr/backup/<sub>_<utcstamp>/<relpath>`` and replaced when
+      ``overwrite`` is True.
+
+    Atomicity drops from subject-level to per-file on the merge path; any replaced
+    file is backed up first, so an interrupted merge can be reconstructed.
     """
-    if target.exists():
-        if not overwrite:
-            log.warning(
-                "target %s already exists; skipping subject (use --overwrite to replace)",
-                target,
-            )
-            return
-        backup_root = target.parent / ".bidsmgr" / "backup"
-        backup_root.mkdir(parents=True, exist_ok=True)
-        backup = backup_root / f"{target.name}_{_utc_stamp()}"
-        shutil.move(str(target), str(backup))
-        log.info("backed up existing %s to %s", target, backup)
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        os.rename(staging_subject, target)
+        return
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    os.rename(staging_subject, target)
+    backup_dir = target.parent / ".bidsmgr" / "backup" / f"{target.name}_{_utc_stamp()}"
+    added = replaced = kept = 0
+    for src in sorted(staging_subject.rglob("*")):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(staging_subject)
+        dst = target / rel
+        if dst.exists():
+            if overwrite:
+                bdst = backup_dir / rel
+                bdst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(dst), str(bdst))
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(src), str(dst))
+                replaced += 1
+            else:
+                kept += 1  # existing file wins; staged copy dropped with staging
+        else:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+            added += 1
+    log.info(
+        "merged into existing %s: %d added, %d replaced, %d kept%s",
+        target, added, replaced, kept,
+        "" if not kept else " (use --overwrite to replace the kept files)",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1072,8 +1097,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--overwrite", action="store_true",
         help=(
-            "Replace existing sub-<id>/ folders. Existing content is moved "
-            "to <bids_root>/.bidsmgr/backup/ before the new tree lands."
+            "When a subject already exists, replace colliding files (each is "
+            "backed up to <bids_root>/.bidsmgr/backup/ first). Without this, an "
+            "existing subject is merged into: new sessions/datatypes are added "
+            "and colliding files are kept untouched."
         ),
     )
     parser.add_argument(

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -56,6 +56,7 @@ from ..converter import (
     select_backend,
 )
 from ..fixups import apply_fieldmap_renames, populate_intended_for, update_scans_tsv
+from ..util.cancel import OperationCancelled, is_cancelled
 from ..util.paths import long_path, safe_path_component
 
 log = logging.getLogger(__name__)
@@ -78,6 +79,8 @@ def run_convert(
     line_freq: Optional[float] = 50.0,
     montage: Optional[str] = None,
     raw_root: Optional[Path] = None,
+    skip_residuals: bool = True,
+    cancel_check=None,
 ) -> int:
     """Convert every commit-ready row in ``tsv`` to BIDS under ``bids_parent``.
 
@@ -86,6 +89,10 @@ def run_convert(
     ``line_freq`` and ``montage`` are EEG/MEG-only knobs passed to the
     mne-bids backend; they fill in metadata (``PowerLineFrequency``,
     ``electrodes.tsv``) that recording files don't always carry.
+
+    ``skip_residuals`` (default True) drops the dcm2niix residual/secondary
+    outputs -- derived single-volume duplicates split off one input series
+    (e.g. ``..._bolda`` next to ``..._bold``). Pass False to keep them.
     """
     tsv = Path(tsv)
     bids_parent = Path(bids_parent)
@@ -165,7 +172,10 @@ def run_convert(
     dcm2niix_version = _dcm2niix_version_string(primary.binary)
 
     n_failed = 0
+    cancelled = False
     for dataset_name, dataset_df in df.groupby("dataset"):
+        if cancelled:
+            break
         if not dataset_name:
             log.warning("skipping %d rows with empty dataset name", len(dataset_df))
             continue
@@ -176,6 +186,12 @@ def run_convert(
             _ensure_dataset_description(bids_root, dcm2niix_version)
 
         for subject, subject_df in dataset_df.groupby("BIDS_name", sort=True):
+            # Stop here if the user requested it. Subjects committed before
+            # this point stay (the desired "stop now" behaviour); nothing
+            # half-written is left because the commit is per-subject atomic.
+            if is_cancelled(cancel_check):
+                cancelled = True
+                break
             if not subject:
                 log.warning("skipping rows with empty BIDS_name")
                 continue
@@ -183,6 +199,7 @@ def run_convert(
             tasks = _build_tasks_for_subject(
                 subject_df, bids_root, files_by_uid,
                 source_search_roots=source_search_roots,
+                skip_residuals=skip_residuals,
             )
             if not tasks:
                 continue
@@ -196,11 +213,19 @@ def run_convert(
                     tasks, bids_root, backends,
                     n_jobs=n_jobs, overwrite=overwrite,
                     dcm2niix_version=dcm2niix_version,
+                    cancel_check=cancel_check,
                 )
+            except OperationCancelled:
+                log.warning("conversion stopped by user (sub-%s not committed)", subject)
+                cancelled = True
+                break
             except Exception:
                 log.exception("subject %s failed during conversion", subject)
                 n_failed += 1
 
+    if cancelled:
+        log.warning("conversion stopped by user before all subjects were processed")
+        return 130  # 128 + SIGINT, conventional "interrupted" code
     return 0 if n_failed == 0 else 1
 
 
@@ -217,6 +242,7 @@ def _convert_subject(
     n_jobs: int,
     overwrite: bool,
     dcm2niix_version: str,
+    cancel_check=None,
 ) -> None:
     """Run Phases 1–3 for a single (dataset, subject, session) group."""
     subject = tasks[0].subject
@@ -234,7 +260,7 @@ def _convert_subject(
     try:
         # Phase 1: parallel per-series dispatch + conversion.
         results = _phase1_parallel_dcm2niix(
-            tasks, staging, backends, n_jobs=n_jobs,
+            tasks, staging, backends, n_jobs=n_jobs, cancel_check=cancel_check,
         )
 
         # Phase 2: per-subject post-conv (sequential, fast).
@@ -256,6 +282,11 @@ def _convert_subject(
         )
         log.info("committed sub-%s to %s", subject, target)
 
+    except OperationCancelled:
+        # User Stop, not a failure: no forensic error log. The ``finally``
+        # wipes staging so this subject leaves nothing half-written; the
+        # caller (run_convert) stops the subject loop.
+        raise
     except Exception as exc:
         # Determine which phase blew up: results being non-empty means
         # Phase 1 finished before something went wrong.
@@ -325,19 +356,40 @@ def _phase1_parallel_dcm2niix(
     backends: list,
     *,
     n_jobs: int,
+    cancel_check=None,
 ) -> list[ConvertResult]:
     """Run per-series conversion in parallel; return per-task results.
 
     Backend selection is per-task: each task is dispatched to the
     first registered backend whose ``can_handle()`` returns True.
+
+    A Stop request raises :class:`OperationCancelled` once the in-flight
+    task(s) return -- new tasks stop dispatching, the subject's staging is
+    wiped by the caller's ``finally``, and nothing is committed.
     """
+    from ..util.cancel import OperationCancelled, is_cancelled
+
+    if is_cancelled(cancel_check):
+        raise OperationCancelled("conversion cancelled by user")
+
     if n_jobs == 1 or len(tasks) == 1:
-        return [_phase1_one(backends, t, staging) for t in tasks]
+        out: list[ConvertResult] = []
+        for t in tasks:
+            if is_cancelled(cancel_check):
+                raise OperationCancelled("conversion cancelled by user")
+            out.append(_phase1_one(backends, t, staging))
+        return out
 
     parallel_backend = "threading" if len(tasks) < 4 else "loky"
-    return Parallel(n_jobs=n_jobs, backend=parallel_backend)(
+    gen = Parallel(n_jobs=n_jobs, backend=parallel_backend, return_as="generator")(
         delayed(_phase1_one)(backends, t, staging) for t in tasks
     )
+    out = []
+    for res in gen:
+        out.append(res)
+        if is_cancelled(cancel_check):
+            raise OperationCancelled("conversion cancelled by user")
+    return out
 
 
 def _phase1_one(backends: list, task: ConvertTask, staging: Path) -> ConvertResult:
@@ -445,12 +497,14 @@ def _build_tasks_for_subject(
     files_by_uid: dict[str, list[str]],
     *,
     source_search_roots: tuple[Path, ...] = (),
+    skip_residuals: bool = True,
 ) -> list[ConvertTask]:
     tasks: list[ConvertTask] = []
     for _, row in subject_df.iterrows():
         task = _row_to_task(
             row, bids_root, files_by_uid,
             source_search_roots=source_search_roots,
+            skip_residuals=skip_residuals,
         )
         if task is not None:
             tasks.append(task)
@@ -463,6 +517,7 @@ def _row_to_task(
     files_by_uid: dict[str, list[str]],
     *,
     source_search_roots: tuple[Path, ...] = (),
+    skip_residuals: bool = True,
 ) -> Optional[ConvertTask]:
     """Detect MRI vs EEG/MEG row shape and dispatch to the right builder.
 
@@ -472,7 +527,9 @@ def _row_to_task(
     """
     series_uid = str(row.get("series_uid", "")).strip()
     if series_uid:
-        return _row_to_task_mri(row, bids_root, files_by_uid)
+        return _row_to_task_mri(
+            row, bids_root, files_by_uid, skip_residuals=skip_residuals,
+        )
 
     source_file = str(row.get("source_file", "")).strip()
     if source_file:
@@ -487,6 +544,8 @@ def _row_to_task_mri(
     row: pd.Series,
     bids_root: Path,
     files_by_uid: dict[str, list[str]],
+    *,
+    skip_residuals: bool = True,
 ) -> Optional[ConvertTask]:
     series_uid = str(row.get("series_uid", "")).strip()
     if not series_uid:
@@ -566,6 +625,7 @@ def _row_to_task_mri(
         basename=basename,
         expected_outputs=expected_outputs,
         repetition_type=str(row.get("repetition_type", "")).strip(),
+        skip_residuals=skip_residuals,
     )
 
 
@@ -967,6 +1027,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
+        "--keep-residuals", action="store_true",
+        help=(
+            "Keep dcm2niix residual/secondary outputs. By default the "
+            "converter drops the derived single-volume duplicates dcm2niix "
+            "splits off one input series (e.g. ..._bolda alongside ..._bold, "
+            "or _Eq_ / _ROI markers). These are not real acquired images and "
+            "have no valid BIDS suffix. Pass this flag to keep them."
+        ),
+    )
+    parser.add_argument(
         "-v", "--verbose", action="count", default=0,
         help="Increase log verbosity (-v INFO, -vv DEBUG)",
     )
@@ -986,6 +1056,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         line_freq=args.line_freq if args.line_freq > 0 else None,
         montage=args.montage,
         raw_root=args.raw_root,
+        skip_residuals=not args.keep_residuals,
     )
 
 

--- a/bidsmgr/cli/create.py
+++ b/bidsmgr/cli/create.py
@@ -1,0 +1,131 @@
+"""``bidsmgr-create`` — create + scaffold a BIDS dataset workspace.
+
+Creates the dataset folder (if needed), writes a minimal valid BIDS skeleton
+(``dataset_description.json`` + ``README`` + ``.bidsignore``), and initializes
+the event-sourced project bundle at ``<bids_root>/.bidsmgr/project`` so curation
+can be resumed later. The folder name is the dataset slug you later pass to
+``bidsmgr-scan --dataset`` / convert.
+
+Safe to run on a directory that already holds a BIDS dataset: it ADOPTS it,
+adding only the missing scaffold files + the project bundle, and never
+overwriting an existing ``dataset_description.json`` / ``README``. Running it a
+second time on a BM workspace is a no-op (the bundle already exists).
+
+Architectural note (rule 3, no Pipeline orchestrator): orchestration is
+straight-line code here; ``Project`` and the ``_scaffold`` helpers do the work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ..project import Project
+from ._scaffold import (
+    ensure_bidsignore,
+    ensure_dataset_description,
+    ensure_readme,
+    project_bundle_dir,
+)
+
+log = logging.getLogger(__name__)
+
+
+def open_or_create_workspace(
+    bids_root: Path,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Project:
+    """Create, adopt, or reopen the project workspace at ``bids_root``.
+
+    Writes the minimal BIDS skeleton (never overwriting existing files) and
+    returns the opened :class:`~bidsmgr.project.Project` bundle (created at
+    ``<bids_root>/.bidsmgr/project`` if absent). Safe on a fresh folder, an
+    external/non-BM BIDS dataset (adopted read-only), or an existing BM project
+    (reopened). This is the single entry point the GUI Welcome tab uses.
+    """
+    bids_root = Path(bids_root)
+    bids_root.mkdir(parents=True, exist_ok=True)
+    ds_name = name or bids_root.name
+
+    # Minimal valid BIDS skeleton (each helper is never-overwrite).
+    ensure_dataset_description(bids_root, name=ds_name)
+    ensure_readme(bids_root, ds_name)
+    ensure_bidsignore(bids_root)
+
+    bundle = project_bundle_dir(bids_root)
+    if bundle.exists():
+        return Project.open(bundle)
+    return Project.create(bundle, name=ds_name, description=description)
+
+
+def run_create(
+    output_dir: Path,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> int:
+    """Create or adopt a BIDS dataset workspace at ``output_dir``.
+
+    Returns 0 on success. ``name`` seeds the dataset_description ``Name``
+    (defaults to the folder name); ``description`` is recorded in the project
+    bundle's first event.
+    """
+    bids_root = Path(output_dir)
+    existed = bids_root.exists()
+    already = project_bundle_dir(bids_root).exists()
+
+    open_or_create_workspace(bids_root, name=name, description=description)
+
+    if already:
+        log.info("%s is already a BIDS-Manager project", bids_root)
+    else:
+        verb = "Adopted existing dataset" if existed else "Created dataset"
+        log.info("%s at %s", verb, bids_root)
+
+    print(f"BIDS dataset ready at: {bids_root}")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="bidsmgr-create",
+        description=(
+            "Create + scaffold a BIDS dataset workspace (or adopt an existing "
+            "BIDS folder). The folder name is the dataset slug used by "
+            "bidsmgr-scan / bidsmgr-convert."
+        ),
+    )
+    parser.add_argument(
+        "output_dir", type=Path,
+        help="Dataset folder to create or adopt.",
+    )
+    parser.add_argument(
+        "--name", default=None,
+        help="Human-readable dataset Name for dataset_description.json "
+             "(defaults to the folder name).",
+    )
+    parser.add_argument(
+        "--description", default=None,
+        help="Optional project description recorded in the project bundle.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0,
+        help="Increase log verbosity (-v INFO).",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(message)s",
+    )
+    return run_create(
+        args.output_dir, name=args.name, description=args.description,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bidsmgr/cli/metadata.py
+++ b/bidsmgr/cli/metadata.py
@@ -36,7 +36,7 @@ def run_metadata_cli(
     dataset: Optional[str] = None,
     inventory_tsv: Optional[Path] = None,
     name: Optional[str] = None,
-    bids_version: str = "1.10.0",
+    bids_version: Optional[str] = None,
     license: Optional[str] = None,
     authors: Optional[list[str]] = None,
     acknowledgements: Optional[str] = None,
@@ -72,8 +72,13 @@ def run_metadata_cli(
     n_failed = 0
     for bids_root in bids_roots:
         meta = DatasetMetadata(
-            name=name or bids_root.name,
-            bids_version=bids_version,
+            # Omit name when unset so the engine preserves an existing
+            # dataset_description Name (e.g. from `bidsmgr create`) instead of
+            # overwriting it with the folder name.
+            **({"name": name} if name else {}),
+            # Omit when unset so DatasetMetadata's schema-sourced default
+            # applies (no hardcoded BIDS version anywhere).
+            **({"bids_version": bids_version} if bids_version else {}),
             license=license,
             authors=list(authors or []),
             acknowledgements=acknowledgements,
@@ -231,7 +236,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         "--name", default=None,
         help="Dataset Name (defaults to the BIDS root directory name).",
     )
-    parser.add_argument("--bids-version", default="1.10.0")
+    parser.add_argument(
+        "--bids-version", default=None,
+        help="BIDS version for dataset_description.json (defaults to the "
+             "bundled schema's version).",
+    )
     parser.add_argument("--license", default=None)
     parser.add_argument(
         "--author", action="append", dest="authors", default=None,

--- a/bidsmgr/cli/metadata.py
+++ b/bidsmgr/cli/metadata.py
@@ -47,10 +47,17 @@ def run_metadata_cli(
     dataset_doi: Optional[str] = None,
     fill_todos: bool = False,
     write_report: bool = True,
+    participants_file: Optional[Path] = None,
+    phenotype_files: Optional[list[Path]] = None,
 ) -> int:
     """Run the metadata engine on every BIDS root under ``target``.
 
     Returns 0 if every root processed cleanly, 1 if any errored.
+
+    ``participants_file`` is an optional demographics spreadsheet whose
+    ``age`` / ``sex`` / ``handedness`` columns override the inventory; it is
+    applied to every BIDS root. ``phenotype_files`` are measure tables written
+    to ``phenotype/`` in each root.
     """
     target = Path(target)
     if not target.is_dir():
@@ -83,6 +90,8 @@ def run_metadata_cli(
                 dataset_meta=meta,
                 fill_todos=fill_todos,
                 write_report=write_report,
+                participants_file=participants_file,
+                phenotype_files=phenotype_files,
             )
         except Exception:
             log.exception("metadata engine failed on %s", bids_root)
@@ -202,6 +211,23 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
+        "--participants", default=None, type=Path, dest="participants_file",
+        help=(
+            "Optional participants spreadsheet (TSV/CSV/XLSX/ODS) keyed by a "
+            "'participant_id' column. Its 'age' / 'sex' / 'handedness' columns "
+            "override the inventory-derived demographics in participants.tsv."
+        ),
+    )
+    parser.add_argument(
+        "--phenotype", action="append", default=None, type=Path,
+        dest="phenotype_files",
+        help=(
+            "Phenotype measure table (TSV/CSV/XLSX/ODS) keyed by "
+            "'participant_id'. Repeat for each instrument; each is written to "
+            "phenotype/<measure>.tsv + .json."
+        ),
+    )
+    parser.add_argument(
         "--name", default=None,
         help="Dataset Name (defaults to the BIDS root directory name).",
     )
@@ -265,6 +291,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         dataset_doi=args.dataset_doi,
         fill_todos=args.fill_todos,
         write_report=args.write_report,
+        participants_file=args.participants_file,
+        phenotype_files=args.phenotype_files,
     )
 
 

--- a/bidsmgr/cli/metadata.py
+++ b/bidsmgr/cli/metadata.py
@@ -200,8 +200,25 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
-        "target",
-        help="BIDS root, or a parent containing one or more BIDS roots.",
+        "target", nargs="?", default=None,
+        help="BIDS root, or a parent containing one or more BIDS roots "
+             "(omit when using --project).",
+    )
+    parser.add_argument(
+        "--project", default=None, type=Path,
+        help=(
+            "Run on a project dataset folder: the target is the project root "
+            "and the inventory is resolved from its active scan version "
+            "(so demographics / phenotype / participants flow through). "
+            "Supersedes the positional target."
+        ),
+    )
+    parser.add_argument(
+        "--version", default=None,
+        help=(
+            "With --project, take the inventory from a specific scan version "
+            "instead of the latest (version id or index; see bidsmgr-project)."
+        ),
     )
     parser.add_argument(
         "--dataset", default=None,
@@ -284,10 +301,34 @@ def main(argv: Optional[list[str]] = None) -> int:
     level = logging.WARNING - 10 * min(args.verbose, 2)
     logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
 
+    target = args.target
+    inventory_tsv = args.inventory_tsv
+    if args.project is not None:
+        # Project mode: target is the project root; inventory is a scan
+        # version (so demographics + the scaffold's phenotype / participants
+        # files are auto-discovered relative to it).
+        from ..project.orchestration import find_version, latest_version
+        bids_root = Path(args.project)
+        target = bids_root
+        if inventory_tsv is None:
+            version = (
+                find_version(bids_root, args.version) if args.version
+                else latest_version(bids_root)
+            )
+            if args.version and version is None:
+                parser.error(
+                    f"no scan version {args.version!r} in {bids_root} "
+                    f"(see `bidsmgr-project {bids_root}`)"
+                )
+            if version is not None:
+                inventory_tsv = version.inventory
+    elif not target:
+        parser.error("provide a target directory, or use --project <dataset>")
+
     return run_metadata_cli(
-        Path(args.target),
+        Path(target),
         dataset=args.dataset,
-        inventory_tsv=args.inventory_tsv,
+        inventory_tsv=inventory_tsv,
         name=args.name,
         bids_version=args.bids_version,
         license=args.license,

--- a/bidsmgr/cli/project.py
+++ b/bidsmgr/cli/project.py
@@ -1,0 +1,70 @@
+"""``bidsmgr-project`` — inspect a project dataset's scan versions.
+
+A companion to ``bidsmgr-create`` / ``bidsmgr-scan --project`` /
+``bidsmgr-convert --project``: lists the versioned scans recorded under
+``<dataset>/.bidsmgr/project/scans/`` (the same versions the GUI's scan picker
+shows), so a CLI user can see what is in a project and which scan is active
+(the latest). Read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+from ..cli._scaffold import project_bundle_dir
+from ..project import workspace
+
+
+def run_project_list(bids_root: Path) -> int:
+    bids_root = Path(bids_root)
+    if not project_bundle_dir(bids_root).exists():
+        print(
+            f"{bids_root} is not a BIDS-Manager project "
+            f"(no .bidsmgr/project bundle). Create one with `bidsmgr-create`."
+        )
+        return 1
+
+    versions = workspace.list_versions(bids_root)
+    print(f"Project: {bids_root}")
+    if not versions:
+        print("  no scans yet (run `bidsmgr-scan <raw> --project " f"{bids_root}`)")
+        return 0
+    print(f"  {len(versions)} scan version(s); active = latest:")
+    for v in versions:
+        active = "  *" if v is versions[-1] else "   "
+        raw = v.raw_root or "(raw moved/unknown)"
+        try:
+            import pandas as pd
+            n_rows = len(pd.read_csv(v.inventory, sep="\t", dtype=str))
+        except Exception:
+            n_rows = "?"
+        print(
+            f"{active} {v.version_id}  [{v.status}]  "
+            f"{n_rows} rows  source={v.source_label}  raw={raw}"
+        )
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="bidsmgr-project",
+        description=(
+            "Inspect a BIDS-Manager project dataset: list its versioned scans "
+            "(the active one is the latest, marked *)."
+        ),
+    )
+    parser.add_argument("dataset", type=Path, help="Project dataset folder.")
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List scan versions (the default action).",
+    )
+    args = parser.parse_args(argv)
+    # ``--list`` is the only (and default) action today.
+    return run_project_list(Path(args.dataset))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -64,6 +64,12 @@ from ..inventory.mri_dicom import (
 )
 from ..inventory.probe_convert import ProbeFileStats
 from ..inventory.types import InventoryRow
+from ..recording_meta import (
+    AcquisitionSpec,
+    RecordingMetaSpec,
+    dump_spec,
+    scaffold_sidecar_path,
+)
 
 log = logging.getLogger(__name__)
 
@@ -1150,11 +1156,69 @@ def _default_dataset_slug(dicom_root: Path) -> str:
     return slug or "dataset"
 
 
+def _write_recording_meta_scaffold(merged: pd.DataFrame, output_tsv: Path):
+    """Seed a recording-metadata scaffold from detected EEG/MEG header facts.
+
+    Reads the internal ``_event_codes`` / ``_manufacturer`` / ``_model``
+    columns (populated by the EEG/MEG scanner, dropped from the TSV itself),
+    aggregates them across the dataset, and writes a starter
+    :class:`RecordingMetaSpec` next to the inventory TSV. Event labels are left
+    blank for the user to fill; the enrichment step skips blank labels, so an
+    unedited scaffold is harmless. Returns the path written, or ``None`` when
+    there is nothing to seed (no EEG/MEG rows, or no detectable facts).
+
+    The scaffold is never overwritten if one already exists, so a re-scan does
+    not clobber labels the user has filled in.
+    """
+    if "source_file" not in merged.columns:
+        return None
+    eeg_rows = merged[merged["source_file"].astype(str).str.len() > 0]
+    if eeg_rows.empty:
+        return None
+
+    # Union of detected trigger/annotation codes across all recordings.
+    codes: list[str] = []
+    for raw in eeg_rows.get("_event_codes", pd.Series([], dtype=object)):
+        try:
+            for c in json.loads(raw) if isinstance(raw, str) and raw else []:
+                if c and c not in codes:
+                    codes.append(c)
+        except (ValueError, TypeError):
+            continue
+
+    def _most_common(col: str) -> str:
+        if col not in eeg_rows.columns:
+            return ""
+        vals = [str(v).strip() for v in eeg_rows[col] if str(v).strip()]
+        return max(set(vals), key=vals.count) if vals else ""
+
+    manufacturer = _most_common("_manufacturer")
+    model = _most_common("_model")
+
+    if not codes and not manufacturer and not model:
+        return None
+
+    scaffold_path = scaffold_sidecar_path(output_tsv)
+    if scaffold_path.exists():
+        # Preserve any labels/edits the user already made on a prior scan.
+        return None
+
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(
+            manufacturer=manufacturer or None,
+            amplifier_model=model or None,
+        ),
+        event_maps={"*": {c: "" for c in sorted(codes)}} if codes else {},
+    )
+    scaffold_path.write_text(dump_spec(spec), encoding="utf-8")
+    return scaffold_path
+
+
 def _unified_column_order(df: pd.DataFrame) -> list[str]:
     """Final unified TSV column order. Locked contract:
 
-    ``TSV(22) + BIDS_GUESS(8) + ENTITIES(1) + DATASET(1) + PROBE(4) +
-    EXTENDED(3) + EEG_MEG(12) = 51``.
+    ``TSV(24) + BIDS_GUESS(8) + ENTITIES(1) + DATASET(1) + PROBE(4) +
+    EXTENDED(3) + EEG_MEG(15) = 56``.
 
     The ``entities`` column carries the canonical JSON-encoded BIDS
     entity dict; the converter and ``bidsmgr-rebuild`` use it as the
@@ -1293,6 +1357,9 @@ def run_scan(
         _apply_user_exclusions(merged, exclusions)
         merged.to_csv(output_tsv, sep="\t", index=False, columns=_unified_column_order(merged))
         print(f"Inventory written to: {output_tsv}")
+        scaffold_path = _write_recording_meta_scaffold(merged, Path(output_tsv))
+        if scaffold_path is not None:
+            print(f"Recording-metadata scaffold written to: {scaffold_path}")
         log.warning(
             "no DICOMs found; the inventory has only EEG/MEG rows. "
             "files_by_uid sidecar will not be written."
@@ -1373,6 +1440,13 @@ def run_scan(
         columns=_unified_column_order(merged),
     )
     print(f"Inventory written to: {output_tsv}")
+
+    # Seed a recording-metadata scaffold from facts detected in the EEG/MEG
+    # headers (event codes, device). The convert/metadata verbs auto-discover
+    # it; the user fills the human-only fields (event labels, reference, ...).
+    scaffold_path = _write_recording_meta_scaffold(merged, Path(output_tsv))
+    if scaffold_path is not None:
+        print(f"Recording-metadata scaffold written to: {scaffold_path}")
 
     # Always write the per-UID DICOM file map next to the TSV. ``bidsmgr-convert``
     # reads this sidecar to find the source files for each MRI row's dcm2niix call.

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -65,7 +65,6 @@ from ..inventory.mri_dicom import (
 from ..inventory.probe_convert import ProbeFileStats
 from ..inventory.types import InventoryRow
 from ..recording_meta import (
-    AcquisitionSpec,
     RecordingMetaSpec,
     dump_spec,
     scaffold_sidecar_path,
@@ -1157,18 +1156,22 @@ def _default_dataset_slug(dicom_root: Path) -> str:
 
 
 def _write_recording_meta_scaffold(merged: pd.DataFrame, output_tsv: Path):
-    """Seed a recording-metadata scaffold from detected EEG/MEG header facts.
+    """Seed a recording-metadata scaffold from detected EEG/MEG event codes.
 
-    Reads the internal ``_event_codes`` / ``_manufacturer`` / ``_model``
-    columns (populated by the EEG/MEG scanner, dropped from the TSV itself),
-    aggregates them across the dataset, and writes a starter
-    :class:`RecordingMetaSpec` next to the inventory TSV. Event labels are left
-    blank for the user to fill; the enrichment step skips blank labels, so an
-    unedited scaffold is harmless. Returns the path written, or ``None`` when
-    there is nothing to seed (no EEG/MEG rows, or no detectable facts).
+    Reads the internal ``_event_codes`` column (populated by the EEG/MEG
+    scanner, dropped from the TSV itself), unions the codes across recordings,
+    and writes a starter :class:`RecordingMetaSpec` with an event map of blank
+    labels next to the inventory TSV. Event labels are left blank for the user
+    to fill; the enrichment step skips blank labels, so an unedited scaffold is
+    harmless. Returns the path written, or ``None`` when there is nothing to
+    seed (no EEG/MEG rows, or no event codes).
 
-    The scaffold is never overwritten if one already exists, so a re-scan does
-    not clobber labels the user has filled in.
+    Device fields are intentionally NOT seeded: the manufacturer is a read-only
+    suggestion (``manufacturer_suggestion`` column) and mne-bids fills the MEG
+    sidecar Manufacturer itself, so seeding a default here would wrongly
+    overwrite it. The scaffold is never overwritten if one already exists, so a
+    CLI re-scan does not clobber labels the user has filled in (the GUI resets a
+    stale scaffold when it starts a fresh scan).
     """
     if "source_file" not in merged.columns:
         return None
@@ -1186,16 +1189,7 @@ def _write_recording_meta_scaffold(merged: pd.DataFrame, output_tsv: Path):
         except (ValueError, TypeError):
             continue
 
-    def _most_common(col: str) -> str:
-        if col not in eeg_rows.columns:
-            return ""
-        vals = [str(v).strip() for v in eeg_rows[col] if str(v).strip()]
-        return max(set(vals), key=vals.count) if vals else ""
-
-    manufacturer = _most_common("_manufacturer")
-    model = _most_common("_model")
-
-    if not codes and not manufacturer and not model:
+    if not codes:
         return None
 
     scaffold_path = scaffold_sidecar_path(output_tsv)
@@ -1204,11 +1198,7 @@ def _write_recording_meta_scaffold(merged: pd.DataFrame, output_tsv: Path):
         return None
 
     spec = RecordingMetaSpec(
-        defaults=AcquisitionSpec(
-            manufacturer=manufacturer or None,
-            amplifier_model=model or None,
-        ),
-        event_maps={"*": {c: "" for c in sorted(codes)}} if codes else {},
+        event_maps={"*": {c: "" for c in sorted(codes)}},
     )
     scaffold_path.write_text(dump_spec(spec), encoding="utf-8")
     return scaffold_path
@@ -1218,7 +1208,7 @@ def _unified_column_order(df: pd.DataFrame) -> list[str]:
     """Final unified TSV column order. Locked contract:
 
     ``TSV(24) + BIDS_GUESS(8) + ENTITIES(1) + DATASET(1) + PROBE(4) +
-    EXTENDED(3) + EEG_MEG(15) = 56``.
+    EXTENDED(3) + EEG_MEG(16) = 57``.
 
     The ``entities`` column carries the canonical JSON-encoded BIDS
     entity dict; the converter and ``bidsmgr-rebuild`` use it as the

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -920,7 +920,78 @@ def _augment_dataframe(
                     annotated_issues.append(anomaly)
                     df.at[df_idx, "proposed_issues"] = " | ".join(annotated_issues)
 
+    _flag_nonimage_rows(df)
     return df
+
+
+# Marker prepended to ``proposed_issues`` for a DERIVED non-image series.
+# The GUI inventory model keys on the leading ``NONIMAGE_ISSUE_TOKEN``
+# substring to paint the row's "not an image" highlight, so keep the two
+# in sync (mirrors how the abort highlight keys on ``suspected_abort``).
+NONIMAGE_ISSUE_TOKEN = "non-image series"
+NONIMAGE_ISSUE = (
+    "non-image series: the DICOM headers carry no pixel data "
+    "(Rows/Columns absent), so dcm2niix cannot convert it to NIfTI. "
+    "This is typically a scanner-derived object such as a Siemens "
+    "diffusion TENSOR map. Excluded from conversion."
+)
+
+
+def _is_nonimage_flag(val: object) -> bool:
+    """True only when the internal ``_has_pixel_data`` flag is explicitly
+    False. NaN / blank / True (fmap-collapsed rows, EEG/MEG rows, real
+    images) are treated as images."""
+    if val is True or val is False:
+        return val is False
+    return str(val).strip().lower() in ("false", "0")
+
+
+def _is_physio_row(df: pd.DataFrame, idx: object) -> bool:
+    """True for Siemens CMRR ``_PhysioLog.dcm`` rows.
+
+    Physio DICOMs carry no Image Pixel module (no Rows/Columns) just like a
+    DERIVED non-image object, but unlike one they ARE convertible -- the
+    ``PhysioDcmBackend`` (bidsphysio) turns them into ``_physio.tsv.gz`` +
+    ``_physio.json``. So they must be exempt from the non-image exclusion.
+    Identified by the ``physio`` suffix the converter dispatches on, with
+    ``modality`` / basename fallbacks for robustness."""
+    def _cell(col: str) -> str:
+        return str(df.at[idx, col]).strip().lower() if col in df.columns else ""
+
+    return (
+        _cell("bids_guess_suffix") == "physio"
+        or _cell("modality") == "physio"
+        or _cell("proposed_basename").endswith("_physio")
+    )
+
+
+def _flag_nonimage_rows(df: pd.DataFrame) -> None:
+    """Exclude + annotate DICOM series that carry no pixel data.
+
+    A series whose DICOMs lack the Image Pixel module (Rows/Columns) is a
+    DERIVED non-image object (commonly a Siemens diffusion TENSOR map, also
+    structured reports / spectroscopy frames). dcm2niix cannot turn it into
+    a NIfTI, so instead of letting the converter attempt it and fail with a
+    cryptic ``rc=2`` we flag the row here: force ``bids_guess_skip`` /
+    ``include=0`` so it is never converted, and prepend a clear reason to
+    ``proposed_issues`` so it surfaces in the inventory table highlighted as
+    "not an actual image". Operates on the internal ``_has_pixel_data``
+    column (stamped by ``inventory.mri_dicom``, dropped from the final TSV).
+    """
+    if "_has_pixel_data" not in df.columns:
+        return
+    for df_idx in df.index:
+        if not _is_nonimage_flag(df.at[df_idx, "_has_pixel_data"]):
+            continue
+        # Physio rows have no pixel data but ARE convertible (bidsphysio).
+        if _is_physio_row(df, df_idx):
+            continue
+        df.at[df_idx, "bids_guess_skip"] = True
+        df.at[df_idx, "include"] = 0
+        existing = str(df.at[df_idx, "proposed_issues"] or "").strip()
+        df.at[df_idx, "proposed_issues"] = (
+            f"{NONIMAGE_ISSUE} | {existing}" if existing else NONIMAGE_ISSUE
+        )
 
 
 def _probe_anomaly(

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -1543,7 +1543,20 @@ def run_scan(
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="bidsmgr-scan", description=__doc__.split("\n")[0])
     parser.add_argument("dicom_root", help="Directory containing DICOM files (any depth)")
-    parser.add_argument("output_tsv", help="Destination TSV file")
+    parser.add_argument(
+        "output_tsv", nargs="?", default=None,
+        help="Destination TSV file (omit when using --project)",
+    )
+    parser.add_argument(
+        "--project", default=None, type=Path,
+        help=(
+            "Scan INTO a project dataset folder (created by bidsmgr-create or "
+            "the GUI; created/adopted if absent). The inventory is saved as a "
+            "new versioned scan under <project>/.bidsmgr/project/scans/ instead "
+            "of a loose TSV, so it is resumable in the GUI and never overwrites "
+            "an earlier scan. --dataset defaults to the project folder name."
+        ),
+    )
     parser.add_argument(
         "--jobs", "-j",
         type=int,
@@ -1644,6 +1657,41 @@ def main(argv: Optional[list[str]] = None) -> int:
                 err = user_rules_module.validate_regex(r.pattern)
                 if err:
                     parser.error(f"--rules-file: bad exclusion regex {r.pattern!r}: {err}")
+
+    if args.project is None and not args.output_tsv:
+        parser.error("provide an output_tsv path, or use --project <dataset>")
+
+    if args.project is not None:
+        # Project mode: scan into a new versioned bundle under the project.
+        from ..cli.create import open_or_create_workspace
+        from ..project import workspace
+        from ..project.orchestration import import_scan_as_version, row_id
+
+        bids_root = Path(args.project)
+        open_or_create_workspace(bids_root)  # ensure scaffold + project bundle
+        staging = workspace.scans_dir(bids_root).parent / ".scan_staging"
+        if staging.exists():
+            shutil.rmtree(staging, ignore_errors=True)
+        staging.mkdir(parents=True, exist_ok=True)
+        staged_tsv = staging / "inventory.tsv"
+        df = run_scan(
+            Path(args.dicom_root), staged_tsv,
+            n_jobs=args.jobs, skip_bids_guess=args.no_bids_guess,
+            probe_convert=args.probe_convert,
+            dataset=args.dataset or bids_root.name,
+            line_freq=args.line_freq, montage=args.montage,
+            user_hints=user_hints, exclusions=exclusions,
+        )
+        version = import_scan_as_version(
+            bids_root, staged_tsv, raw_root=Path(args.dicom_root),
+            row_ids=tuple(row_id(df, i) for i in range(len(df))),
+            n_rows=len(df),
+        )
+        print(
+            f"Scan saved as version '{version.version_id}' in project "
+            f"{bids_root} ({len(df)} rows)."
+        )
+        return 0
 
     run_scan(
         Path(args.dicom_root),

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -46,6 +46,12 @@ import pandas as pd
 from .. import schema
 from ..classifier import dcm2niix_bidsguess, sequence_dict
 from ..classifier.types import Classification
+from ..classifier.user_rules import (
+    ExclusionRule,
+    UserHint,
+    exclusion_matches,
+)
+from ..classifier import user_rules as user_rules_module
 from ..inventory import probe_convert as probe_convert_module
 from ..inventory._time import parse_dicom_time_seconds as _parse_dicom_time_seconds
 from ..inventory.eeg_meg import EEG_MEG_COLUMNS, scan_eeg_meg
@@ -202,6 +208,10 @@ def _reroute_b0_references_to_fmap_epi(
     for k, c in list(chosen.items()):
         if c.datatype != "dwi" or c.suffix != "dwi":
             continue
+        # A user hint that resolved to dwi/dwi is the user's explicit choice;
+        # don't second-guess it with the B0 reroute.
+        if c.classifier == "user_hint":
+            continue
         row = rows_by_id.get(k)
         if row is None:
             continue
@@ -316,13 +326,51 @@ def _is_classification_schema_valid(c: Classification) -> bool:
     return not [v for v in verdicts if v.severity is schema.Severity.ERROR]
 
 
-def _run_classifier_chain(rows: list[InventoryRow]) -> dict[str, Classification]:
+# A user-hint classification at or above this confidence is a "force" hint
+# (sequence_dict emits 0.95 for force, 0.60 otherwise; dcm2niix BidsGuess is
+# 0.85). Force hints override BidsGuess; non-force hints only beat the regex
+# fallback.
+_FORCE_HINT_CONFIDENCE = 0.90
+
+
+def _user_hint_classifications(
+    rows: list[InventoryRow],
+    user_hints: Optional[list[UserHint]],
+) -> dict[str, Classification]:
+    """Return ``{row_id hex -> Classification}`` for rows matching a user hint,
+    schema-validated. ``derivatives`` is rejected (user hints route to raw
+    BIDS datatypes only). A hand-edited / invalid hint is dropped with a log
+    rather than producing a broken basename."""
+    out: dict[str, Classification] = {}
+    for c in sequence_dict.classify_user_hints(rows, user_hints):
+        if c.datatype == "derivatives":
+            log.debug("user hint rejected (derivatives not allowed): %s", c)
+            continue
+        if not _is_classification_schema_valid(c):
+            log.debug("user hint rejected by schema: %s", c)
+            continue
+        out[c.row_id.hex] = c
+    return out
+
+
+def _run_classifier_chain(
+    rows: list[InventoryRow],
+    *,
+    user_hints: Optional[list[UserHint]] = None,
+) -> dict[str, Classification]:
     """Run the BidsGuess classifier first; fall back to sequence_dict.
 
     Returns a mapping ``row_id (hex) -> Classification``. Each row gets at
-    most one classification — the highest-confidence schema-valid result,
-    or the sequence_dict fallback if BidsGuess produced nothing usable.
+    most one classification — the highest-confidence schema-valid result.
+
+    User hints (when supplied) sit by confidence: a ``force`` hint (0.95)
+    overrides even BidsGuess (0.85); a default hint (0.60) beats the regex
+    fallback (0.40/0.45) but loses to BidsGuess.
     """
+
+    user_cls = _user_hint_classifications(rows, user_hints)
+    force_hints = {h: c for h, c in user_cls.items() if c.confidence >= _FORCE_HINT_CONFIDENCE}
+    nonforce_hints = {h: c for h, c in user_cls.items() if c.confidence < _FORCE_HINT_CONFIDENCE}
 
     # Layer 1 — dcm2niix BidsGuess.
     try:
@@ -333,7 +381,9 @@ def _run_classifier_chain(rows: list[InventoryRow]) -> dict[str, Classification]
 
     rows_by_id = {r.row_id.hex: r for r in rows}
 
-    chosen: dict[str, Classification] = {}
+    # Seed force user hints (0.95) before BidsGuess so BidsGuess (0.85) can't
+    # displace them.
+    chosen: dict[str, Classification] = dict(force_hints)
     for c in bg_results:
         if not _is_classification_schema_valid(c):
             log.debug("BidsGuess result rejected by schema: %s", c)
@@ -350,6 +400,12 @@ def _run_classifier_chain(rows: list[InventoryRow]) -> dict[str, Classification]
         key = c.row_id.hex
         existing = chosen.get(key)
         if existing is None or c.confidence > existing.confidence:
+            chosen[key] = c
+
+    # Non-force user hints (0.60) win on rows BidsGuess did not claim, before
+    # the regex fallback gets a turn.
+    for key, c in nonforce_hints.items():
+        if key not in chosen:
             chosen[key] = c
 
     # Layer 3 — legacy regex/sequence-dictionary classifier (also runs the
@@ -994,6 +1050,52 @@ def _flag_nonimage_rows(df: pd.DataFrame) -> None:
         )
 
 
+# Marker prepended to ``proposed_issues`` for a user-excluded series. Mirrors
+# the non-image precedent: row stays visible (include=0) so the user can
+# re-enable it; the GUI surfaces the reason via the issues column / tooltip.
+USER_EXCLUDED_ISSUE_TOKEN = "user-excluded"
+
+
+def _apply_user_exclusions(
+    df: pd.DataFrame,
+    exclusions: Optional[list[ExclusionRule]],
+) -> None:
+    """Flag rows matching a user exclusion rule: ``include=0`` +
+    ``bids_guess_skip`` + a ``user-excluded`` note prepended to
+    ``proposed_issues``. Reversible (the row stays in the inventory; the user
+    can re-tick ``include``). Matches the rule against the series description
+    (``sequence``) or the relative path (``source_folder`` / ``source_file``).
+    """
+    if not exclusions:
+        return
+
+    def _cell(idx, col: str) -> str:
+        return str(df.at[idx, col]).strip() if col in df.columns else ""
+
+    for idx in df.index:
+        sequence = _cell(idx, "sequence")
+        path = _cell(idx, "source_folder") or _cell(idx, "source_file")
+        matched = next(
+            (r for r in exclusions
+             if exclusion_matches(r, sequence=sequence, path=path)),
+            None,
+        )
+        if matched is None:
+            continue
+        if "include" in df.columns:
+            df.at[idx, "include"] = 0
+        if "bids_guess_skip" in df.columns:
+            df.at[idx, "bids_guess_skip"] = True
+        note = (
+            f"{USER_EXCLUDED_ISSUE_TOKEN}: matched the scan exclusion rule "
+            f"'{matched.pattern}' ({matched.target}/{matched.match_mode}); "
+            "excluded from conversion. Re-tick 'include' to convert it anyway."
+        )
+        existing = str(df.at[idx, "proposed_issues"] or "").strip() if "proposed_issues" in df.columns else ""
+        if "proposed_issues" in df.columns:
+            df.at[idx, "proposed_issues"] = f"{note} | {existing}" if existing else note
+
+
 def _probe_anomaly(
     datatype: str, suffix: str, *, n_nifti: int, n_uids: int,
 ) -> Optional[str]:
@@ -1121,6 +1223,8 @@ def run_scan(
     line_freq: Optional[float] = None,
     montage: Optional[str] = None,
     cancel_check=None,
+    user_hints: Optional[list[UserHint]] = None,
+    exclusions: Optional[list[ExclusionRule]] = None,
 ) -> pd.DataFrame:
     """Run the full scan pipeline and return the DataFrame written to TSV.
 
@@ -1186,6 +1290,7 @@ def run_scan(
             if col not in df_eeg.columns:
                 _init_object_column(df_eeg, col)
         merged = _finalize_unified_dataframe(df_eeg)
+        _apply_user_exclusions(merged, exclusions)
         merged.to_csv(output_tsv, sep="\t", index=False, columns=_unified_column_order(merged))
         print(f"Inventory written to: {output_tsv}")
         log.warning(
@@ -1198,11 +1303,13 @@ def run_scan(
 
     chosen: dict[str, Classification] = {}
     if skip_bids_guess:
-        # Only run sequence_dict (legacy regex layer).
+        # Only run sequence_dict (legacy regex layer). User hints (force +
+        # non-force) still apply, taking priority over the regex fallback.
+        chosen = dict(_user_hint_classifications(rows, user_hints))
         for c in sequence_dict.classify(rows):
             chosen.setdefault(c.row_id.hex, c)
     else:
-        chosen = _run_classifier_chain(rows)
+        chosen = _run_classifier_chain(rows, user_hints=user_hints)
 
     chosen = _reroute_b0_references_to_fmap_epi(rows, chosen)
     abort_verdicts = _detect_aborts(rows, chosen)
@@ -1255,6 +1362,11 @@ def run_scan(
     else:
         merged = df
     merged = _finalize_unified_dataframe(merged)
+
+    # User exclusions run last, on the unified frame, so they cover MRI +
+    # EEG/MEG rows and stamp the same proposed_issues cell after non-image
+    # flagging (mutates in place; reversible).
+    _apply_user_exclusions(merged, exclusions)
 
     merged.to_csv(
         output_tsv, sep="\t", index=False,
@@ -1342,6 +1454,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
+        "--rules-file", default=None,
+        help=(
+            "Path to a JSON file with user scan rules: "
+            "{\"user_hints\": [{\"patterns\": [...], \"datatype\": \"func\", "
+            "\"suffix\": \"bold\", \"task\": \"rest\", \"match_mode\": "
+            "\"substring\", \"force\": false}], \"scan_exclusions\": "
+            "[{\"pattern\": \"calibration\", \"target\": \"sequence\", "
+            "\"match_mode\": \"substring\"}]}. Same schema the GUI Settings "
+            "'Scan rules' tab persists. Hints extend the classifier; "
+            "exclusions mark matching series include=0."
+        ),
+    )
+    parser.add_argument(
         "-v", "--verbose", action="count", default=0,
         help="Increase log verbosity (-v INFO, -vv DEBUG)",
     )
@@ -1349,6 +1474,28 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = parser.parse_args(argv)
     level = logging.WARNING - 10 * min(args.verbose, 2)
     logging.basicConfig(level=level, format="%(levelname)s %(name)s: %(message)s")
+
+    user_hints: Optional[list[UserHint]] = None
+    exclusions: Optional[list[ExclusionRule]] = None
+    if args.rules_file:
+        try:
+            with open(args.rules_file, "r", encoding="utf-8") as fh:
+                rules_obj = json.load(fh)
+        except (OSError, ValueError) as exc:
+            parser.error(f"--rules-file could not be read as JSON: {exc}")
+        user_hints, exclusions = user_rules_module.from_json(rules_obj)
+        # Reject any bad regex up front so the scan doesn't run a no-op rule.
+        for h in user_hints:
+            if h.match_mode == "regex":
+                for p in h.patterns:
+                    err = user_rules_module.validate_regex(p)
+                    if err:
+                        parser.error(f"--rules-file: bad hint regex {p!r}: {err}")
+        for r in exclusions:
+            if r.match_mode == "regex":
+                err = user_rules_module.validate_regex(r.pattern)
+                if err:
+                    parser.error(f"--rules-file: bad exclusion regex {r.pattern!r}: {err}")
 
     run_scan(
         Path(args.dicom_root),
@@ -1359,6 +1506,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         dataset=args.dataset,
         line_freq=args.line_freq,
         montage=args.montage,
+        user_hints=user_hints,
+        exclusions=exclusions,
     )
     return 0
 

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -1120,6 +1120,7 @@ def run_scan(
     dataset: Optional[str] = None,
     line_freq: Optional[float] = None,
     montage: Optional[str] = None,
+    cancel_check=None,
 ) -> pd.DataFrame:
     """Run the full scan pipeline and return the DataFrame written to TSV.
 
@@ -1157,7 +1158,13 @@ def run_scan(
 
     df = scan_dicoms_long(
         dicom_root, output_tsv=None, n_jobs=n_jobs, dataset=dataset_slug,
+        cancel_check=cancel_check,
     )
+
+    # Honour a Stop requested during the (dominant) DICOM read before
+    # starting the EEG/MEG walk.
+    from ..util.cancel import raise_if_cancelled
+    raise_if_cancelled(cancel_check, "scan cancelled by user")
 
     # EEG/MEG branch: independent walk, merged at the end.
     df_eeg = scan_eeg_meg(

--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -1266,6 +1266,84 @@ def _write_files_by_uid_sidecar(output_tsv: Path, files_by_uid: dict[str, list[s
     return sidecar
 
 
+# Marker prepended to ``proposed_issues`` for a row whose scan pooled multiple
+# distinct DICOM StudyDescriptions. This routes the heads-up through the
+# existing severity system: the GUI inventory model classifies any non-error
+# ``proposed_issues`` note as a ``warn`` row, so these rows count toward the
+# "warnings" chip and appear in the Issues dialog. Awareness-only: the row is
+# NOT excluded or altered, and it still converts. The wording deliberately
+# avoids the error-token substrings the model treats as fatal
+# (``required`` / ``missing`` / ``build_basename`` / ``suspected_abort``).
+MIXED_STUDY_ISSUE_TOKEN = "multiple studies in scan"
+
+
+def _flag_mixed_study_descriptions(df: pd.DataFrame) -> None:
+    """Flag rows (and log) when one scan pooled multiple DICOM StudyDescriptions.
+
+    Several distinct StudyDescriptions in a single scanned source usually mean
+    two studies were pooled together, or the protocol changed mid-acquisition.
+    StudyDescription is not a BIDS entity and is deliberately not shown as a GUI
+    column, so the heads-up is surfaced two ways instead: a one-line summary on
+    the ``bidsmgr.cli.scan`` logger (the CLI surface, also the GUI Log dock), and
+    a non-fatal note appended to each affected row's ``proposed_issues`` so the
+    rows read as ``warn`` in the inventory table, count toward the warnings chip,
+    and list in the Issues dialog (the GUI surface the user already knows).
+    Nothing is excluded or rewritten. EEG/MEG rows have no StudyDescription and
+    are ignored.
+    """
+    if "StudyDescription" not in df.columns:
+        return
+    studies = df["StudyDescription"].astype(str).str.strip()
+    present = studies != ""
+    if not present.any():
+        return
+    distinct = sorted(studies[present].unique())
+    if len(distinct) <= 1:
+        return
+
+    # CLI / Log-dock surface: one summary line.
+    counts = studies[present].value_counts()
+    summary = ", ".join(f"'{name}' ({int(counts[name])} series)" for name in distinct)
+    log.warning(
+        "Multiple distinct DICOM StudyDescriptions found in this scan: %s. "
+        "This usually means two studies were pooled or the protocol changed. "
+        "If these are separate studies, scan each into its own dataset.",
+        summary,
+    )
+
+    # GUI severity-system surface: append a per-row warning note so each affected
+    # row shows up in the warnings chip + Issues dialog.
+    if "proposed_issues" in df.columns:
+        for df_idx in df.index[present]:
+            this_study = studies.at[df_idx]
+            others = ", ".join(f"'{s}'" for s in distinct if s != this_study)
+            note = (
+                f"{MIXED_STUDY_ISSUE_TOKEN}: this series is '{this_study}'; "
+                f"scan also contains {others}"
+            )
+            existing = str(df.at[df_idx, "proposed_issues"] or "").strip()
+            df.at[df_idx, "proposed_issues"] = (
+                f"{existing} | {note}" if existing else note
+            )
+
+    # The strongest signal is a single subject spanning more than one study.
+    if "BIDS_name" in df.columns:
+        sub = df.loc[present, ["BIDS_name", "StudyDescription"]].copy()
+        sub["BIDS_name"] = sub["BIDS_name"].astype(str).str.strip()
+        sub = sub[sub["BIDS_name"] != ""]
+        for name, grp in sub.groupby("BIDS_name"):
+            subj_studies = sorted(
+                grp["StudyDescription"].astype(str).str.strip().unique()
+            )
+            if len(subj_studies) > 1:
+                log.warning(
+                    "  subject %s spans %d StudyDescriptions: %s",
+                    name,
+                    len(subj_studies),
+                    ", ".join(f"'{s}'" for s in subj_studies),
+                )
+
+
 def run_scan(
     dicom_root: Path,
     output_tsv: Path,
@@ -1424,6 +1502,12 @@ def run_scan(
     # EEG/MEG rows and stamp the same proposed_issues cell after non-image
     # flagging (mutates in place; reversible).
     _apply_user_exclusions(merged, exclusions)
+
+    # Heads-up (warnings chip + Issues dialog + log) if the scan pooled
+    # multiple DICOM studies. Runs after non-image flagging + user exclusions
+    # so it only appends to proposed_issues and never downgrades a more severe
+    # row state.
+    _flag_mixed_study_descriptions(merged)
 
     merged.to_csv(
         output_tsv, sep="\t", index=False,

--- a/bidsmgr/converter/backends/dcm2niix_direct.py
+++ b/bidsmgr/converter/backends/dcm2niix_direct.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -155,6 +156,21 @@ class Dcm2niixDirect:
             )
 
         staged = _collect_outputs(output_dir, task.basename)
+
+        if task.skip_residuals:
+            staged, dropped = _partition_residuals(staged, task.basename)
+            for p in dropped:
+                try:
+                    p.unlink()
+                except OSError:
+                    pass  # best-effort; a leftover residual is harmless
+            if dropped:
+                log.info(
+                    "skip_residuals: dropped %d dcm2niix residual output(s) "
+                    "for %s: %s",
+                    len(dropped), task.basename,
+                    ", ".join(p.name for p in dropped),
+                )
 
         missing = _missing_expected(staged, task.expected_outputs, task.basename, output_dir)
         if missing:
@@ -292,6 +308,61 @@ def _collect_outputs(output_dir: Path, basename: str) -> list[Path]:
     catches them all; deterministic sorting makes the result stable.
     """
     return sorted(output_dir.glob(f"{basename}*"))
+
+
+# Extensions dcm2niix may write for one task. Stripped before the residual
+# match so the marker is compared against the bare stem (longest first so
+# ``.nii.gz`` wins over ``.nii``).
+_KNOWN_OUTPUT_EXTS: tuple[str, ...] = (
+    ".nii.gz", ".tsv.gz", ".nii", ".json", ".bval", ".bvec",
+)
+
+# A "residual" is an EXTRA output dcm2niix splits off a single input series:
+# a derived / secondary volume that is not a real acquired image and has no
+# valid BIDS suffix. dcm2niix names them by appending a marker to the
+# user-supplied ``-f`` basename (the PRIMARY image keeps the exact basename):
+#   * a single glued collision letter   ``..._bold`` -> ``..._bolda``
+#   * ``_Eq_<n>``   an equidistant-resliced duplicate of a variable-spacing run
+#   * ``_ROI<n>``   a Siemens on-scanner MoCo / ROI secondary series
+#   * ``_i<instance>``  a raw per-instance dump (5+ digits)
+# Legitimate multi-output is deliberately NOT matched here: fmap/multi-echo
+# (``_e1`` / ``_e2`` / ``_ph`` / ``_e2_ph``), complex parts
+# (``_real`` / ``_imaginary``), and DWI ``.bval`` / ``.bvec`` all survive
+# (their tails start with ``_e`` / ``_real`` / ``_imag`` or strip to an empty
+# tail), so the fmap and DWI fixups still see everything they expect.
+_RESIDUAL_TAIL_RE = re.compile(r"^(?:[a-z]|_Eq_\d+|_ROI\d*|_i\d{5,})$")
+
+
+def _strip_known_ext(name: str) -> str:
+    for ext in _KNOWN_OUTPUT_EXTS:
+        if name.endswith(ext):
+            return name[: -len(ext)]
+    return name
+
+
+def _is_residual_output(path: Path, basename: str) -> bool:
+    """True if ``path`` is a dcm2niix residual/secondary output for ``basename``.
+
+    The PRIMARY output (stem == ``basename``) and every legitimate sibling
+    return False; only the appended-marker duplicates documented in
+    :data:`_RESIDUAL_TAIL_RE` return True.
+    """
+    stem = _strip_known_ext(path.name)
+    if not stem.startswith(basename):
+        return False
+    tail = stem[len(basename):]
+    return bool(_RESIDUAL_TAIL_RE.match(tail))
+
+
+def _partition_residuals(
+    staged: list[Path], basename: str,
+) -> tuple[list[Path], list[Path]]:
+    """Split ``staged`` into (keep, residual) by :func:`_is_residual_output`."""
+    keep: list[Path] = []
+    residual: list[Path] = []
+    for p in staged:
+        (residual if _is_residual_output(p, basename) else keep).append(p)
+    return keep, residual
 
 
 def _missing_expected(

--- a/bidsmgr/converter/backends/mne_bids.py
+++ b/bidsmgr/converter/backends/mne_bids.py
@@ -161,6 +161,18 @@ class MneBidsBackend:
                 root=str(bids_root_for_mne),
             )
 
+            # Output format. Default "auto" keeps the source format where
+            # mne-bids supports BIDS I/O. With force_edf set (EEG / iEEG only;
+            # EDF is not a MEG/NIRS format), re-encode to EDF: this both
+            # harmonises a study to one format AND makes a non-BIDS-native but
+            # mne-readable source (GDF, EGI, ...) convertible. EDF conversion
+            # needs the data, so allow mne-bids to preload.
+            out_format = "auto"
+            allow_preload = False
+            if getattr(task, "force_edf", False) and task.datatype in {"eeg", "ieeg"}:
+                out_format = "EDF"
+                allow_preload = True
+
             try:
                 # ``overwrite=True`` lets sibling tasks for the same
                 # subject share metadata files (coordsystem.json,
@@ -174,7 +186,8 @@ class MneBidsBackend:
                     raw,
                     bids_path,
                     overwrite=True,
-                    format="auto",
+                    format=out_format,
+                    allow_preload=allow_preload,
                     verbose="ERROR",
                 )
             except Exception as exc:

--- a/bidsmgr/converter/backends/mne_bids.py
+++ b/bidsmgr/converter/backends/mne_bids.py
@@ -40,12 +40,12 @@ _SUPPORTED_DATATYPES: frozenset[str] = frozenset({"eeg", "meg", "ieeg", "nirs"})
 class MneBidsBackend:
     """Convert raw EEG/MEG/iEEG/NIRS recordings via mne-bids.
 
-    Per-row knobs come from the :class:`ConvertTask` (set by the CLI
-    from the inventory TSV's ``line_freq`` / ``montage`` columns). The
-    constructor takes only fallback defaults used when those columns
-    are blank — typical case is the user supplies a single dataset-
-    wide default at scan time and the per-row column carries it
-    forward.
+    The per-row ``line_freq`` and ``montage`` come from the
+    :class:`ConvertTask`, already resolved by the CLI (the inventory cell,
+    else the recording-metadata dataset default). The backend applies them
+    during the write; richer sidecar metadata (reference, ground, filters,
+    device, institution, ...) is folded in afterwards by
+    :func:`bidsmgr.fixups.eeg_sidecar.enrich_recording_sidecars`.
 
     What the backend writes (via mne-bids):
 
@@ -58,20 +58,10 @@ class MneBidsBackend:
       ``line_freq``).
     * ``*_events.tsv`` from ``raw.annotations`` (auto for EDF+).
     * ``*_electrodes.tsv`` + ``*_coordsystem.json`` when a montage is
-      applied (per-row ``montage`` column, fallback to constructor).
+      applied (per-row ``montage``; never for MEG).
     """
 
     name = "mne_bids"
-
-    def __init__(
-        self,
-        *,
-        line_freq: Optional[float] = 50.0,
-        montage: Optional[str] = None,
-    ) -> None:
-        # Fallback defaults used when the per-task value is None/blank.
-        self.default_line_freq = line_freq
-        self.default_montage = montage
 
     def can_handle(self, task: ConvertTask) -> bool:
         if task.datatype not in _SUPPORTED_DATATYPES:
@@ -135,11 +125,10 @@ class MneBidsBackend:
                     duration_s=time.monotonic() - t0,
                 )
 
-            # Per-row line_freq (TSV) wins; constructor default is the
-            # dataset-wide fallback.
+            # ``line_freq`` is the resolved per-row value (inventory cell,
+            # else the recording-metadata dataset default). Written into
+            # raw.info so mne-bids emits PowerLineFrequency in the sidecar.
             line_freq = task.line_freq
-            if line_freq is None:
-                line_freq = self.default_line_freq
             if line_freq is not None and not raw.info.get("line_freq"):
                 with raw.info._unlock() if hasattr(raw.info, "_unlock") else _noop():
                     raw.info["line_freq"] = float(line_freq)
@@ -152,7 +141,7 @@ class MneBidsBackend:
             # + ``EEG 001`` channel sets after non-alphanumeric stripping).
             # Skip silently for MEG so the user's dataset-wide setting
             # doesn't crash MEG rows.
-            montage_name = task.montage or self.default_montage
+            montage_name = task.montage
             if montage_name and task.datatype != "meg":
                 _apply_standard_montage(raw, montage_name, source)
 
@@ -298,6 +287,27 @@ def _apply_standard_montage(raw, montage_name: str, source: Path) -> None:
                 "channel rename failed for %s: %s — proceeding without rename",
                 source.name, exc,
             )
+
+    # Safety: ``set_montage(on_missing="ignore")`` silently assigns positions
+    # only to channels whose names match the montage and leaves the rest
+    # unset — so a valid-but-wrong montage produces a partly-wrong
+    # electrodes.tsv with no error. Surface the match rate so the user can
+    # catch a mismatched montage choice. ``ch_names`` here are already
+    # normalised by the rename above; match case-insensitively.
+    montage_names = {n.lower() for n in getattr(montage, "ch_names", [])}
+    raw_names = {n.lower() for n in raw.ch_names}
+    n_matched = len(montage_names & raw_names)
+    if n_matched == 0:
+        log.warning(
+            "montage %r matched none of %s's %d channels; positions not "
+            "applied (montage likely wrong for this recording)",
+            montage_name, source.name, len(raw.ch_names),
+        )
+    else:
+        log.info(
+            "montage %r matched %d/%d channel(s) in %s",
+            montage_name, n_matched, len(raw.ch_names), source.name,
+        )
 
     try:
         raw.set_montage(

--- a/bidsmgr/converter/backends/physio_dcm.py
+++ b/bidsmgr/converter/backends/physio_dcm.py
@@ -131,7 +131,23 @@ class PhysioDcmBackend:
                     duration_s=time.monotonic() - t0,
                 )
 
-        staged = sorted(output_dir.glob(f"{task.basename}*"))
+        # bidsphysio inserts a ``_recording-<label>`` infix *before* the
+        # ``_physio`` suffix when a recording carries multiple sampling
+        # rates, so the emitted names are
+        # ``<stem>_recording-<label>_physio.{tsv.gz,json}`` rather than the
+        # exact ``<basename>`` (= ``<stem>_physio``). Glob on the stem so we
+        # detect both the single-rate (``<stem>_physio.*``) and multi-rate
+        # forms; ``*_physio.`` keeps us from picking up a sibling imaging
+        # file (e.g. the accompanying ``_bold.nii.gz``) in the same dir.
+        stem = (
+            task.basename[: -len("_physio")]
+            if task.basename.endswith("_physio")
+            else task.basename
+        )
+        staged = sorted(
+            set(output_dir.glob(f"{stem}*_physio.tsv.gz"))
+            | set(output_dir.glob(f"{stem}*_physio.json"))
+        )
         if not staged:
             return ConvertResult(
                 task=task, success=False,

--- a/bidsmgr/converter/registry.py
+++ b/bidsmgr/converter/registry.py
@@ -43,8 +43,6 @@ class ConverterBackend(Protocol):
 def default_backends(
     *,
     dcm2niix_bin: Optional[Path] = None,
-    line_freq: Optional[float] = 50.0,
-    montage: Optional[str] = None,
 ) -> list[ConverterBackend]:
     """Return the priority-ordered list of registered backends.
 
@@ -58,10 +56,10 @@ def default_backends(
     ``can_handle`` declines the others' datatypes so the dispatch is
     unambiguous.
 
-    EEG/MEG-specific overrides (``line_freq``, ``montage``) flow into
-    the :class:`MneBidsBackend` constructor so the user can supply them
-    at the CLI level (``bidsmgr-convert --line-freq 60 --montage
-    biosemi64``).
+    EEG/MEG ``line_freq`` / ``montage`` are not backend-level knobs: they
+    are resolved per row by the convert verb (the inventory cell, else the
+    recording-metadata dataset default) and carried on each
+    :class:`ConvertTask`.
     """
     from .backends.dcm2niix_direct import Dcm2niixDirect
     from .backends.mne_bids import MneBidsBackend
@@ -69,7 +67,7 @@ def default_backends(
 
     return [
         PhysioDcmBackend(),
-        MneBidsBackend(line_freq=line_freq, montage=montage),
+        MneBidsBackend(),
         Dcm2niixDirect(dcm2niix_bin=dcm2niix_bin),
     ]
 

--- a/bidsmgr/converter/types.py
+++ b/bidsmgr/converter/types.py
@@ -68,6 +68,13 @@ class ConvertTask(BaseModel):
     eeg_reference: Optional[str] = None
     eeg_ground: Optional[str] = None
 
+    # When True, EEG / iEEG recordings are re-encoded to EDF on write
+    # (``mne_bids.write_raw_bids(format="EDF")``) instead of kept in their
+    # source format. Lets a study harmonise to a single BIDS-native format,
+    # and is the way a non-BIDS-native but mne-readable source (GDF, EGI, ...)
+    # becomes convertible. MEG / NIRS ignore it (EDF is an EEG / iEEG format).
+    force_edf: bool = False
+
     # Already-curated companion files to COPY into the BIDS tree on convert
     # (not converted): ``((suffix, source_path), ...)`` where suffix is a
     # BIDS companion suffix (events / beh / stim / physio / channels / ...).

--- a/bidsmgr/converter/types.py
+++ b/bidsmgr/converter/types.py
@@ -48,6 +48,16 @@ class ConvertTask(BaseModel):
     expected_outputs: tuple[str, ...] = (".nii.gz", ".json")
     repetition_type: str = ""
 
+    # When True (default), the MRI backend drops dcm2niix "residual"
+    # secondary outputs -- the derived single-volume duplicates dcm2niix
+    # splits off a single input series and names by gluing a collision
+    # letter onto the basename (e.g. ``..._bold`` -> ``..._bolda``) or with
+    # an ``_Eq_<n>`` / ``_ROI`` / ``_i<instance>`` marker. They are not real
+    # acquired images and have no valid BIDS suffix. Legitimate multi-output
+    # (fmap ``_e1``/``_e2``/``_ph``, complex ``_real``/``_imaginary``,
+    # DWI ``.bval``/``.bvec``) is never affected. Set False to keep them.
+    skip_residuals: bool = True
+
     # EEG/MEG-specific: per-row knobs that the inventory TSV carries.
     # Backends consult these when present; the CLI passes its own
     # default so blank cells fall back to the dataset-wide value.

--- a/bidsmgr/converter/types.py
+++ b/bidsmgr/converter/types.py
@@ -58,11 +58,22 @@ class ConvertTask(BaseModel):
     # DWI ``.bval``/``.bvec``) is never affected. Set False to keep them.
     skip_residuals: bool = True
 
-    # EEG/MEG-specific: per-row knobs that the inventory TSV carries.
-    # Backends consult these when present; the CLI passes its own
-    # default so blank cells fall back to the dataset-wide value.
+    # EEG/MEG-specific: per-row knobs the inventory TSV carries. The CLI
+    # resolves these (cell, else recording-metadata default) before building
+    # the task. ``line_freq`` / ``montage`` are applied during the write;
+    # ``eeg_reference`` / ``eeg_ground`` are consumed by the post-write
+    # sidecar-enrichment fixup, where they override the spec value.
     line_freq: Optional[float] = None
     montage: Optional[str] = None
+    eeg_reference: Optional[str] = None
+    eeg_ground: Optional[str] = None
+
+    # Already-curated companion files to COPY into the BIDS tree on convert
+    # (not converted): ``((suffix, source_path), ...)`` where suffix is a
+    # BIDS companion suffix (events / beh / stim / physio / channels / ...).
+    # The file is named ``<entity_prefix>_<suffix><ext>`` next to the
+    # recording; an attached ``events`` replaces the auto-generated events.tsv.
+    companion_files: tuple[tuple[str, str], ...] = ()
 
     @model_validator(mode="before")
     @classmethod

--- a/bidsmgr/editor/validator.py
+++ b/bidsmgr/editor/validator.py
@@ -25,10 +25,11 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
 
 import bidsmgr
 from .. import schema as schema_mod
+from ..schema.types import Severity as SchemaSeverity
 from .types import (
     FieldLevel,
     FileVerdict,
@@ -405,16 +406,25 @@ def _check_filename_entities(
         return
 
     for v in verdicts or []:
-        # ValidationVerdict has fields: severity, kind, message, ...
-        ok = bool(getattr(v, "ok", True))
-        if ok:
+        # ValidationVerdict exposes ``is_ok`` (property) + ``severity``
+        # (schema Severity enum) + ``rule_id`` - NOT ``ok``/``kind``. The
+        # old code read the wrong attributes, so ``getattr(v, "ok", True)``
+        # always defaulted to True and basename validation never flagged
+        # anything (a silent no-op). Use the real fields + map the severity.
+        if v.is_ok:
             continue
+        sev = (
+            Severity.ERR if v.severity == SchemaSeverity.ERROR else Severity.WARN
+        )
         verdict.issues.append(Issue(
-            severity=Severity.ERR,
-            rule_id=f"bids.basename.{getattr(v, 'kind', 'invalid')}",
+            severity=sev,
+            rule_id=f"bids.basename.{getattr(v, 'rule_id', 'invalid')}",
             message=str(getattr(v, "message", v)),
         ))
-        verdict.severity = Severity.ERR
+        if sev is Severity.ERR:
+            verdict.severity = Severity.ERR
+        elif verdict.severity is Severity.OK:
+            verdict.severity = Severity.WARN
 
 
 def _audit_sidecar(

--- a/bidsmgr/fixups/__init__.py
+++ b/bidsmgr/fixups/__init__.py
@@ -19,8 +19,16 @@ Planned later: ``derivatives`` (DWI map relocation: FA/ADC/TRACE/ColFA →
 ``derivatives/<pipeline>/sub-/ses-/dwi/``).
 """
 
+from .companion import attach_companion_files
+from .eeg_sidecar import enrich_recording_sidecars
 from .fieldmaps import apply_fieldmap_renames
 from .intended_for import populate_intended_for
 from .scans_tsv import update_scans_tsv
 
-__all__ = ["apply_fieldmap_renames", "populate_intended_for", "update_scans_tsv"]
+__all__ = [
+    "apply_fieldmap_renames",
+    "populate_intended_for",
+    "update_scans_tsv",
+    "enrich_recording_sidecars",
+    "attach_companion_files",
+]

--- a/bidsmgr/fixups/companion.py
+++ b/bidsmgr/fixups/companion.py
@@ -1,0 +1,83 @@
+"""Copy already-curated companion files into the BIDS tree (no conversion).
+
+For task logs / behavioural / stimulus data that the user has already curated
+into a BIDS-shaped file, the per-row "companion files" links are copied into the
+staged datatype directory under the recording's BIDS name. This is a "place and
+name" step, not a converter: the file's content is the user's responsibility and
+is checked by ``bidsmgr-validate`` afterwards. The set of attachable suffixes is
+deliberately constrained (so this never becomes a generic file copier).
+
+An attached ``events`` companion overwrites the events.tsv mne-bids generated
+from the recording's triggers (the curated file wins, per the agreed precedence).
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# BIDS companion suffixes a row may link. Constrained on purpose.
+ALLOWED_COMPANION_SUFFIXES: frozenset[str] = frozenset(
+    {"events", "beh", "stim", "physio", "channels", "electrodes"}
+)
+
+
+def _src_extension(path: Path) -> str:
+    """Return the source file's extension, preserving ``.tsv.gz`` etc."""
+    name = path.name.lower()
+    if name.endswith(".tsv.gz"):
+        return ".tsv.gz"
+    if name.endswith(".nii.gz"):
+        return ".nii.gz"
+    return path.suffix
+
+
+def attach_companion_files(subject_staging_dir: Path, tasks) -> int:
+    """Copy each task's linked companion files into the staged tree.
+
+    Returns the number of files copied. Best-effort: a missing source, an
+    unsupported suffix, or a copy error is logged and skipped, never raised.
+    """
+    if not subject_staging_dir.is_dir():
+        return 0
+
+    n_copied = 0
+    for task in tasks:
+        companions = getattr(task, "companion_files", ()) or ()
+        if not companions:
+            continue
+        basename = getattr(task, "basename", "") or ""
+        if not basename:
+            continue
+        # Anchor on the staged datatype sidecar so we land beside the recording.
+        sidecar = next(iter(subject_staging_dir.rglob(f"{basename}.json")), None)
+        if sidecar is None:
+            continue
+        prefix = basename.rsplit("_", 1)[0] if "_" in basename else basename
+
+        for suffix, src in companions:
+            if suffix not in ALLOWED_COMPANION_SUFFIXES:
+                log.warning(
+                    "companion: unsupported suffix %r for %s; skipped", suffix, basename,
+                )
+                continue
+            src_path = Path(src)
+            if not src_path.is_file():
+                log.warning("companion: source not found %s (%s); skipped", src_path, suffix)
+                continue
+            ext = _src_extension(src_path)
+            dest = sidecar.with_name(f"{prefix}_{suffix}{ext}")
+            try:
+                shutil.copyfile(src_path, dest)
+                n_copied += 1
+                log.info("companion: copied %s -> %s", src_path.name, dest.name)
+            except OSError as exc:
+                log.warning("companion: copy failed %s: %s", src_path, exc)
+
+    return n_copied
+
+
+__all__ = ["attach_companion_files", "ALLOWED_COMPANION_SUFFIXES"]

--- a/bidsmgr/fixups/eeg_sidecar.py
+++ b/bidsmgr/fixups/eeg_sidecar.py
@@ -142,7 +142,12 @@ def _apply_sidecar_fields(sidecar: Path, eff: EffectiveSpec, datatype: str) -> i
     acq = eff.acquisition
     updates: dict = {}
 
-    # Common keys (every EEG/MEG/iEEG/NIRS sidecar).
+    # Common keys (every EEG/MEG/iEEG/NIRS sidecar). Each is written only when
+    # the user supplied it (truthy), so a blank value never clobbers what the
+    # backend already wrote. mne-bids DOES auto-fill Manufacturer for MEG, so the
+    # truthy guard is what preserves it when the user leaves manufacturer blank;
+    # ManufacturersModelName / SoftwareVersions / InstitutionName are mne-bids
+    # omissions, so writing them here only adds information.
     if acq.manufacturer:
         updates["Manufacturer"] = acq.manufacturer
     if acq.amplifier_model:
@@ -176,6 +181,17 @@ def _apply_sidecar_fields(sidecar: Path, eff: EffectiveSpec, datatype: str) -> i
             updates["iEEGReference"] = acq.eeg_reference
         if acq.eeg_ground:
             updates["iEEGGround"] = acq.eeg_ground
+    elif datatype == "meg":
+        # MEG-specific fields mne-bids cannot derive from the recording. The
+        # channel-derived ones (ContinuousHeadLocalization / DigitizedLandmarks
+        # / DigitizedHeadPoints / HeadCoilFrequency) are intentionally NOT
+        # written here - mne-bids already computes them correctly.
+        if acq.dewar_position:
+            updates["DewarPosition"] = acq.dewar_position
+        if acq.associated_empty_room:
+            updates["AssociatedEmptyRoom"] = acq.associated_empty_room
+        if acq.subject_artefact_description:
+            updates["SubjectArtefactDescription"] = acq.subject_artefact_description
 
     # Extras (non-required keys) for non-MEG datatypes.
     if acq.extras is not None and datatype != "meg":

--- a/bidsmgr/fixups/eeg_sidecar.py
+++ b/bidsmgr/fixups/eeg_sidecar.py
@@ -1,0 +1,351 @@
+"""Post-write enrichment of EEG / MEG / iEEG / NIRS BIDS outputs.
+
+Runs in the per-subject Phase 2 of the converter, on the staged tree, after
+mne-bids has written the recording plus its ``channels.tsv``, datatype JSON
+sidecar, and ``events.tsv``. mne-bids fills only what it can read from the
+recording (channel counts, sampling rate, power-line frequency, electrode
+positions); this step folds in the information the recording cannot carry on its
+own, taken from a resolved :class:`~bidsmgr.recording_meta.RecordingMetaSpec`:
+
+* sidecar JSON: reference, ground, hardware/software filters, manufacturer and
+  model, software versions, cap details, institution, and optional extras.
+* ``channels.tsv``: upgrade generically-typed auxiliary channels (ECG, EOG, ...)
+  to their real BIDS type and fill units + description.
+* ``events.tsv`` + ``events.json``: rename trigger codes to human-readable labels
+  via the task's event map.
+* the task sidecar: TaskDescription / Instructions from the task protocol.
+
+The step is additive and best-effort: a missing file or a per-file error is
+logged and skipped, never raised, so a single bad row cannot abort the subject.
+``PowerLineFrequency`` and electrode positions are intentionally NOT touched here
+- the backend already writes them from the resolved per-row value during the
+write (they shape the data file and the coordinate files).
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ..recording_meta import RecordingMetaSpec, resolve_effective
+from ..recording_meta.resolve import EffectiveSpec
+
+log = logging.getLogger(__name__)
+
+_SUPPORTED_DATATYPES = frozenset({"eeg", "meg", "ieeg", "nirs"})
+# Channel ``type`` values we consider safe to overwrite with a user-specified
+# BIDS type (we never clobber an already-specific type the reader assigned).
+_GENERIC_CH_TYPES = frozenset({"MISC", "OTHER", "N/A", ""})
+
+
+def enrich_recording_sidecars(
+    subject_staging_dir: Path,
+    tasks: Iterable,
+    spec: Optional[RecordingMetaSpec],
+) -> int:
+    """Enrich every staged EEG/MEG/iEEG/NIRS recording for one subject.
+
+    Parameters
+    ----------
+    subject_staging_dir
+        Per-subject staging tree (``<bids_root>/.tmp_bidsmgr/sub-<id>/``); the
+        recording's datatype directory lives at ``<staging>/[ses-Y/]<datatype>/``.
+    tasks
+        The :class:`ConvertTask` objects for this subject. Non-EEG/MEG tasks are
+        ignored.
+    spec
+        The resolved recording-metadata spec. ``None`` makes this a no-op.
+
+    Returns
+    -------
+    int
+        Count of files (sidecar JSON / channels.tsv / events.tsv) modified.
+    """
+    if spec is None:
+        return 0
+
+    n_modified = 0
+    for task in tasks:
+        datatype = getattr(task, "datatype", "")
+        if datatype not in _SUPPORTED_DATATYPES:
+            continue
+        basename = getattr(task, "basename", "") or ""
+        if not basename:
+            continue
+
+        sidecar = _find_sidecar(subject_staging_dir, basename)
+        if sidecar is None:
+            # mne-bids should always emit the datatype JSON; if it is absent the
+            # conversion of this row likely failed and was already reported.
+            continue
+
+        eff = resolve_effective(
+            spec,
+            getattr(task, "row_id", "") or "",
+            (getattr(task, "entities", {}) or {}).get("task"),
+        )
+
+        # Per-row inventory cells (eeg_reference / eeg_ground) take final
+        # precedence over the resolved spec value.
+        row_ref = getattr(task, "eeg_reference", None)
+        row_gnd = getattr(task, "eeg_ground", None)
+        if row_ref:
+            eff.acquisition.eeg_reference = row_ref
+        if row_gnd:
+            eff.acquisition.eeg_ground = row_gnd
+
+        n_modified += _apply_sidecar_fields(sidecar, eff, datatype)
+        n_modified += _retype_channels(sidecar, basename, eff)
+        n_modified += _map_events(sidecar, basename, eff)
+        n_modified += _apply_task_protocol(sidecar, eff)
+
+    return n_modified
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_sidecar(staging: Path, basename: str) -> Optional[Path]:
+    """Locate the staged ``<basename>.json`` datatype sidecar, if present."""
+    if not staging.is_dir():
+        return None
+    matches = list(staging.rglob(f"{basename}.json"))
+    return matches[0] if matches else None
+
+
+def _entity_prefix(basename: str) -> str:
+    """``sub-01_task-rest_eeg`` -> ``sub-01_task-rest`` (strip the suffix token)."""
+    return basename.rsplit("_", 1)[0] if "_" in basename else basename
+
+
+def _read_json(path: Path) -> dict:
+    # utf-8-sig tolerates a leading BOM (mne-bids writes its TSVs with one;
+    # JSON usually has none, but reading sig-aware is harmless and safe).
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        log.warning("enrich: could not read %s: %s", path.name, exc)
+        return {}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=4) + "\n", encoding="utf-8")
+
+
+def _apply_sidecar_fields(sidecar: Path, eff: EffectiveSpec, datatype: str) -> int:
+    """Write reference/ground/filters/device/institution/extras into the JSON."""
+    acq = eff.acquisition
+    updates: dict = {}
+
+    # Common keys (every EEG/MEG/iEEG/NIRS sidecar).
+    if acq.manufacturer:
+        updates["Manufacturer"] = acq.manufacturer
+    if acq.amplifier_model:
+        updates["ManufacturersModelName"] = acq.amplifier_model
+    if acq.software_versions or acq.software:
+        updates["SoftwareVersions"] = acq.software_versions or acq.software
+    if acq.institution_name:
+        updates["InstitutionName"] = acq.institution_name
+    if acq.institution_dept:
+        updates["InstitutionalDepartmentName"] = acq.institution_dept
+
+    hw = {f.name: f.info for f in acq.filters if f.kind == "Hardware"}
+    sw = {f.name: f.info for f in acq.filters if f.kind == "Software"}
+    if hw:
+        updates["HardwareFilters"] = hw
+    if sw:
+        updates["SoftwareFilters"] = sw
+
+    # Datatype-scoped reference / ground / cap.
+    if datatype == "eeg":
+        if acq.eeg_reference:
+            updates["EEGReference"] = acq.eeg_reference
+        if acq.eeg_ground:
+            updates["EEGGround"] = acq.eeg_ground
+        if acq.cap_manufacturer:
+            updates["CapManufacturer"] = acq.cap_manufacturer
+        if acq.cap_model:
+            updates["CapManufacturersModelName"] = acq.cap_model
+    elif datatype == "ieeg":
+        if acq.eeg_reference:
+            updates["iEEGReference"] = acq.eeg_reference
+        if acq.eeg_ground:
+            updates["iEEGGround"] = acq.eeg_ground
+
+    # Extras (non-required keys) for non-MEG datatypes.
+    if acq.extras is not None and datatype != "meg":
+        updates.update(_extras_to_keys(acq.extras))
+
+    if not updates:
+        return 0
+
+    data = _read_json(sidecar)
+    data.update(updates)
+    _write_json(sidecar, data)
+    log.info("enrich: %s sidecar +%d field(s)", sidecar.name, len(updates))
+    return 1
+
+
+def _extras_to_keys(extras) -> dict:
+    out: dict = {}
+    if extras.acceptable_impedance is not None:
+        imp = extras.acceptable_impedance
+        val = {k: v for k, v in {"value": imp.value, "units": imp.units}.items() if v is not None}
+        if val:
+            out["AcceptableImpedance"] = val
+    if extras.electrode_type is not None:
+        out["ElectrodeType"] = extras.electrode_type
+    if extras.conductive_medium is not None:
+        out["ConductiveMedium"] = extras.conductive_medium
+    if extras.faraday_cage is not None:
+        out["FaradayCage"] = extras.faraday_cage
+    if extras.sound_proof is not None:
+        out["SoundProofing"] = extras.sound_proof
+    if extras.lighting_conditions is not None:
+        lc = extras.lighting_conditions
+        val = {
+            k: v for k, v in {
+                "description": lc.description, "measurement": lc.measurement,
+            }.items() if v is not None
+        }
+        if val:
+            out["LightingConditions"] = val
+    return out
+
+
+def _retype_channels(sidecar: Path, basename: str, eff: EffectiveSpec) -> int:
+    """Upgrade generic aux-channel rows in channels.tsv and fill units/description."""
+    aux = eff.acquisition.aux_channels
+    if not aux:
+        return 0
+    tsv = sidecar.with_name(f"{_entity_prefix(basename)}_channels.tsv")
+    if not tsv.is_file():
+        return 0
+
+    try:
+        with open(tsv, newline="", encoding="utf-8-sig") as fh:
+            reader = csv.DictReader(fh, delimiter="\t")
+            fieldnames = list(reader.fieldnames or [])
+            rows = list(reader)
+    except OSError as exc:  # pragma: no cover - defensive
+        log.warning("enrich: could not read %s: %s", tsv.name, exc)
+        return 0
+    if "name" not in fieldnames:
+        return 0
+
+    present = {row.get("name", "") for row in rows}
+    for missing in sorted(set(aux) - present):
+        log.warning("enrich: aux channel %r in spec not found in %s", missing, tsv.name)
+
+    changed = False
+    for row in rows:
+        name = row.get("name", "")
+        spec_ch = aux.get(name)
+        if spec_ch is None:
+            continue
+        if spec_ch.bids_type and "type" in fieldnames:
+            current = str(row.get("type", "")).upper()
+            if current in _GENERIC_CH_TYPES:
+                row["type"] = spec_ch.bids_type
+                changed = True
+        if spec_ch.units and "units" in fieldnames:
+            current_u = str(row.get("units", "")).strip()
+            if current_u in ("", "n/a"):
+                row["units"] = spec_ch.units
+                changed = True
+        if spec_ch.description and "description" in fieldnames:
+            current_d = str(row.get("description", "")).strip()
+            if current_d in ("", "n/a"):
+                row["description"] = spec_ch.description
+                changed = True
+
+    if not changed:
+        return 0
+    with open(tsv, "w", newline="", encoding="utf-8-sig") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+    log.info("enrich: %s channel types/units updated", tsv.name)
+    return 1
+
+
+def _map_events(sidecar: Path, basename: str, eff: EffectiveSpec) -> int:
+    """Rename trigger codes to labels in events.tsv and write an events.json."""
+    event_map = eff.event_map
+    if not event_map:
+        return 0
+    tsv = sidecar.with_name(f"{_entity_prefix(basename)}_events.tsv")
+    if not tsv.is_file():
+        return 0
+
+    try:
+        with open(tsv, newline="", encoding="utf-8-sig") as fh:
+            reader = csv.DictReader(fh, delimiter="\t")
+            fieldnames = list(reader.fieldnames or [])
+            rows = list(reader)
+    except OSError as exc:  # pragma: no cover - defensive
+        log.warning("enrich: could not read %s: %s", tsv.name, exc)
+        return 0
+
+    # Map on the column that carries the trigger label/code. mne-bids puts the
+    # annotation description in ``trial_type`` and the numeric code in ``value``.
+    label_col = "trial_type" if "trial_type" in fieldnames else None
+    if label_col is None:
+        return 0
+
+    used: dict[str, str] = {}
+    changed = False
+    for row in rows:
+        code = str(row.get(label_col, ""))
+        # Skip blank labels: a scaffold seeds detected codes with empty
+        # labels for the user to fill; an unedited entry must not rename
+        # the trial_type to "".
+        if code in event_map and event_map[code]:
+            row[label_col] = event_map[code]
+            used[event_map[code]] = code
+            changed = True
+    if not changed:
+        return 0
+
+    with open(tsv, "w", newline="", encoding="utf-8-sig") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    # Companion events.json documenting the trial_type levels we produced.
+    events_json = sidecar.with_name(f"{_entity_prefix(basename)}_events.json")
+    data = _read_json(events_json) if events_json.is_file() else {}
+    levels = {label: f"trigger code {code}" for label, code in used.items()}
+    tt = data.get("trial_type", {})
+    tt.setdefault("Description", "Event category")
+    tt["Levels"] = {**tt.get("Levels", {}), **levels}
+    data["trial_type"] = tt
+    _write_json(events_json, data)
+    log.info("enrich: %s mapped %d event label(s)", tsv.name, len(used))
+    return 1
+
+
+def _apply_task_protocol(sidecar: Path, eff: EffectiveSpec) -> int:
+    """Write TaskDescription / Instructions into the datatype sidecar."""
+    proto = eff.task_protocol
+    if proto is None:
+        return 0
+    updates: dict = {}
+    if proto.task_description:
+        updates["TaskDescription"] = proto.task_description
+    if proto.instructions:
+        updates["Instructions"] = proto.instructions
+    if not updates:
+        return 0
+    data = _read_json(sidecar)
+    data.update(updates)
+    _write_json(sidecar, data)
+    return 1
+
+
+__all__ = ["enrich_recording_sidecars"]

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -13,7 +13,8 @@ adding a new one outside that namespace is a code smell.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -45,6 +46,10 @@ KEYS = {
     "convert_n_jobs":     "convert/n_jobs",
     "convert_overwrite":  "convert/overwrite",
     "convert_skip_residuals": "convert/skip_residuals",
+    # Scan rules (user-extensible classifier hints + series exclusions).
+    # Stored as JSON-encoded lists - see ``bidsmgr.classifier.user_rules``.
+    "user_hints":         "classifier/user_hints",
+    "scan_exclusions":    "classifier/scan_exclusions",
     # Post-convert chain
     "post_run_metadata":  "post_convert/run_metadata",
     "post_run_validate":  "post_convert/run_validate",
@@ -137,6 +142,16 @@ class AppSettings:
     # "app_icon" → full-color BIDS-Manager app icon (``assets/macos/AppIcon128.png``).
     header_logo: str = "default"
 
+    # Scan rules (JSON-serialisable list[dict]); converted to/from the
+    # engine's frozen dataclasses at the boundary via ``to_user_hints`` /
+    # ``to_exclusions`` (keeps the classifier import out of this module's
+    # hot path and the engine free of any GUI dependency).
+    # hint:      {"patterns": [...], "datatype", "suffix", "task",
+    #             "entities": {k: v}, "match_mode", "force"}
+    # exclusion: {"pattern", "target": "sequence"|"path", "match_mode"}
+    user_hints: list = field(default_factory=list)
+    scan_exclusions: list = field(default_factory=list)
+
     # ------------------------------------------------------------------
     @staticmethod
     def _settings() -> QSettings:
@@ -173,6 +188,16 @@ class AppSettings:
 
         def _as_str(v, default: str) -> str:
             return str(v) if v not in (None, "") else default
+
+        def _as_json_list(v, default: list) -> list:
+            """Parse a JSON list stored in QSettings; corrupt/non-list -> default."""
+            if not v:
+                return list(default)
+            try:
+                out = json.loads(v) if isinstance(v, str) else v
+            except (ValueError, TypeError):
+                return list(default)
+            return out if isinstance(out, list) else list(default)
 
         out.theme = _as_str(s.value(KEYS["theme"]), out.theme)
         if out.theme not in ("dark", "light"):
@@ -251,6 +276,8 @@ class AppSettings:
         )
         if out.header_logo not in ("default", "app_icon"):
             out.header_logo = "default"
+        out.user_hints = _as_json_list(s.value(KEYS["user_hints"]), [])
+        out.scan_exclusions = _as_json_list(s.value(KEYS["scan_exclusions"]), [])
         return out
 
     def save(self) -> None:
@@ -286,6 +313,9 @@ class AppSettings:
         s.setValue(KEYS["skipped_update_version"], self.skipped_update_version)
         s.setValue(KEYS["font_scale"], float(self.font_scale))
         s.setValue(KEYS["header_logo"], self.header_logo)
+        # Scan rules as JSON blobs.
+        s.setValue(KEYS["user_hints"], json.dumps(self.user_hints))
+        s.setValue(KEYS["scan_exclusions"], json.dumps(self.scan_exclusions))
         s.sync()
 
     # ------------------------------------------------------------------
@@ -336,6 +366,24 @@ class AppSettings:
         cls._settings().setValue(
             KEYS["editor_strict_validate"], "1" if enabled else "0",
         )
+
+    # ------------------------------------------------------------------
+    # Scan-rules boundary: list[dict] (JSON) <-> engine frozen dataclasses.
+    # The conversion lives here so the engine never imports settings and the
+    # GUI / CLI share one (de)serialiser (``classifier.user_rules``).
+    # ------------------------------------------------------------------
+
+    def to_user_hints(self) -> list:
+        """Return the persisted hints as ``list[UserHint]`` for the scanner."""
+        from ..classifier import user_rules
+        hints, _ = user_rules.from_json({"user_hints": self.user_hints})
+        return hints
+
+    def to_exclusions(self) -> list:
+        """Return the persisted exclusions as ``list[ExclusionRule]``."""
+        from ..classifier import user_rules
+        _, excl = user_rules.from_json({"scan_exclusions": self.scan_exclusions})
+        return excl
 
     @classmethod
     def remember_nifti_crosshair(cls, color: str, thickness: int) -> None:

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -45,6 +45,7 @@ KEYS = {
     "convert_overwrite":  "convert/overwrite",      # legacy; migrated to on_existing
     "convert_on_existing": "convert/on_existing",    # skip|update|replace|error
     "convert_skip_residuals": "convert/skip_residuals",
+    "convert_force_edf":  "convert/force_edf",       # re-encode EEG/iEEG to EDF
     # Scan rules (user-extensible classifier hints + series exclusions).
     # Stored as JSON-encoded lists - see ``bidsmgr.classifier.user_rules``.
     "user_hints":         "classifier/user_hints",
@@ -123,6 +124,8 @@ class AppSettings:
     # Drop dcm2niix residual/secondary outputs (e.g. ``..._bolda`` next to
     # ``..._bold``). Default on: they are derived duplicates, not real images.
     convert_skip_residuals: bool = True
+    # Re-encode EEG / iEEG recordings to EDF on convert (mne-bids format="EDF").
+    convert_force_edf: bool = False
 
     # Post-convert chain
     post_run_metadata: bool = True
@@ -263,6 +266,9 @@ class AppSettings:
         out.convert_skip_residuals = _as_bool(
             s.value(KEYS["convert_skip_residuals"]), out.convert_skip_residuals,
         )
+        out.convert_force_edf = _as_bool(
+            s.value(KEYS["convert_force_edf"]), out.convert_force_edf,
+        )
 
         out.post_run_metadata = _as_bool(s.value(KEYS["post_run_metadata"]),
                                          out.post_run_metadata)
@@ -314,6 +320,7 @@ class AppSettings:
             ("scan_skip_bids_guess",     self.scan_skip_bids_guess),
             ("convert_overwrite",        self.convert_overwrite),
             ("convert_skip_residuals",   self.convert_skip_residuals),
+            ("convert_force_edf",        self.convert_force_edf),
             ("post_run_metadata",        self.post_run_metadata),
             ("post_run_validate",        self.post_run_validate),
             ("post_metadata_fill_todos", self.post_metadata_fill_todos),

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -39,8 +39,6 @@ KEYS = {
     # Scan defaults
     "scan_n_jobs":        "scan/n_jobs",
     "scan_probe_convert": "scan/probe_convert",
-    "scan_line_freq":     "scan/line_freq",
-    "scan_montage":       "scan/montage",
     "scan_skip_bids_guess": "scan/skip_bids_guess",
     # Convert defaults
     "convert_n_jobs":     "convert/n_jobs",
@@ -109,8 +107,6 @@ class AppSettings:
     # Scan defaults
     scan_n_jobs: int = 1
     scan_probe_convert: bool = False
-    scan_line_freq: float = 50.0
-    scan_montage: str = ""
     scan_skip_bids_guess: bool = False
 
     # Convert defaults
@@ -239,8 +235,6 @@ class AppSettings:
         out.scan_n_jobs = _as_int(s.value(KEYS["scan_n_jobs"]), out.scan_n_jobs)
         out.scan_probe_convert = _as_bool(s.value(KEYS["scan_probe_convert"]),
                                           out.scan_probe_convert)
-        out.scan_line_freq = _as_float(s.value(KEYS["scan_line_freq"]), out.scan_line_freq)
-        out.scan_montage = _as_str(s.value(KEYS["scan_montage"]), out.scan_montage)
         out.scan_skip_bids_guess = _as_bool(s.value(KEYS["scan_skip_bids_guess"]),
                                             out.scan_skip_bids_guess)
 
@@ -286,14 +280,12 @@ class AppSettings:
         s.setValue(KEYS["theme"], self.theme)
         s.setValue(KEYS["dataset_slug"], self.dataset_slug)
         s.setValue(KEYS["scan_tsv_filename"], self.scan_tsv_filename)
-        s.setValue(KEYS["scan_montage"], self.scan_montage)
         if self.raw_root is not None:
             s.setValue(KEYS["raw_root"], self.raw_root)
         if self.bids_parent is not None:
             s.setValue(KEYS["bids_parent"], self.bids_parent)
         # Ints / floats.
         s.setValue(KEYS["scan_n_jobs"], int(self.scan_n_jobs))
-        s.setValue(KEYS["scan_line_freq"], float(self.scan_line_freq))
         s.setValue(KEYS["convert_n_jobs"], int(self.convert_n_jobs))
         # Bools — store as strings so the load path doesn't depend on
         # platform-specific QVariant→Python bool quirks.

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -44,6 +44,7 @@ KEYS = {
     # Convert defaults
     "convert_n_jobs":     "convert/n_jobs",
     "convert_overwrite":  "convert/overwrite",
+    "convert_skip_residuals": "convert/skip_residuals",
     # Post-convert chain
     "post_run_metadata":  "post_convert/run_metadata",
     "post_run_validate":  "post_convert/run_validate",
@@ -110,6 +111,9 @@ class AppSettings:
     # Convert defaults
     convert_n_jobs: int = 1
     convert_overwrite: bool = False
+    # Drop dcm2niix residual/secondary outputs (e.g. ``..._bolda`` next to
+    # ``..._bold``). Default on: they are derived duplicates, not real images.
+    convert_skip_residuals: bool = True
 
     # Post-convert chain
     post_run_metadata: bool = True
@@ -218,6 +222,9 @@ class AppSettings:
         out.convert_n_jobs = _as_int(s.value(KEYS["convert_n_jobs"]), out.convert_n_jobs)
         out.convert_overwrite = _as_bool(s.value(KEYS["convert_overwrite"]),
                                           out.convert_overwrite)
+        out.convert_skip_residuals = _as_bool(
+            s.value(KEYS["convert_skip_residuals"]), out.convert_skip_residuals,
+        )
 
         out.post_run_metadata = _as_bool(s.value(KEYS["post_run_metadata"]),
                                          out.post_run_metadata)
@@ -267,6 +274,7 @@ class AppSettings:
             ("scan_probe_convert",       self.scan_probe_convert),
             ("scan_skip_bids_guess",     self.scan_skip_bids_guess),
             ("convert_overwrite",        self.convert_overwrite),
+            ("convert_skip_residuals",   self.convert_skip_residuals),
             ("post_run_metadata",        self.post_run_metadata),
             ("post_run_validate",        self.post_run_validate),
             ("post_metadata_fill_todos", self.post_metadata_fill_todos),

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -42,7 +42,8 @@ KEYS = {
     "scan_skip_bids_guess": "scan/skip_bids_guess",
     # Convert defaults
     "convert_n_jobs":     "convert/n_jobs",
-    "convert_overwrite":  "convert/overwrite",
+    "convert_overwrite":  "convert/overwrite",      # legacy; migrated to on_existing
+    "convert_on_existing": "convert/on_existing",    # skip|update|replace|error
     "convert_skip_residuals": "convert/skip_residuals",
     # Scan rules (user-extensible classifier hints + series exclusions).
     # Stored as JSON-encoded lists - see ``bidsmgr.classifier.user_rules``.
@@ -114,7 +115,11 @@ class AppSettings:
 
     # Convert defaults
     convert_n_jobs: int = 1
-    convert_overwrite: bool = False
+    convert_overwrite: bool = False  # legacy; migrated into convert_on_existing
+    # Policy when an incoming subject already exists during convert:
+    # skip (default, keep existing) | update (replace changed) | replace
+    # (back up + replace colliding) | error (abort on any collision).
+    convert_on_existing: str = "skip"
     # Drop dcm2niix residual/secondary outputs (e.g. ``..._bolda`` next to
     # ``..._bold``). Default on: they are derived duplicates, not real images.
     convert_skip_residuals: bool = True
@@ -247,6 +252,14 @@ class AppSettings:
         out.convert_n_jobs = _as_int(s.value(KEYS["convert_n_jobs"]), out.convert_n_jobs)
         out.convert_overwrite = _as_bool(s.value(KEYS["convert_overwrite"]),
                                           out.convert_overwrite)
+        # Migrate the legacy overwrite checkbox: if no explicit policy is stored
+        # but overwrite was on, default the policy to "replace".
+        out.convert_on_existing = _as_str(
+            s.value(KEYS["convert_on_existing"]),
+            "replace" if out.convert_overwrite else "skip",
+        )
+        if out.convert_on_existing not in ("skip", "update", "replace", "error"):
+            out.convert_on_existing = "skip"
         out.convert_skip_residuals = _as_bool(
             s.value(KEYS["convert_skip_residuals"]), out.convert_skip_residuals,
         )
@@ -309,6 +322,7 @@ class AppSettings:
             ("editor_strict_validate",   self.editor_strict_validate),
         ):
             s.setValue(KEYS[key], "1" if val else "0")
+        s.setValue(KEYS["convert_on_existing"], self.convert_on_existing)
         s.setValue(KEYS["skipped_update_version"], self.skipped_update_version)
         s.setValue(KEYS["font_scale"], float(self.font_scale))
         s.setValue(KEYS["header_logo"], self.header_logo)

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -63,6 +63,9 @@ KEYS = {
     # "default" → ``assets/logo.png`` (monochrome, palette-inverted on dark).
     # "app_icon" → ``assets/macos/AppIcon128.png`` (full-color BIDS-Manager logo).
     "header_logo": "ui/header_logo",
+    # Recently opened/created project dataset roots (JSON list, most-recent
+    # first), shown on the Welcome tab.
+    "recent_projects": "project/recent",
 }
 
 
@@ -147,6 +150,9 @@ class AppSettings:
     # exclusion: {"pattern", "target": "sequence"|"path", "match_mode"}
     user_hints: list = field(default_factory=list)
     scan_exclusions: list = field(default_factory=list)
+
+    # Recently opened/created project dataset roots (most-recent first).
+    recent_projects: list = field(default_factory=list)
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -272,6 +278,7 @@ class AppSettings:
             out.header_logo = "default"
         out.user_hints = _as_json_list(s.value(KEYS["user_hints"]), [])
         out.scan_exclusions = _as_json_list(s.value(KEYS["scan_exclusions"]), [])
+        out.recent_projects = _as_json_list(s.value(KEYS["recent_projects"]), [])
         return out
 
     def save(self) -> None:
@@ -308,6 +315,7 @@ class AppSettings:
         # Scan rules as JSON blobs.
         s.setValue(KEYS["user_hints"], json.dumps(self.user_hints))
         s.setValue(KEYS["scan_exclusions"], json.dumps(self.scan_exclusions))
+        s.setValue(KEYS["recent_projects"], json.dumps(self.recent_projects))
         s.sync()
 
     # ------------------------------------------------------------------
@@ -336,6 +344,27 @@ class AppSettings:
         cls._settings().setValue(
             KEYS["highlight_aborts"], "1" if enabled else "0",
         )
+
+    @classmethod
+    def remember_recent_project(cls, path: Path, *, cap: int = 10) -> None:
+        """Push a project dataset root to the front of the recent list.
+
+        De-duplicates (most-recent-first) and caps the list length so the
+        Welcome tab stays tidy.
+        """
+        s = cls._settings()
+        existing = cls.load().recent_projects
+        p = str(path)
+        out = [p] + [x for x in existing if x != p]
+        s.setValue(KEYS["recent_projects"], json.dumps(out[:cap]))
+
+    @classmethod
+    def forget_recent_project(cls, path: Path) -> None:
+        """Drop a project from the recent list (does not touch the dataset)."""
+        s = cls._settings()
+        p = str(path)
+        out = [x for x in cls.load().recent_projects if x != p]
+        s.setValue(KEYS["recent_projects"], json.dumps(out))
 
     @classmethod
     def remember_theme(cls, theme: str) -> None:

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -27,7 +27,6 @@ KEYS = {
     "theme":              "ui/theme",                # "dark" | "light"
     "raw_root":           "paths/raw_root",          # last raw input dir
     "bids_parent":        "paths/bids_parent",       # last BIDS output dir
-    "dataset_slug":       "scan/dataset_slug",       # default dataset name
     "scan_tsv_filename":  "scan/tsv_filename",       # filename of the scan TSV
     "highlight_aborts":   "inspector/highlight_aborts",   # toolbar toggle
     "active_view":        "ui/active_view",          # "converter" | "editor"
@@ -101,7 +100,6 @@ class AppSettings:
     # Recently-used paths (paths come back as str; callers wrap in Path).
     raw_root: Optional[str] = None
     bids_parent: Optional[str] = None
-    dataset_slug: str = ""
     # Scan-TSV filename only (the TSV lives under ``<bids_parent>/``).
     # The user can override this from the toolbar field.
     scan_tsv_filename: str = "inventory.tsv"
@@ -111,7 +109,9 @@ class AppSettings:
 
     # Scan defaults
     scan_n_jobs: int = 1
-    scan_probe_convert: bool = False
+    # Default on: probe-convert runs dcm2niix per series at scan time to
+    # enrich the BIDS guess with sidecar-derived hints.
+    scan_probe_convert: bool = True
     scan_skip_bids_guess: bool = False
 
     # Convert defaults
@@ -127,12 +127,13 @@ class AppSettings:
     # Re-encode EEG / iEEG recordings to EDF on convert (mne-bids format="EDF").
     convert_force_edf: bool = False
 
-    # Post-convert chain
+    # Post-convert chain. All steps on by default: run metadata + validation
+    # with TODO placeholders, strict validation, and an HTML report.
     post_run_metadata: bool = True
     post_run_validate: bool = True
     post_metadata_fill_todos: bool = True
-    post_validate_strict: bool = False
-    post_validate_html: bool = False
+    post_validate_strict: bool = True
+    post_validate_html: bool = True
 
     # PyPI version string the user picked "Skip this version" on, so the
     # startup update check doesn't nag them about the same release on
@@ -238,7 +239,6 @@ class AppSettings:
         )
         out.raw_root = s.value(KEYS["raw_root"]) or None
         out.bids_parent = s.value(KEYS["bids_parent"]) or None
-        out.dataset_slug = _as_str(s.value(KEYS["dataset_slug"]), out.dataset_slug)
         out.scan_tsv_filename = _as_str(
             s.value(KEYS["scan_tsv_filename"]), out.scan_tsv_filename,
         )
@@ -304,7 +304,6 @@ class AppSettings:
         s = self._settings()
         # Strings.
         s.setValue(KEYS["theme"], self.theme)
-        s.setValue(KEYS["dataset_slug"], self.dataset_slug)
         s.setValue(KEYS["scan_tsv_filename"], self.scan_tsv_filename)
         if self.raw_root is not None:
             s.setValue(KEYS["raw_root"], self.raw_root)
@@ -351,10 +350,6 @@ class AppSettings:
     @classmethod
     def remember_bids_parent(cls, path: Path) -> None:
         cls._settings().setValue(KEYS["bids_parent"], str(path))
-
-    @classmethod
-    def remember_dataset_slug(cls, slug: str) -> None:
-        cls._settings().setValue(KEYS["dataset_slug"], slug)
 
     @classmethod
     def remember_tsv_filename(cls, filename: str) -> None:

--- a/bidsmgr/gui/bulk_edit_dialog.py
+++ b/bidsmgr/gui/bulk_edit_dialog.py
@@ -30,6 +30,7 @@ from PyQt6.QtWidgets import (
 )
 
 from .. import schema as schema_mod
+from .delegates import builtin_montages
 from .models import COLUMNS, InventoryTableModel
 
 
@@ -43,8 +44,22 @@ _COLUMN_DESCRIPTION: dict[str, str] = {
     "run":       "Run number.",
     "datatype":  "BIDS datatype (anat, func, dwi, …). Triggers a basename rebuild.",
     "suffix":    "BIDS suffix (T1w, bold, …). Triggers a basename rebuild.",
-    "line_freq": "EEG/MEG power-line frequency (Hz).",
-    "montage":   "EEG/MEG mne montage name.",
+    "line_freq": "EEG/MEG power-line frequency (Hz). Choose 50 or 60.",
+    "montage":   "EEG/MEG montage. Choose from the MNE built-in montages.",
+    "eeg_reference": "EEG/iEEG reference electrode (e.g. Cz, average).",
+    "eeg_ground":    "EEG/iEEG ground electrode.",
+    "PatientSex":    "Participant sex. Choose M / F / O.",
+    "PatientAge":    "Participant age in years.",
+    "Handedness":    "Participant handedness. Choose R / L / A.",
+}
+
+# Columns whose value must come from a fixed, non-editable dropdown (never
+# free-typed). datatype / suffix stay editable combos (schema-bounded but
+# large + interdependent); these are short, closed sets.
+_FIXED_CHOICES: dict[str, list[str]] = {
+    "line_freq": ["50", "60"],
+    "PatientSex": ["M", "F", "O"],
+    "Handedness": ["R", "L", "A"],
 }
 
 
@@ -126,6 +141,9 @@ class BulkEditDialog(QDialog):
         form.addRow("", self._value_combo)
         self._value_combo.setVisible(False)
         self._value_row_index = 1  # the row we toggle (line edit vs combo)
+        # Which editor is active. Tracked explicitly rather than via
+        # ``isVisible()`` (unreliable before the dialog is shown / in tests).
+        self._value_is_combo = False
 
         # Per-column description so the user knows what the apply will do.
         self._description = QLabel("")
@@ -182,8 +200,8 @@ class BulkEditDialog(QDialog):
 
         # Decide which editor to show.
         if key == "datatype":
-            options = sorted(schema_mod.list_datatypes())
-            self._show_value_combo(options)
+            # Schema-bounded but editable (large set, lets the user type).
+            self._show_value_combo(sorted(schema_mod.list_datatypes()), editable=True)
         elif key == "suffix":
             # ``suffix`` depends on datatype, but bulk-applying spans
             # rows that may differ. Offer the union of all datatypes'
@@ -192,24 +210,33 @@ class BulkEditDialog(QDialog):
                 s for dt in schema_mod.list_datatypes()
                 for s in schema_mod.list_suffixes(dt)
             })
-            self._show_value_combo(options)
+            self._show_value_combo(options, editable=True)
+        elif key == "montage":
+            # Dropdown-only: MNE built-in montages, never hand-typed.
+            self._show_value_combo(builtin_montages(), editable=False)
+        elif key in _FIXED_CHOICES:
+            # Short closed sets (line_freq / sex / handedness): dropdown-only.
+            self._show_value_combo(_FIXED_CHOICES[key], editable=False)
         else:
             self._show_value_lineedit()
 
-    def _show_value_combo(self, options: list[str]) -> None:
+    def _show_value_combo(self, options: list[str], *, editable: bool = False) -> None:
         self._value_combo.blockSignals(True)
         self._value_combo.clear()
+        self._value_combo.setEditable(editable)
         self._value_combo.addItems(options)
         self._value_combo.blockSignals(False)
         self._value_edit.setVisible(False)
         self._value_combo.setVisible(True)
+        self._value_is_combo = True
 
     def _show_value_lineedit(self) -> None:
         self._value_combo.setVisible(False)
         self._value_edit.setVisible(True)
+        self._value_is_combo = False
 
     def _read_value(self) -> str:
-        if self._value_combo.isVisible():
+        if self._value_is_combo:
             return self._value_combo.currentText().strip()
         return self._value_edit.text().strip()
 

--- a/bidsmgr/gui/column_manager_dialog.py
+++ b/bidsmgr/gui/column_manager_dialog.py
@@ -1,0 +1,139 @@
+"""Manage-columns dialog for the inspection table.
+
+Replaces the one-at-a-time header right-click menu with a single popup that
+lets the user toggle every column at once, with a plain-language description
+of what each column means. Mandatory columns (row identity) are shown ticked
+and disabled. Selections are applied on Save.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .models import COLUMN_DESCRIPTIONS, COLUMNS, MANDATORY_COLUMN_KEYS
+
+
+class ColumnManagerDialog(QDialog):
+    """Pick which inspection-table columns are shown.
+
+    Parameters
+    ----------
+    current
+        ``{column_key: visible}`` map of the present visibility state.
+    parent
+        Owning widget.
+
+    After ``exec()`` returns ``Accepted``, :meth:`result_visibility` gives
+    the chosen ``{key: visible}`` map (mandatory columns always ``True``).
+    """
+
+    def __init__(self, current: dict[str, bool], parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("BIDS-Manager - Manage columns")
+        self.resize(560, 620)
+        self._checks: dict[str, QCheckBox] = {}
+
+        v = QVBoxLayout(self)
+
+        intro = QLabel(
+            "Choose which columns the inspection table shows. Hover or read "
+            "the note under each name for what it means. The first three "
+            "columns identify the row and are always shown."
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: #8b949e;")
+        v.addWidget(intro)
+
+        # Select all / Hide optional shortcuts.
+        bar = QHBoxLayout()
+        all_btn = QPushButton("Select all")
+        none_btn = QPushButton("Hide optional")
+        defaults_btn = QPushButton("Defaults")
+        all_btn.clicked.connect(lambda: self._set_all(True))
+        none_btn.clicked.connect(lambda: self._set_all(False))
+        defaults_btn.clicked.connect(self._restore_defaults)
+        bar.addWidget(all_btn)
+        bar.addWidget(none_btn)
+        bar.addWidget(defaults_btn)
+        bar.addStretch(1)
+        v.addLayout(bar)
+
+        # Scrollable list of column rows (checkbox + description).
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        holder = QWidget()
+        hv = QVBoxLayout(holder)
+        hv.setSpacing(8)
+        for spec in COLUMNS:
+            hv.addWidget(self._build_row(spec, current))
+        hv.addStretch(1)
+        scroll.setWidget(holder)
+        v.addWidget(scroll, 1)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save
+            | QDialogButtonBox.StandardButton.Cancel,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        v.addWidget(buttons)
+
+    # ------------------------------------------------------------------
+    def _build_row(self, spec, current: dict[str, bool]) -> QWidget:
+        row = QFrame()
+        row.setObjectName("column-row")
+        rl = QVBoxLayout(row)
+        rl.setContentsMargins(2, 2, 2, 2)
+        rl.setSpacing(1)
+
+        label = spec.header.strip() or spec.key
+        cb = QCheckBox(f"{label}   ({spec.key})")
+        mandatory = spec.key in MANDATORY_COLUMN_KEYS
+        cb.setChecked(True if mandatory else current.get(spec.key, spec.default_visible))
+        if mandatory:
+            cb.setEnabled(False)
+            cb.setToolTip("Row-identity column - always shown.")
+        self._checks[spec.key] = cb
+        rl.addWidget(cb)
+
+        desc = COLUMN_DESCRIPTIONS.get(spec.key, "")
+        if desc:
+            d = QLabel(desc)
+            d.setWordWrap(True)
+            d.setStyleSheet("color: #8b949e; margin-left: 22px;")
+            rl.addWidget(d)
+        return row
+
+    def _set_all(self, visible: bool) -> None:
+        for key, cb in self._checks.items():
+            if key not in MANDATORY_COLUMN_KEYS:
+                cb.setChecked(visible)
+
+    def _restore_defaults(self) -> None:
+        for spec in COLUMNS:
+            if spec.key in MANDATORY_COLUMN_KEYS:
+                continue
+            self._checks[spec.key].setChecked(spec.default_visible)
+
+    def result_visibility(self) -> dict[str, bool]:
+        out: dict[str, bool] = {}
+        for key, cb in self._checks.items():
+            out[key] = True if key in MANDATORY_COLUMN_KEYS else cb.isChecked()
+        return out
+
+
+__all__ = ["ColumnManagerDialog"]

--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -1,0 +1,89 @@
+"""Round ``QComboBox`` popups application-wide.
+
+Two things are needed for a combo dropdown to look like the header project
+menu (rounded corners, no square frame):
+
+1. The QSS rule ``QComboBox { combobox-popup: 0; }`` (in ``theme.qss``)
+   forces Qt's own ``QListView`` popup instead of the native macOS
+   ``NSMenu``, which ignores every stylesheet rule. With it the popup view
+   honours ``QComboBox QAbstractItemView`` (rounded list + rounded
+   selection).
+
+2. The popup still lives in a top-level window with a square OS frame +
+   shadow behind the rounded view. This installs an application event
+   filter that makes that container frameless + translucent + shadowless
+   (the exact recipe the project menu uses), so only the rounded view
+   shows. Geometry is captured and restored around the flag change so the
+   popup stays anchored under its combo.
+
+Defensive: any failure is swallowed so a dropdown can never be broken by
+this cosmetic pass. Call :func:`install` once, after the QApplication and
+theme are set up.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import QEvent, QObject, Qt
+
+log = logging.getLogger(__name__)
+
+_FLAG = "_bidsmgr_round_popup"
+
+
+class _ComboPopupRounder(QObject):
+    """App event filter that rounds combo-popup container windows."""
+
+    def eventFilter(self, obj, event):  # noqa: N802 - Qt signature
+        try:
+            if (
+                event.type() == QEvent.Type.Show
+                and obj.metaObject().className() == "QComboBoxPrivateContainer"
+                and not obj.property(_FLAG)
+            ):
+                obj.setProperty(_FLAG, True)
+                geo = obj.geometry()
+                obj.setObjectName("combo-popup")
+                obj.setWindowFlags(
+                    obj.windowFlags()
+                    | Qt.WindowType.FramelessWindowHint
+                    | Qt.WindowType.NoDropShadowWindowHint
+                )
+                obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+                obj.setGeometry(geo)
+                obj.show()  # re-show so the new window flags take effect
+        except Exception as exc:  # noqa: BLE001 - never break a dropdown
+            log.debug("combo popup round failed: %s", exc)
+        return False
+
+
+_instance: _ComboPopupRounder | None = None
+
+
+def install(app) -> _ComboPopupRounder:
+    """Install the combo-popup rounder on *app* (idempotent)."""
+    global _instance
+    if _instance is None:
+        _instance = _ComboPopupRounder(app)
+        app.installEventFilter(_instance)
+    return _instance
+
+
+def round_menu(menu) -> None:
+    """Give a ``QMenu`` rounded corners (the project-menu recipe).
+
+    Frameless + translucent + no-shadow so the QSS ``QMenu#rounded-menu``
+    border-radius renders without a square OS frame behind it. Use for any
+    context / popup menu (e.g. the Welcome recents right-click menu).
+    """
+    menu.setObjectName("rounded-menu")
+    menu.setWindowFlags(
+        menu.windowFlags()
+        | Qt.WindowType.FramelessWindowHint
+        | Qt.WindowType.NoDropShadowWindowHint
+    )
+    menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+
+__all__ = ["install", "round_menu"]

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -84,6 +84,35 @@ from .widgets import BusySpinner, Chip, PaneHeader, PanelFrame, PathBar, VSep
 log = logging.getLogger(__name__)
 
 
+def _repolish_combo(combo: QComboBox) -> None:
+    """Force a ``QComboBox`` (and its popup view) to re-read the stylesheet.
+
+    A global ``QApplication.setStyleSheet`` swap (the theme toggle) does not
+    re-polish already-shown widgets, and a combo's drop-down view is a separate
+    top-level widget that Qt never re-polishes at all. Without the unpolish /
+    polish dance below, the closed combo and (worse) its popup keep stale
+    dark-theme colours after switching to light, and vice versa.
+
+    GENERAL RULE: any ``QComboBox`` whose colours come from QSS must be run
+    through this on every palette swap (call it from the owner's
+    ``repaint_for_palette``). Re-tinting icons is not enough.
+    """
+    if combo is None:
+        return
+    style = combo.style()
+    targets = [combo]
+    view = combo.view()
+    if view is not None:
+        targets.append(view)
+        viewport = view.viewport()
+        if viewport is not None:
+            targets.append(viewport)
+    for w in targets:
+        style.unpolish(w)
+        style.polish(w)
+        w.update()
+
+
 class ConverterPanel(QWidget):
     """The pre-conversion Inspector layout.
 
@@ -290,6 +319,12 @@ class ConverterPanel(QWidget):
         outside the project). The inventory + recording-metadata scaffold then
         live in the project bundle and the dataset name is the folder name.
         """
+        # Switching datasets must NOT leak the previous project's rows / raw
+        # input / metadata into the new tab. Clear the converter to its empty
+        # state first; the resume below repopulates only if THIS project has a
+        # scan of its own.
+        self._reset_inventory_view()
+
         self._project = project
         self._bids_root = Path(bids_root)
         self._bids_parent = self._bids_root.parent
@@ -306,6 +341,38 @@ class ConverterPanel(QWidget):
         # Resume: if this project already holds a scan, reload its inventory and
         # replay the curation edits so the user lands back in their table.
         self._resume_from_project()
+
+    def _reset_inventory_view(self) -> None:
+        """Return the converter to its pre-scan empty state.
+
+        Called when binding a new project so one dataset's inventory, raw
+        input, recording-metadata scaffold and curation history never bleed
+        into another's tab. The output path bar is set by :meth:`set_project`
+        right after this.
+        """
+        self._model = None
+        self._active_version_dir = None
+        self._raw_root = None
+        self._output_tsv = None
+        self._redo_stack.clear()
+        # Detach the model from every dependent view.
+        self._table.setModel(None)
+        self._properties.bind_model(None)
+        self._filter_pane.bind_model(None)
+        self._raw_pane.bind_model(None)
+        self._raw_pane.set_root(None)
+        # Raw input bar back to "nothing picked".
+        self._raw_pathbar.set_value("(no folder selected)", ok=False)
+        # Inspection back to the placeholder; clear previews + chips + stats.
+        self._inspection_stack.setCurrentIndex(0)
+        self._bids_preview.clear()
+        self._chip_valid.setText("0 valid")
+        self._chip_warn.setText("0 warnings")
+        self._chip_err.setText("0 error")
+        self._chip_skip.setText("0 skipped")
+        self._update_stats_label()
+        self._run_btn.setEnabled(False)
+        self._revalidate_btn.setEnabled(False)
 
     def _resume_from_project(self) -> None:
         """Resume the project's most recent scan version (curation resume).
@@ -341,6 +408,14 @@ class ConverterPanel(QWidget):
                 f"Could not load scan '{version.version_id}': {exc}"
             )
             return
+        # Keep the dataset column in lock-step with the actual (possibly
+        # renamed-on-disk) project folder. Conversion writes into
+        # ``<bids_parent>/<dataset>``; if the user renamed the dataset folder
+        # outside the app, the stored value would be stale and convert would
+        # target the wrong folder. The column is read-only in the GUI, so this
+        # is the single source of truth.
+        if self._bids_root is not None and "dataset" in df.columns:
+            df["dataset"] = self._bids_root.name
         self._project = proj
         self._properties.set_project(proj)
         self._active_version_dir = Path(version.dir)
@@ -524,7 +599,10 @@ class ConverterPanel(QWidget):
         self._model.recordingSpecChanged.connect(self._persist_recording_spec)
         # Default-select row 0 if any rows exist so the Properties panel
         # has something to show without the user having to click first.
-        if self._model.rowCount() > 0:
+        has_rows = self._model.rowCount() > 0
+        # Re-validate is available once a scan has populated the inventory.
+        self._revalidate_btn.setEnabled(has_rows)
+        if has_rows:
             self._table.selectRow(0)
             self._run_btn.setEnabled(True)
             self._run_btn.setToolTip("Run conversion on the included rows")
@@ -644,14 +722,17 @@ class ConverterPanel(QWidget):
         # Scan-version picker (project mode): switch between scans of different
         # source folders within this dataset. Hidden until a project has >=1
         # scan; replaces the free-path TSV filename field in project mode.
-        self._scans_label = QLabel("Scan:")
+        self._scans_label = QLabel("Scan table:")
         self._scans_label.setObjectName("tb-mini-label")
         self._scans_label.setVisible(False)
         lay.addWidget(self._scans_label)
         self._scans_combo = QComboBox()
         self._scans_combo.setObjectName("tb-input")
-        self._scans_combo.setMinimumWidth(190)
-        self._scans_combo.setToolTip("Switch between scans in this project")
+        self._scans_combo.setMinimumWidth(210)
+        self._scans_combo.setToolTip(
+            "Load a previous scan table in this project. Each scan of a source "
+            "folder is its own version; pick one to resume curating it."
+        )
         self._scans_combo.setVisible(False)
         self._scans_combo.activated.connect(self._on_scans_combo_activated)
         lay.addWidget(self._scans_combo)
@@ -696,6 +777,23 @@ class ConverterPanel(QWidget):
         self._chip_warn.clicked.connect(lambda: self._open_issues_dialog("warn"))
         self._chip_err.clicked.connect(lambda: self._open_issues_dialog("err"))
         self._chip_skip.clicked.connect(lambda: self._open_issues_dialog("skip"))
+
+        # Re-validate: force a full recompute of every row's valid / warning /
+        # error state + the chip tallies. Edits update these live, but this is
+        # the explicit, guaranteed-current control the user asked for. Enabled
+        # only once a scan has populated the model.
+        self._revalidate_btn = QPushButton("  Re-validate")
+        self._revalidate_btn.setObjectName("tb-btn-ghost")
+        self._revalidate_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        icons.apply_button(self._revalidate_btn, "revalidate")
+        self._revalidate_btn.setToolTip(
+            "Recompute the valid / warning / error tallies for every row "
+            "against the BIDS schema (after editing entities, tasks, includes, "
+            "etc.)."
+        )
+        self._revalidate_btn.setEnabled(False)
+        self._revalidate_btn.clicked.connect(self._on_revalidate_clicked)
+        lay.addWidget(self._revalidate_btn)
 
         # Toggle: highlight suspected-abort rows with a purple tint.
         # Aborts are already auto-deselected by the scanner; highlighting
@@ -1467,7 +1565,7 @@ class ConverterPanel(QWidget):
             self._output_tsv,
             bids_parent,
             n_jobs=n_jobs,
-            overwrite=self._app_settings.convert_overwrite,
+            on_existing=self._app_settings.convert_on_existing,
             raw_root=self._raw_root,
             skip_residuals=self._app_settings.convert_skip_residuals,
             parent=self,
@@ -1490,9 +1588,13 @@ class ConverterPanel(QWidget):
                 success=(rc == 0),
                 summary={"bids_parent": str(bids_parent), "returncode": int(rc)},
             ))
-        # Re-walk the output tree so the user sees the just-converted
-        # files appear in the lower half of col 1.
-        self._output_pane.set_root(bids_parent)
+        # Re-walk the output tree so the user sees the just-converted files.
+        # In project mode keep the tree rooted at the DATASET (not its parent),
+        # matching what set_project showed; only the free-path flow shows the
+        # parent (which holds one folder per dataset slug).
+        self._output_pane.set_root(
+            self._bids_root if self._bids_root is not None else bids_parent
+        )
         self.convert_finished.emit(rc, bids_parent)
 
         # Post-convert chain. Only kicks off when convert succeeded
@@ -1672,6 +1774,12 @@ class ConverterPanel(QWidget):
         icons.apply_button(self._aborts_btn, "highlight")
         icons.apply_button(self._bulk_btn, "bulk_edit")
         icons.apply_button(self._columns_btn, "columns")
+        if hasattr(self, "_undo_btn"):
+            icons.apply_button(self._undo_btn, "undo")
+        if hasattr(self, "_redo_btn"):
+            icons.apply_button(self._redo_btn, "redo")
+        if hasattr(self, "_revalidate_btn"):
+            icons.apply_button(self._revalidate_btn, "revalidate")
         icons.apply_button(
             self._run_btn,
             "stop" if convert_running else "run",
@@ -1682,6 +1790,13 @@ class ConverterPanel(QWidget):
         if hasattr(self, "_right_tabs"):
             icons.apply_tab(self._right_tabs, 0, "preview")
             icons.apply_tab(self._right_tabs, 1, "statistics")
+        # The scan-table dropdown (and any QComboBox) does not re-read the
+        # re-applied stylesheet on a global ``setStyleSheet`` swap on its own:
+        # its popup view is a separate top-level widget Qt does not re-polish.
+        # Run the unpolish/polish dance on the combo + its view so no stale
+        # dark/light patch survives. See ``_repolish_combo``.
+        if hasattr(self, "_scans_combo"):
+            _repolish_combo(self._scans_combo)
 
     def _on_aborts_toggled(self, checked: bool) -> None:
         """Apply the toggle to the active model + persist for next launch."""
@@ -1768,6 +1883,10 @@ class ConverterPanel(QWidget):
         # isolated curation bundle, and make it the active project.
         if self._bids_root is not None:
             output_tsv = self._promote_scan_to_version(Path(output_tsv))
+            # Heads-up: flag scanned rows whose subject id already exists in the
+            # dataset (a fresh scan adding to an existing dataset). Resume does
+            # not pass through here, so existing-version rows are never flagged.
+            self._flag_existing_subject_rows(df)
         self.load_inventory(df, output_tsv)
         if self._project is not None:
             row_ids = self._collect_row_ids(df)
@@ -1831,6 +1950,74 @@ class ConverterPanel(QWidget):
         if src.exists():
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(src), str(dst))
+
+    def _flag_existing_subject_rows(self, df: pd.DataFrame) -> None:
+        """(Re)compute the incremental-collision warning for every scanned row.
+
+        Idempotent: any prior collision note (tagged with
+        ``dataset_identity.EXISTING_SUBJECT_TOKEN``) is stripped from every row
+        first, then a fresh note is added only to rows whose CURRENT id is still
+        on disk. This is what lets the warning clear after the user renames a
+        clashing subject (e.g. sub-001 -> sub-002) and clicks Re-validate -- the
+        stale "sub-001 ... DIFFERENT subject" note no longer lingers.
+
+        Routes through the warnings system (a non-fatal proposed_issues note ->
+        warn row -> warnings chip / Issues dialog). When participants.tsv carries
+        identity (PatientID / names), the note is precise -- same subject (and
+        whether this is a new session), a possible match (one field coincides),
+        or a different subject reusing the id (with a suggested free id) --
+        otherwise it degrades to a generic heads-up. The merge-aware commit keeps
+        existing data safe regardless.
+        """
+        if "proposed_issues" not in df.columns:
+            return
+        from ..inventory import dataset_identity as di
+
+        token = di.EXISTING_SUBJECT_TOKEN
+
+        # 1) Strip any stale collision note from EVERY row so a rename / re-scan
+        #    starts from a clean slate (the note bakes in the old id).
+        for i in df.index:
+            cur = str(df.at[i, "proposed_issues"] or "")
+            if token not in cur:
+                continue
+            kept = [
+                seg.strip() for seg in cur.split(" | ")
+                if seg.strip() and not seg.strip().startswith(token)
+            ]
+            df.at[i, "proposed_issues"] = " | ".join(kept)
+
+        if self._bids_root is None or "BIDS_name" not in df.columns:
+            return
+        existing = {p.name for p in self._bids_root.glob("sub-*") if p.is_dir()}
+        if not existing:
+            return
+        identities = di.read_existing_identities(self._bids_root)
+        next_free = di.next_free_subject_id(self._bids_root)
+        sessions_cache: dict[str, set] = {}
+
+        def _cell(idx, col: str) -> str:
+            return str(df.at[idx, col]).strip() if col in df.columns else ""
+
+        # 2) Re-add a fresh, tagged note to rows whose current id is on disk.
+        for i in df.index:
+            name = _cell(i, "BIDS_name")
+            if not name or name not in existing:
+                continue
+            scanned = {
+                "patient_id": _cell(i, "PatientID"),
+                "given_name": _cell(i, "GivenName"),
+                "family_name": _cell(i, "FamilyName"),
+            }
+            session = _cell(i, "session")
+            if name not in sessions_cache:
+                sessions_cache[name] = di.existing_sessions(self._bids_root, name)
+            note = f"{token}: " + di.classify(
+                name, scanned, session, identities.get(name),
+                sessions_cache[name], next_free,
+            )
+            cur = str(df.at[i, "proposed_issues"] or "").strip()
+            df.at[i, "proposed_issues"] = f"{cur} | {note}" if cur else note
 
     @staticmethod
     def _collect_row_ids(df: pd.DataFrame) -> list[str]:
@@ -1907,6 +2094,24 @@ class ConverterPanel(QWidget):
     # ------------------------------------------------------------------
     # Status chips
     # ------------------------------------------------------------------
+
+    def _on_revalidate_clicked(self) -> None:
+        """Force a full re-validation of the inventory and refresh the tallies."""
+        if self._model is None:
+            return
+        # Recompute the incremental-collision warnings against the CURRENT row
+        # ids + on-disk subjects (so a rename like sub-001 -> sub-002 clears the
+        # stale "already on disk / DIFFERENT subject" note). This mutates the
+        # model's live DataFrame; revalidate_all then rebuilds row states from it.
+        self._flag_existing_subject_rows(self._model.dataframe())
+        self._model.revalidate_all()
+        # ``revalidate_all`` emits dataChanged (which the listeners below also
+        # react to), but call them directly so the refresh is immediate and
+        # self-contained even if a listener was ever detached.
+        self._update_status_chips()
+        self._rebuild_bids_preview()
+        self._update_stats_label()
+        self.log_message.emit("Re-validated inventory against the BIDS schema")
 
     def _update_status_chips(self) -> None:
         """Recount severities from the active model and refresh chips."""

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -419,6 +419,7 @@ class ConverterPanel(QWidget):
         # Detach the model from every dependent view.
         self._table.setModel(None)
         self._properties.bind_model(None)
+        self._properties.set_raw_root(None)
         self._filter_pane.bind_model(None)
         self._raw_pane.bind_model(None)
         self._raw_pane.set_root(None)
@@ -628,6 +629,7 @@ class ConverterPanel(QWidget):
             sel_model.currentRowChanged.connect(self._on_current_row_changed)
             sel_model.selectionChanged.connect(self._on_selection_changed)
         self._properties.bind_model(self._model)
+        self._properties.set_raw_root(self._raw_root)
         self._filter_pane.bind_model(self._model)
         self._raw_pane.bind_model(self._model)
         if self._raw_root is not None:
@@ -669,17 +671,6 @@ class ConverterPanel(QWidget):
             self._run_btn.setToolTip("Run conversion on the included rows")
         else:
             self._run_btn.setEnabled(False)
-
-    @staticmethod
-    def _default_dataset_slug(folder: Path) -> str:
-        """Mirror ``bidsmgr.cli.scan._default_dataset_slug`` so the
-        prefilled placeholder matches what the CLI would generate.
-        """
-        import re as _re
-        raw = Path(folder).name.lower()
-        slug = _re.sub(r"[^a-z0-9_-]+", "-", raw)
-        slug = _re.sub(r"-{2,}", "-", slug).strip("-_")
-        return slug or "dataset"
 
     def start_scan(
         self,
@@ -1513,7 +1504,8 @@ class ConverterPanel(QWidget):
         # inventory lives in the project bundle and the dataset name is the
         # project's folder name (output is locked to the project root). The
         # free-path case keeps the toolbar filename + chosen BIDS-output folder
-        # and the user partitions datasets by editing the ``dataset`` column.
+        # and lets the scanner derive the dataset slug from the raw folder name;
+        # the user then partitions datasets by editing the ``dataset`` column.
         if self._bids_root is not None:
             # Scan into a fresh staging dir; on success it is promoted to a new
             # version under .bidsmgr/project/scans/ (so a second source scan
@@ -1529,7 +1521,10 @@ class ConverterPanel(QWidget):
             if not filename.lower().endswith(".tsv"):
                 filename += ".tsv"
             self._output_tsv = self._bids_parent / filename
-            dataset = (s.dataset_slug or None)
+            # No GUI dataset-slug setting any more: leave it unset so the
+            # scanner derives the slug from the raw folder name (the CLI's
+            # ``_default_dataset_slug`` default).
+            dataset = None
         self.start_scan(
             self._raw_root,
             self._output_tsv,
@@ -1576,6 +1571,8 @@ class ConverterPanel(QWidget):
                 status=meta.get("status") or "curating",
             )
             self.log_message.emit(f"Relocated source for the active scan to {d}")
+        # Keep the Properties PSD button resolving against the new root.
+        self._properties.set_raw_root(self._raw_root)
         # Live preview of the picked folder before any scan runs.
         self._raw_pane.set_root(self._raw_root)
 

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -68,7 +68,9 @@ from .app_settings import AppSettings
 from .delegates import (
     CellTextDelegate,
     CheckboxDelegate,
+    ChoiceDelegate,
     StatusDelegate,
+    builtin_montages,
 )
 from .filter_pane import FilterPane
 from .models import COLUMNS, MANDATORY_COLUMN_KEYS, InventoryTableModel
@@ -298,6 +300,10 @@ class ConverterPanel(QWidget):
         self._update_status_chips()
         self._rebuild_bids_preview()
         self._update_stats_label()
+        self._update_meta_button_state()
+        # Seed the model's dataset-wide defaults so inheritance columns show
+        # the global value (muted) in rows that have no per-row override.
+        self._model.set_global_spec(self._load_global_spec())
         # Refresh chips + previews when the model edits a row.
         def _on_model_changed(*_a):
             self._update_status_chips()
@@ -472,6 +478,21 @@ class ConverterPanel(QWidget):
         )
         self._columns_btn.clicked.connect(self._open_column_manager)
 
+        # "Recording metadata" opens the dataset-level EEG/MEG enrichment
+        # editor (device, institution, reference/ground, event labels) shared
+        # across every recording. Per-row overrides live in the table itself.
+        self._meta_btn = QPushButton("  Dataset metadata…")
+        self._meta_btn.setObjectName("tb-btn")
+        self._meta_btn.setToolTip(
+            "Edit dataset-wide metadata grouped by destination: modality-agnostic "
+            "sections (events -> events.tsv, phenotype -> phenotype/) plus "
+            "EEG/MEG-specific acquisition defaults (-> the datatype sidecar). "
+            "Saved beside the inventory."
+        )
+        self._meta_btn.clicked.connect(self._open_recording_meta)
+        # Disabled until a scan loads EEG/MEG rows (it is EEG/MEG-only metadata).
+        self._meta_btn.setEnabled(False)
+
         # Busy spinner + status message — visible only while a worker
         # is running. Lives in the centre of the toolbar so it's hard
         # to miss when something's in flight.
@@ -549,6 +570,7 @@ class ConverterPanel(QWidget):
         fl.setSpacing(8)
         fl.addWidget(self._aborts_btn)
         fl.addStretch(1)
+        fl.addWidget(self._meta_btn)
         fl.addWidget(self._columns_btn)
         fl.addWidget(self._bulk_btn)
         v.addWidget(footer)
@@ -596,6 +618,18 @@ class ConverterPanel(QWidget):
                 t.setItemDelegateForColumn(col, CheckboxDelegate(t))
             elif spec.role == "status":
                 t.setItemDelegateForColumn(col, StatusDelegate(t))
+            elif spec.key == "montage":
+                # Dropdown-only: pick from the MNE built-in montages.
+                t.setItemDelegateForColumn(
+                    col, ChoiceDelegate(builtin_montages, role=spec.role,
+                                        blank_label="(none)", parent=t),
+                )
+            elif spec.key == "line_freq":
+                # Dropdown-only: the two electrical-grid conventions.
+                t.setItemDelegateForColumn(
+                    col, ChoiceDelegate(["50", "60"], role=spec.role,
+                                        blank_label="(blank)", parent=t),
+                )
             else:
                 t.setItemDelegateForColumn(col, CellTextDelegate(spec.role, t))
         return t
@@ -686,6 +720,63 @@ class ConverterPanel(QWidget):
         dlg = ColumnManagerDialog(dict(self._column_visible), self)
         if dlg.exec() == dlg.DialogCode.Accepted:
             self.set_columns_visible(dlg.result_visibility())
+
+    def _open_recording_meta(self) -> None:
+        """Open the dataset-level EEG/MEG recording-metadata editor.
+
+        Edits the scaffold beside the inventory TSV (the same file the scan
+        seeds and the convert verb auto-discovers). Requires a loaded scan so
+        there is an inventory to anchor the scaffold to.
+        """
+        if self._output_tsv is None:
+            QMessageBox.information(
+                self,
+                "Recording metadata",
+                "Run a scan first so the metadata can be saved beside the inventory.",
+            )
+            return
+        from ..recording_meta import scaffold_sidecar_path
+        from .recording_meta_dialog import RecordingMetaDialog
+
+        scaffold = scaffold_sidecar_path(self._output_tsv)
+        dlg = RecordingMetaDialog(scaffold, self._present_datatypes(), self)
+        if dlg.exec() and self._model is not None:
+            # Re-flow the saved dataset defaults into every inherited row.
+            self._model.set_global_spec(self._load_global_spec())
+
+    def _load_global_spec(self):
+        """Load the recording-metadata scaffold for the current inventory.
+
+        Falls back to a default spec (PowerLineFrequency=50) when no scaffold
+        exists yet, so inheritance always has a baseline.
+        """
+        from ..recording_meta import default_spec, load_spec, scaffold_sidecar_path
+        if self._output_tsv is not None:
+            path = scaffold_sidecar_path(self._output_tsv)
+            if path.exists():
+                try:
+                    return load_spec(path)
+                except Exception:
+                    pass
+        return default_spec()
+
+    def _present_datatypes(self) -> set[str]:
+        """The set of ``proposed_datatype`` values across the loaded model."""
+        if self._model is None:
+            return set()
+        df = self._model.dataframe()
+        if "proposed_datatype" not in df.columns:
+            return set()
+        return {str(v).strip().lower() for v in df["proposed_datatype"] if str(v).strip()}
+
+    def _update_meta_button_state(self) -> None:
+        """Enable the Dataset-metadata button whenever an inventory is loaded.
+
+        The dialog has modality-agnostic sections (events, phenotype) that
+        apply to any dataset; the EEG/MEG-specific sections inside it are gated
+        by the scanned datatypes.
+        """
+        self._meta_btn.setEnabled(self._model is not None and self._model.rowCount() > 0)
 
     # ------------------------------------------------------------------
     # Column order (drag-to-reorder, persisted via QSettings)
@@ -952,8 +1043,8 @@ class ConverterPanel(QWidget):
             self._raw_root,
             self._output_tsv,
             dataset=(s.dataset_slug or None),
-            line_freq=s.scan_line_freq if s.scan_line_freq else None,
-            montage=s.scan_montage or None,
+            # line_freq / montage are recording metadata now (per-row dropdown
+            # columns + the Recording-metadata editor), not scan settings.
             n_jobs=s.scan_n_jobs,
             probe_convert=s.scan_probe_convert,
             skip_bids_guess=s.scan_skip_bids_guess,
@@ -1035,8 +1126,6 @@ class ConverterPanel(QWidget):
             n_jobs=n_jobs,
             overwrite=self._app_settings.convert_overwrite,
             raw_root=self._raw_root,
-            line_freq=self._app_settings.scan_line_freq or None,
-            montage=self._app_settings.scan_montage or None,
             skip_residuals=self._app_settings.convert_skip_residuals,
             parent=self,
         )

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -6,7 +6,7 @@ Reference: ``inspector_proto/proto.py`` ``ConverterView``,
 M3 scope: this lands the **toolbar + path bars + Inspection table**
 backed by a real :class:`InventoryTableModel`. The other three panes
 in the prototype (raw-FS tree, filter tree, properties panel) and the
-bottom dock (BIDS preview / Log / Conflicts / Stats) are stubbed as
+bottom dock (BIDS preview / Log / Stats) are stubbed as
 empty placeholders so the splitter shape matches; they fill in during
 later milestones.
 
@@ -39,7 +39,6 @@ from typing import Optional
 
 import pandas as pd
 from PyQt6.QtCore import QSettings, Qt, QTimer, pyqtSignal
-from PyQt6.QtGui import QAction
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QFileDialog,
@@ -48,7 +47,6 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QLabel,
     QLineEdit,
-    QMenu,
     QMessageBox,
     QPlainTextEdit,
     QPushButton,
@@ -77,7 +75,7 @@ from .models import COLUMNS, MANDATORY_COLUMN_KEYS, InventoryTableModel
 from .output_fs_pane import OutputFsPane
 from .properties_panel import PropertiesPanel
 from .raw_fs_pane import RawFsPane
-from .widgets import BusySpinner, Chip, PaneHeader, PathBar, VSep
+from .widgets import BusySpinner, Chip, PaneHeader, PanelFrame, PathBar, VSep
 
 log = logging.getLogger(__name__)
 
@@ -150,34 +148,92 @@ class ConverterPanel(QWidget):
         h_split.setHandleWidth(1)
         h_split.setChildrenCollapsible(False)
 
-        # Col 1 is itself a vertical splitter: raw input tree on top,
-        # BIDS output tree below. Lets the user watch the converted
-        # tree grow without leaving the Converter view.
+        # Every side region is wrapped in a ``PanelFrame`` so it can be
+        # collapsed toward its edge and detached into a floating window.
+        # Collapsing a region hands its space to the inspection unit (the
+        # work surface), which always carries the stretch.
+        #   * Raw + Output trees: fold up individually (edge="top"); the
+        #     whole left column also folds left as one (col1_frame).
+        #   * Filter: folds left.   Properties: folds right.
+        #   * Inspection + Properties detach together as one unit.
+        self._panel_frames: list[PanelFrame] = []
+
+        # Left column: raw tree over output tree, each individually
+        # collapsible (fold up) + detachable, wrapped again so the whole
+        # column folds to the left as one.
         self._raw_pane = RawFsPane()
         self._output_pane = OutputFsPane()
-        col1 = QSplitter(Qt.Orientation.Vertical)
-        col1.setHandleWidth(1)
-        col1.setChildrenCollapsible(False)
-        col1.addWidget(self._raw_pane)
-        col1.addWidget(self._output_pane)
-        col1.setStretchFactor(0, 1)
-        col1.setStretchFactor(1, 1)
-        col1.setSizes([320, 320])
-        h_split.addWidget(col1)
+        self._raw_frame = PanelFrame(self._raw_pane, "Raw data tree", edge="top")
+        self._output_frame = PanelFrame(self._output_pane, "Output data tree", edge="top")
+        col1_inner = QSplitter(Qt.Orientation.Vertical)
+        col1_inner.setHandleWidth(1)
+        col1_inner.setChildrenCollapsible(False)
+        col1_inner.addWidget(self._raw_frame)
+        col1_inner.addWidget(self._output_frame)
+        col1_inner.setStretchFactor(0, 1)
+        col1_inner.setStretchFactor(1, 1)
+        col1_inner.setSizes([320, 320])
+        self._raw_frame.attach_splitter(col1_inner)
+        self._output_frame.attach_splitter(col1_inner)
+        self._col1_frame = PanelFrame(
+            col1_inner, "Raw / Output trees", edge="left",
+            detachable=False, hide_inner_header=False,
+        )
+        h_split.addWidget(self._col1_frame)
 
         self._filter_pane = FilterPane()
-        h_split.addWidget(self._filter_pane)
-        h_split.addWidget(self._build_inspection_pane())
+        self._filter_frame = PanelFrame(self._filter_pane, "Filter / structure", edge="left")
+        h_split.addWidget(self._filter_frame)
+
+        # Inspection (work surface, never collapsible) + Properties (folds
+        # right) live in one horizontal sub-splitter; the surrounding frame
+        # detaches both together as a single unit.
         self._properties = PropertiesPanel()
         self._properties.set_project(self._project)
-        h_split.addWidget(self._properties)
+        self._properties_frame = PanelFrame(
+            self._properties, "Properties", edge="right", detachable=False,
+        )
+        right_inner = QSplitter(Qt.Orientation.Horizontal)
+        right_inner.setHandleWidth(1)
+        right_inner.setChildrenCollapsible(False)
+        self._inspection_pane = self._build_inspection_pane()
+        right_inner.addWidget(self._inspection_pane)
+        right_inner.addWidget(self._properties_frame)
+        right_inner.setStretchFactor(0, 1)
+        right_inner.setStretchFactor(1, 0)
+        right_inner.setSizes([720, 320])
+        # Collapsing Properties hands its width to the inspection table.
+        self._properties_frame.attach_splitter(right_inner, grow_target=self._inspection_pane)
+        self._inspection_unit = PanelFrame(
+            right_inner, "Inspection", collapsible=False, detachable=True,
+        )
+        h_split.addWidget(self._inspection_unit)
+
+        # Collapsing the left column or the filter hands width to the
+        # inspection unit (the work surface), which grows automatically.
+        self._col1_frame.attach_splitter(h_split, grow_target=self._inspection_unit)
+        self._filter_frame.attach_splitter(h_split, grow_target=self._inspection_unit)
+        self._panel_frames = [
+            self._raw_frame, self._output_frame, self._col1_frame,
+            self._filter_frame, self._properties_frame, self._inspection_unit,
+        ]
         h_split.setStretchFactor(0, 0)
         h_split.setStretchFactor(1, 0)
         h_split.setStretchFactor(2, 1)
-        h_split.setStretchFactor(3, 0)
-        h_split.setSizes([240, 220, 720, 320])
+        h_split.setSizes([240, 220, 1040])
         v_split.addWidget(h_split)
-        v_split.addWidget(self._build_bottom_dock())
+
+        # The whole bottom dock (Log / BIDS preview / Statistics) folds down
+        # as one and its panes detach; wrap it so it grows the panes above
+        # when collapsed.
+        self._dock_frame = PanelFrame(
+            self._build_bottom_dock(), "Output panels", edge="bottom",
+            detachable=False, hide_inner_header=False,
+        )
+        self._panel_frames.append(self._dock_frame)
+        v_split.addWidget(self._dock_frame)
+        # Collapsing the bottom dock hands its height to the panes above.
+        self._dock_frame.attach_splitter(v_split, grow_target=h_split)
         v_split.setStretchFactor(0, 1)
         v_split.setStretchFactor(1, 0)
         v_split.setSizes([560, 200])
@@ -296,7 +352,6 @@ class ConverterPanel(QWidget):
         self._output_tsv = Path(output_tsv)
         self._raw_pathbar.set_value(str(self._raw_root), ok=True)
 
-        self._scan_btn.setEnabled(False)
         self._spinner.set_busy(True, message=f"Scanning {self._raw_root.name}…")
         worker = ScanWorker(
             self._raw_root, self._output_tsv,
@@ -309,8 +364,11 @@ class ConverterPanel(QWidget):
         worker.progress.connect(self._on_progress)
         worker.finished_with_result.connect(self._on_scan_finished)
         worker.failed.connect(self._on_scan_failed)
+        worker.stopped.connect(self._on_scan_stopped)
         worker.finished.connect(self._on_worker_qt_finished)
         self._scan_worker = worker
+        # Flip the Scan button to "Stop scanning" and lock out Run.
+        self._set_scan_running(True)
         worker.start()
         return worker
 
@@ -398,6 +456,18 @@ class ConverterPanel(QWidget):
         )
         self._bulk_btn.clicked.connect(self._on_bulk_edit_clicked)
 
+        # "Manage columns" opens a popup to toggle every column at once,
+        # with a description of each. Replaces the one-at-a-time header
+        # right-click menu (which still works as a shortcut).
+        self._columns_btn = QPushButton("  Manage columns…")
+        self._columns_btn.setObjectName("tb-btn")
+        icons.apply_button(self._columns_btn, "columns")
+        self._columns_btn.setToolTip(
+            "Choose which columns the inspection table shows, with a note on "
+            "what each one means."
+        )
+        self._columns_btn.clicked.connect(self._open_column_manager)
+
         # Busy spinner + status message — visible only while a worker
         # is running. Lives in the centre of the toolbar so it's hard
         # to miss when something's in flight.
@@ -406,11 +476,8 @@ class ConverterPanel(QWidget):
 
         lay.addStretch(1)
 
-        self._settings_btn = QPushButton("  Settings…")
-        self._settings_btn.setObjectName("tb-btn")
-        icons.apply_button(self._settings_btn, "settings")
-        self._settings_btn.clicked.connect(self._on_settings_clicked)
-        lay.addWidget(self._settings_btn)
+        # The Settings gear lives in the global top header (left of the
+        # theme toggle), not here -- see ``_TopHeader`` in main_window.
 
         self._run_btn = QPushButton("  Run conversion")
         self._run_btn.setObjectName("tb-btn-primary")
@@ -478,6 +545,7 @@ class ConverterPanel(QWidget):
         fl.setSpacing(8)
         fl.addWidget(self._aborts_btn)
         fl.addStretch(1)
+        fl.addWidget(self._columns_btn)
         fl.addWidget(self._bulk_btn)
         v.addWidget(footer)
         return pane
@@ -498,13 +566,25 @@ class ConverterPanel(QWidget):
         )
         t.verticalHeader().setVisible(False)
         t.verticalHeader().setDefaultSectionSize(26)
+        # Spreadsheet-style sizing: every column is independently resizable
+        # (no greedy stretch column to fight) and the table scrolls
+        # horizontally when the columns overflow. The last visible section
+        # stretches only to fill leftover space so there's no dead gap.
+        t.setHorizontalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
         header = t.horizontalHeader()
         header.setHighlightSections(False)
-        header.setStretchLastSection(False)
-
-        # Right-click anywhere on the header opens the column-visibility menu.
-        header.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        header.customContextMenuRequested.connect(self._show_column_menu)
+        header.setStretchLastSection(True)
+        header.setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        # Drag to reorder columns; the order is persisted (see
+        # ``_persist_column_order`` / ``_restore_column_order``).
+        header.setSectionsMovable(True)
+        header.sectionMoved.connect(self._on_section_moved)
+        # Double-clicking a column's right edge auto-fits it to its contents
+        # so shrunk-too-small text becomes readable again. Works per column.
+        header.setSectionsClickable(True)
+        header.sectionHandleDoubleClicked.connect(self._table_resize_column_to_contents)
+        # Column visibility is managed solely via the "Manage columns" button
+        # (a header right-click menu interfered with drag-to-reorder).
 
         # Per-column delegates — reuse the M1 extractions.
         for col, spec in enumerate(COLUMNS):
@@ -518,11 +598,24 @@ class ConverterPanel(QWidget):
 
     def _apply_column_widths(self) -> None:
         header = self._table.horizontalHeader()
+        # Every column Interactive (user-resizable); seed a sensible width.
+        # No per-column Stretch mode -- ``stretchLastSection`` fills any
+        # leftover space, so each column (incl. the predicted-basename one)
+        # can be freely shrunk or widened.
         for col, spec in enumerate(COLUMNS):
+            header.setSectionResizeMode(col, QHeaderView.ResizeMode.Interactive)
             self._table.setColumnWidth(col, spec.width)
-            if spec.stretch:
-                header.setSectionResizeMode(col, QHeaderView.ResizeMode.Stretch)
         self._apply_column_visibility()
+        self._restore_column_order()
+
+    def _table_resize_column_to_contents(self, logical_index: int) -> None:
+        """Auto-fit a column to its contents on header-handle double-click.
+
+        Lets the user reopen a column they shrank too small to read.
+        """
+        if not (0 <= logical_index < len(COLUMNS)):
+            return
+        self._table.resizeColumnToContents(logical_index)
 
     # ------------------------------------------------------------------
     # Column visibility (persisted via QSettings)
@@ -557,6 +650,11 @@ class ConverterPanel(QWidget):
         for col, spec in enumerate(COLUMNS):
             visible = self._column_visible.get(spec.key, spec.default_visible)
             self._table.setColumnHidden(col, not visible)
+            # A column revealed for the first time can come back at width 0
+            # (Qt collapses hidden interactive sections). Re-seed its width
+            # so it shows up draggable rather than as a hairline.
+            if visible and self._table.columnWidth(col) <= 0:
+                self._table.setColumnWidth(col, spec.width)
 
     def set_column_visible(self, key: str, visible: bool) -> None:
         """Toggle a column's visibility + persist the choice."""
@@ -566,28 +664,66 @@ class ConverterPanel(QWidget):
         self._settings().setValue(f"inspector/columns/{key}", "1" if visible else "0")
         self._apply_column_visibility()
 
-    def _show_column_menu(self, pos) -> None:
-        """Build the header right-click menu listing every column."""
-        menu = QMenu(self)
-        for spec in COLUMNS:
-            if spec.key in MANDATORY_COLUMN_KEYS:
-                # Show as a disabled item so the user understands it
-                # exists but cannot be hidden.
-                act = QAction(spec.header or spec.key, menu)
-                act.setEnabled(False)
-                act.setCheckable(True)
-                act.setChecked(True)
-                menu.addAction(act)
+    def set_columns_visible(self, mapping: dict[str, bool]) -> None:
+        """Apply visibility for many columns at once (from the manage dialog)
+        and persist each. Mandatory columns are forced visible."""
+        s = self._settings()
+        for key, visible in mapping.items():
+            if key in MANDATORY_COLUMN_KEYS:
+                self._column_visible[key] = True
                 continue
-            label = spec.header or spec.key
-            act = QAction(label, menu)
-            act.setCheckable(True)
-            act.setChecked(self._column_visible.get(spec.key, spec.default_visible))
-            act.toggled.connect(lambda checked, k=spec.key: self.set_column_visible(k, checked))
-            menu.addAction(act)
-        # Show at the header's global coordinate.
+            self._column_visible[key] = visible
+            s.setValue(f"inspector/columns/{key}", "1" if visible else "0")
+        self._apply_column_visibility()
+
+    def _open_column_manager(self) -> None:
+        """Popup to toggle every column at once, with per-column notes."""
+        from .column_manager_dialog import ColumnManagerDialog
+        dlg = ColumnManagerDialog(dict(self._column_visible), self)
+        if dlg.exec() == dlg.DialogCode.Accepted:
+            self.set_columns_visible(dlg.result_visibility())
+
+    # ------------------------------------------------------------------
+    # Column order (drag-to-reorder, persisted via QSettings)
+    # ------------------------------------------------------------------
+
+    def _on_section_moved(self, _logical: int, _old_vis: int, _new_vis: int) -> None:
+        """User dragged a header section -> persist the new visual order."""
+        if getattr(self, "_restoring_order", False):
+            return
+        self._persist_column_order()
+
+    def _persist_column_order(self) -> None:
         header = self._table.horizontalHeader()
-        menu.exec(header.mapToGlobal(pos))
+        # Keys ordered by their current visual position.
+        ordered = sorted(
+            range(len(COLUMNS)), key=lambda logical: header.visualIndex(logical)
+        )
+        keys = [COLUMNS[logical].key for logical in ordered]
+        self._settings().setValue("inspector/column_order", ",".join(keys))
+
+    def _restore_column_order(self) -> None:
+        """Re-apply the persisted visual order to the header (if any)."""
+        raw = self._settings().value("inspector/column_order", "")
+        if not raw:
+            return
+        saved = [k for k in str(raw).split(",") if k]
+        key_to_logical = {spec.key: i for i, spec in enumerate(COLUMNS)}
+        header = self._table.horizontalHeader()
+        self._restoring_order = True
+        try:
+            target_visual = 0
+            for key in saved:
+                logical = key_to_logical.get(key)
+                if logical is None:
+                    continue
+                current_visual = header.visualIndex(logical)
+                if current_visual != -1 and current_visual != target_visual:
+                    header.moveSection(current_visual, target_visual)
+                target_visual += 1
+        finally:
+            self._restoring_order = False
+
 
     # ------------------------------------------------------------------
     # Internals — bottom dock
@@ -596,9 +732,8 @@ class ConverterPanel(QWidget):
     def _build_bottom_dock(self) -> QSplitter:
         """Bottom dock split into two tabbed halves.
 
-        Left half:  Log + Conflicts   — the "what happened" pane (live
-                                         output from workers + collision
-                                         warnings).
+        Left half:  Log              — the "what happened" pane (live
+                                        output from workers).
         Right half: BIDS preview + Statistics — the "what will be
                                          produced" pane (predicted tree
                                          + row counts).
@@ -610,7 +745,7 @@ class ConverterPanel(QWidget):
         split.setHandleWidth(1)
         split.setChildrenCollapsible(False)
 
-        # ---------- left: Log + Conflicts ----------
+        # ---------- left: Log ----------
         left_tabs = QTabWidget()
         left_tabs.setDocumentMode(True)
         left_tabs.setMovable(False)
@@ -624,13 +759,14 @@ class ConverterPanel(QWidget):
         left_tabs.addTab(self._log_view, "Log")
         icons.apply_tab(left_tabs, 0, "log")
 
-        conflicts = QLabel("(no conflicts detected yet)")
-        conflicts.setObjectName("pane-hint")
-        conflicts.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        left_tabs.addTab(conflicts, "Conflicts")
-        icons.apply_tab(left_tabs, 1, "warning")
-
-        split.addWidget(left_tabs)
+        # Detach-only wrappers so the Log and the preview/stats group can
+        # each pop out into their own window (no collapse here -- the whole
+        # dock collapses together via the surrounding ``_dock_frame``).
+        self._log_frame = PanelFrame(
+            left_tabs, "Log", collapsible=False, detachable=True,
+            hide_inner_header=False,
+        )
+        split.addWidget(self._log_frame)
 
         # ---------- right: BIDS preview + Statistics ----------
         right_tabs = QTabWidget()
@@ -656,7 +792,13 @@ class ConverterPanel(QWidget):
         self._left_tabs = left_tabs
         self._right_tabs = right_tabs
 
-        split.addWidget(right_tabs)
+        self._preview_frame = PanelFrame(
+            right_tabs, "BIDS preview", collapsible=False, detachable=True,
+            hide_inner_header=False,
+        )
+        split.addWidget(self._preview_frame)
+        # Register the dock's two detach frames for theme re-tinting.
+        self._panel_frames.extend([self._log_frame, self._preview_frame])
 
         # Equal split by default; user can drag the handle to rebalance.
         split.setStretchFactor(0, 1)
@@ -769,6 +911,16 @@ class ConverterPanel(QWidget):
     # ------------------------------------------------------------------
 
     def _on_scan_clicked(self) -> None:
+        # Toggle: while a scan is running this button reads "Stop scanning",
+        # so a click requests a cooperative stop instead of starting a scan.
+        if self._scan_worker is not None and self._scan_worker.isRunning():
+            self._scan_worker.request_stop()
+            self._scan_btn.setEnabled(False)
+            self._scan_btn.setText("  Stopping…")
+            self.log_message.emit(
+                "Stop requested; finishing the read already in flight, then halting."
+            )
+            return
         # 1. Raw input is required.
         if self._raw_root is None:
             self._on_pick_raw_dir()
@@ -839,9 +991,17 @@ class ConverterPanel(QWidget):
         self._output_pane.set_root(self._bids_parent)
 
     def _on_run_clicked(self) -> None:
-        if self._model is None or self._output_tsv is None:
-            return
+        # Toggle: while a conversion is running this button reads "Stop
+        # conversion", so a click requests a cooperative stop.
         if self._convert_worker is not None and self._convert_worker.isRunning():
+            self._convert_worker.request_stop()
+            self._run_btn.setEnabled(False)
+            self._run_btn.setText("  Stopping…")
+            self.log_message.emit(
+                "Stop requested; finishing the subject already in flight, then halting."
+            )
+            return
+        if self._model is None or self._output_tsv is None:
             return
         # Use the pre-set BIDS output if the user picked one; otherwise
         # prompt now.
@@ -861,8 +1021,6 @@ class ConverterPanel(QWidget):
         self._app_settings = AppSettings.load()
         if n_jobs is None:
             n_jobs = self._app_settings.convert_n_jobs
-        self._run_btn.setEnabled(False)
-        self._scan_btn.setEnabled(False)
         self._spinner.set_busy(True, message="Converting…")
         worker = ConvertWorker(
             self._model.dataframe(),
@@ -873,13 +1031,17 @@ class ConverterPanel(QWidget):
             raw_root=self._raw_root,
             line_freq=self._app_settings.scan_line_freq or None,
             montage=self._app_settings.scan_montage or None,
+            skip_residuals=self._app_settings.convert_skip_residuals,
             parent=self,
         )
         worker.progress.connect(self._on_progress)
         worker.finished_with_result.connect(self._on_convert_finished)
         worker.failed.connect(self._on_convert_failed)
+        worker.stopped.connect(self._on_convert_stopped)
         worker.finished.connect(self._on_convert_worker_qt_finished)
         self._convert_worker = worker
+        # Flip the Run button to "Stop conversion" and lock out Scan.
+        self._set_convert_running(True)
         worker.start()
         return worker
 
@@ -1019,7 +1181,15 @@ class ConverterPanel(QWidget):
         self.log_message.emit(tb)
         QMessageBox.critical(self, "Conversion crashed", tb)
 
+    def _on_convert_stopped(self) -> None:
+        """The conversion halted because the user clicked Stop."""
+        self.log_message.emit(
+            "Conversion stopped. Subjects committed before the stop were kept."
+        )
+
     def _on_convert_worker_qt_finished(self) -> None:
+        # Restore the Run button from "Stop conversion" and re-enable Scan.
+        self._set_convert_running(False)
         self._run_btn.setEnabled(self._model is not None and self._model.rowCount() > 0)
         self._scan_btn.setEnabled(True)
         self._convert_worker = None
@@ -1050,17 +1220,27 @@ class ConverterPanel(QWidget):
             self._output_pane.repaint_for_palette(pal)
         if hasattr(self, "_filter_pane"):
             self._filter_pane.repaint_for_palette(pal)
+        # Re-tint the collapse/detach icons on every panel frame.
+        for frame in getattr(self, "_panel_frames", []):
+            frame._refresh_icons()
         # Re-tint toolbar icons + bottom-tab icons. The cache lives in
         # ``icons``; ``MainWindow`` clears it once per swap, so every
         # call below produces an icon in the newly applied palette.
-        icons.apply_button(self._scan_btn, "scan")
+        # While a scan / convert is running these buttons show the "stop"
+        # glyph, so don't clobber it on a mid-run theme swap.
+        scan_running = self._scan_worker is not None and self._scan_worker.isRunning()
+        convert_running = self._convert_worker is not None and self._convert_worker.isRunning()
+        icons.apply_button(self._scan_btn, "stop" if scan_running else "scan")
         icons.apply_button(self._aborts_btn, "highlight")
         icons.apply_button(self._bulk_btn, "bulk_edit")
-        icons.apply_button(self._settings_btn, "settings")
-        icons.apply_button(self._run_btn, "run", color=pal.get("primary_btn_text"))
+        icons.apply_button(self._columns_btn, "columns")
+        icons.apply_button(
+            self._run_btn,
+            "stop" if convert_running else "run",
+            color=pal.get("primary_btn_text"),
+        )
         if hasattr(self, "_left_tabs"):
             icons.apply_tab(self._left_tabs, 0, "log")
-            icons.apply_tab(self._left_tabs, 1, "warning")
         if hasattr(self, "_right_tabs"):
             icons.apply_tab(self._right_tabs, 0, "preview")
             icons.apply_tab(self._right_tabs, 1, "statistics")
@@ -1098,27 +1278,15 @@ class ConverterPanel(QWidget):
             self._table.ScrollHint.PositionAtCenter,
         )
 
-    def _on_settings_clicked(self) -> None:
-        from .settings_dialog import SettingsDialog
-        # Pass a fresh load so the dialog sees the latest persisted values.
-        s = AppSettings.load()
-        dlg = SettingsDialog(s, self)
-        if dlg.exec() == dlg.DialogCode.Accepted:
-            self._app_settings = s
-            # Push the new font scale into the live ThemeManager before
-            # re-applying the theme; the manager re-substitutes the QSS
-            # template with the scaled font-size values and resizes the
-            # QApplication default font in one step.
-            apply_scale = getattr(self.window(), "apply_font_scale", None)
-            if callable(apply_scale):
-                apply_scale(s.font_scale)
-            # Forward the theme change to the listener registered by
-            # MainWindow (which owns the ThemeManager). Done via the
-            # parent's ``apply_theme`` if present so the panel stays
-            # decoupled from QApplication.
-            apply_fn = getattr(self.window(), "apply_theme", None)
-            if callable(apply_fn):
-                apply_fn(s.theme)
+    def reload_app_settings(self) -> None:
+        """Re-read persisted settings into the live panel.
+
+        Called by :class:`MainWindow` after the header Settings dialog is
+        saved so changed scan / convert defaults take effect without a
+        restart. (Scan / convert also reload settings at launch time, so
+        this is belt-and-braces for any cached toolbar state.)
+        """
+        self._app_settings = AppSettings.load()
 
     def _on_current_row_changed(self, current, _previous) -> None:
         """Forward the table's row selection to the Properties panel."""
@@ -1200,12 +1368,53 @@ class ConverterPanel(QWidget):
         self.log_message.emit(tb)
         QMessageBox.critical(self, "Scan failed", tb)
 
+    def _on_scan_stopped(self) -> None:
+        """The scan halted because the user clicked Stop (no TSV written)."""
+        self.log_message.emit("Scan stopped. No inventory was written.")
+
     def _on_worker_qt_finished(self) -> None:
-        # Re-enable the Scan button once the worker's event loop wraps
-        # up (this fires after both success and failure paths).
-        self._scan_btn.setEnabled(True)
+        # Restore the Scan button from "Stop scanning"/"Stopping…" and
+        # re-enable Run if a prior scan populated the model. Fires after
+        # the success, failure, and stopped paths.
         self._scan_worker = None
         self._spinner.set_busy(False)
+        self._set_scan_running(False)
+        self._run_btn.setEnabled(self._model is not None and self._model.rowCount() > 0)
+
+    # ------------------------------------------------------------------
+    # Scan / Convert run-state button toggles (item: Stop + mutual lock)
+    # ------------------------------------------------------------------
+
+    def _set_scan_running(self, running: bool) -> None:
+        """Flip the Scan button between "Scan…" and "Stop scanning", and
+        lock the Run button out while a scan is in flight."""
+        if running:
+            self._scan_btn.setText("  Stop scanning")
+            icons.apply_button(self._scan_btn, "stop")
+            self._scan_btn.setToolTip("Stop the running scan")
+            self._scan_btn.setEnabled(True)
+            self._run_btn.setEnabled(False)  # mutual exclusion
+        else:
+            self._scan_btn.setText("  Scan…")
+            icons.apply_button(self._scan_btn, "scan")
+            self._scan_btn.setToolTip("")
+            self._scan_btn.setEnabled(True)
+            # Run re-enabled by the caller based on model state.
+
+    def _set_convert_running(self, running: bool) -> None:
+        """Flip the Run button between "Run conversion" and "Stop
+        conversion", and lock the Scan button out while converting."""
+        if running:
+            self._run_btn.setText("  Stop conversion")
+            icons.apply_button(self._run_btn, "stop")
+            self._run_btn.setToolTip("Stop the running conversion")
+            self._run_btn.setEnabled(True)
+            self._scan_btn.setEnabled(False)  # mutual exclusion
+        else:
+            self._run_btn.setText("  Run conversion")
+            icons.apply_button(self._run_btn, "run", color=CUR().get("primary_btn_text"))
+            self._run_btn.setToolTip("")
+            self._scan_btn.setEnabled(True)
 
     # ------------------------------------------------------------------
     # Status chips

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -302,6 +302,14 @@ class ConverterPanel(QWidget):
         if self._bids_parent is not None:
             self._output_pane.set_root(self._bids_parent)
 
+        # Project-first gate: with no active project the Converter starts reset
+        # and locked (raw input / BIDS output / Scan disabled with a reason) so
+        # a stale path or table from a previous session is never acted on. A
+        # project passed to the constructor (the --project launch) is bound by
+        # MainWindow via set_project, which un-gates.
+        if self._project is None:
+            self._set_no_project_state()
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -309,6 +317,47 @@ class ConverterPanel(QWidget):
     def model(self) -> Optional[InventoryTableModel]:
         """Return the active model (``None`` before the first scan)."""
         return self._model
+
+    _NO_PROJECT_HINT = (
+        "Open or create a dataset on the Home tab to start.\n\n"
+        "The Converter always works inside a project: scanning, the raw input, "
+        "and the locked BIDS output are enabled once a dataset is open."
+    )
+    _NO_PROJECT_TOOLTIP = (
+        "Open or create a dataset on the Home tab first. The Converter works "
+        "inside a project so nothing is scanned or written outside it."
+    )
+
+    def _set_no_project_state(self) -> None:
+        """Gate the Converter until a project is opened/created.
+
+        The project-first entry point: with no active project the Converter is
+        reset to empty and the raw-input / BIDS-output / Scan controls are
+        disabled (with a reason), so a stale path or table from a previous
+        session can never be acted on. ``set_project`` re-enables them. The
+        Editor is intentionally NOT gated (it doubles as a free viewer).
+        """
+        self._project = None
+        self._bids_root = None
+        self._bids_parent = None
+        self._raw_root = None
+        self._reset_inventory_view()
+        # Path bars: clear + lock, with a reason on the buttons.
+        self._raw_pathbar.set_value("(open or create a dataset first)", ok=False)
+        self._raw_pathbar.change_button.setEnabled(False)
+        self._raw_pathbar.change_button.setToolTip(self._NO_PROJECT_TOOLTIP)
+        self._bids_pathbar.set_value("(locked to the dataset you open)", ok=False)
+        self._bids_pathbar.change_button.setEnabled(False)
+        self._bids_pathbar.change_button.setToolTip(self._NO_PROJECT_TOOLTIP)
+        # Scan needs a destination project; disable it too.
+        self._scan_btn.setEnabled(False)
+        self._scan_btn.setToolTip(self._NO_PROJECT_TOOLTIP)
+        # Output tree shows nothing until a project is bound.
+        self._output_pane.set_root(None)
+        # Inspection placeholder explains the gate.
+        if hasattr(self, "_inspection_empty"):
+            self._inspection_empty.setText(self._NO_PROJECT_HINT)
+        self._refresh_scans_combo()
 
     def set_project(self, project: Project, bids_root: Path) -> None:
         """Bind an open project and lock the output to its dataset root.
@@ -337,6 +386,18 @@ class ConverterPanel(QWidget):
             "different dataset."
         )
         self._output_pane.set_root(self._bids_root)
+
+        # Un-gate the project-mode controls: raw input is modifiable (you pick
+        # what to scan), Scan is enabled, and the placeholder reverts to the
+        # normal prompt. The BIDS-output bar stays locked above.
+        self._raw_pathbar.change_button.setEnabled(True)
+        self._raw_pathbar.change_button.setToolTip("")
+        self._scan_btn.setEnabled(True)
+        self._scan_btn.setToolTip("")
+        if hasattr(self, "_inspection_empty"):
+            self._inspection_empty.setText(
+                "Pick a raw-data folder and click Scan… to populate."
+            )
 
         # Resume: if this project already holds a scan, reload its inventory and
         # replay the curation edits so the user lands back in their table.
@@ -910,6 +971,8 @@ class ConverterPanel(QWidget):
         empty = QLabel("Pick a raw-data folder and click Scan… to populate.")
         empty.setObjectName("pane-hint")
         empty.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        empty.setWordWrap(True)
+        self._inspection_empty = empty
         self._inspection_stack.addWidget(empty)
 
         self._table = self._build_table()
@@ -1881,19 +1944,32 @@ class ConverterPanel(QWidget):
 
     def _on_scan_finished(self, df: pd.DataFrame, output_tsv: Path) -> None:
         # Project mode: promote the staged scan to a new version with its own
-        # isolated curation bundle, and make it the active project.
+        # isolated curation bundle (+ ScanImported / StageCompleted events), and
+        # make it the active project. The shared, Qt-free orchestration is the
+        # same engine ``bidsmgr-scan --project`` uses.
         if self._bids_root is not None:
-            output_tsv = self._promote_scan_to_version(Path(output_tsv))
+            from ..project import Project
+            from ..project.orchestration import import_scan_as_version
+            version = import_scan_as_version(
+                self._bids_root, Path(output_tsv),
+                raw_root=self._raw_root,
+                row_ids=tuple(self._collect_row_ids(df)),
+                n_rows=len(df),
+            )
+            self._project = Project.open(version.dir)
+            self._properties.set_project(self._project)
+            self._active_version_dir = Path(version.dir)
+            output_tsv = version.inventory
             # Heads-up: flag scanned rows whose subject id already exists in the
-            # dataset (a fresh scan adding to an existing dataset). Resume does
-            # not pass through here, so existing-version rows are never flagged.
+            # dataset (a fresh scan adding to an existing dataset).
             self._flag_existing_subject_rows(df)
         self.load_inventory(df, output_tsv)
-        if self._project is not None:
-            row_ids = self._collect_row_ids(df)
+        # Legacy standalone-bundle mode (a Project passed to the constructor
+        # without a locked dataset root): still log the scan to that bundle.
+        if self._bids_root is None and self._project is not None:
             self._project.append(ScanImported(
                 inventory_tsv=str(output_tsv),
-                row_ids=tuple(row_ids),
+                row_ids=tuple(self._collect_row_ids(df)),
                 raw_root=str(self._raw_root) if self._raw_root else None,
             ))
             self._project.append(StageCompleted(
@@ -1907,50 +1983,6 @@ class ConverterPanel(QWidget):
             ))
         self._refresh_scans_combo()
         self.scan_finished.emit(df, output_tsv)
-
-    def _promote_scan_to_version(self, staged_tsv: Path) -> Path:
-        """Move a freshly-staged scan into a new version dir; bind it as active.
-
-        Creates ``.bidsmgr/project/scans/<NNNN>__<slug>/`` (its own Project
-        bundle), moves the inventory + recording-meta scaffold + files_by_uid
-        sidecar into it, records the version descriptor, and points
-        ``self._project`` / ``self._output_tsv`` at the new version. Returns the
-        inventory path inside the version dir.
-        """
-        from ..project import Project, workspace
-        from ..recording_meta import scaffold_sidecar_path
-
-        staged_tsv = Path(staged_tsv)
-        source_label = self._raw_root.name if self._raw_root else "scan"
-        version_dir = workspace.allocate_version_dir(self._bids_root, source_label)
-        proj = Project.create(version_dir, name=self._bids_root.name)
-
-        dest_inv = workspace.version_inventory(version_dir)
-        self._move_if_exists(staged_tsv, dest_inv)
-        self._move_if_exists(
-            scaffold_sidecar_path(staged_tsv), scaffold_sidecar_path(dest_inv),
-        )
-        self._move_if_exists(
-            Path(str(staged_tsv) + ".files_by_uid.json.gz"),
-            Path(str(dest_inv) + ".files_by_uid.json.gz"),
-        )
-        workspace.write_version_meta(
-            version_dir,
-            source_label=source_label,
-            raw_root=str(self._raw_root) if self._raw_root else None,
-            status="curating",
-        )
-        self._project = proj
-        self._properties.set_project(proj)
-        self._active_version_dir = version_dir
-        return dest_inv
-
-    @staticmethod
-    def _move_if_exists(src: Path, dst: Path) -> None:
-        src, dst = Path(src), Path(dst)
-        if src.exists():
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(src), str(dst))
 
     def _flag_existing_subject_rows(self, df: pd.DataFrame) -> None:
         """(Re)compute the incremental-collision warning for every scanned row.

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -34,6 +34,7 @@ Signals:
 from __future__ import annotations
 
 import logging
+import shutil
 from pathlib import Path
 from typing import Optional
 
@@ -41,6 +42,7 @@ import pandas as pd
 from PyQt6.QtCore import QSettings, Qt, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
     QAbstractItemView,
+    QComboBox,
     QFileDialog,
     QFrame,
     QHBoxLayout,
@@ -104,6 +106,18 @@ class ConverterPanel(QWidget):
         self._raw_root: Optional[Path] = None
         self._output_tsv: Optional[Path] = None
         self._bids_parent: Optional[Path] = None
+        # Set when an explicit project is bound (Welcome -> Open/Create). The
+        # output is then locked to this dataset root and the inventory lives in
+        # the project bundle. ``None`` keeps the free-path (pick-output) flow.
+        self._bids_root: Optional[Path] = None
+        # The scan version currently loaded/active (``.bidsmgr/project/scans/
+        # <version>/``). Each scan of a source folder is its own version with an
+        # isolated curation history; ``self._project`` is that version's bundle.
+        self._active_version_dir: Optional[Path] = None
+        # In-memory redo stack for the active version: events popped by Undo,
+        # re-appended by Redo. Cleared when a new edit diverges the timeline or
+        # a different version is loaded (not persisted across reopen).
+        self._redo_stack: list = []
         # Persistent settings — loaded fresh each construction so a
         # Settings dialog save propagates on the next open of this panel.
         self._app_settings: AppSettings = AppSettings.load()
@@ -267,6 +281,197 @@ class ConverterPanel(QWidget):
         """Return the active model (``None`` before the first scan)."""
         return self._model
 
+    def set_project(self, project: Project, bids_root: Path) -> None:
+        """Bind an open project and lock the output to its dataset root.
+
+        Soft lock: the BIDS-output bar shows the dataset root and its
+        ``change…`` button is disabled with a tooltip pointing at the Home tab,
+        rather than a free folder picker (so the user cannot scatter subjects
+        outside the project). The inventory + recording-metadata scaffold then
+        live in the project bundle and the dataset name is the folder name.
+        """
+        self._project = project
+        self._bids_root = Path(bids_root)
+        self._bids_parent = self._bids_root.parent
+        self._properties.set_project(project)
+
+        self._bids_pathbar.set_value(str(self._bids_root), ok=True)
+        self._bids_pathbar.change_button.setEnabled(False)
+        self._bids_pathbar.change_button.setToolTip(
+            "Working inside this project. Use the Home tab to open or create a "
+            "different dataset."
+        )
+        self._output_pane.set_root(self._bids_root)
+
+        # Resume: if this project already holds a scan, reload its inventory and
+        # replay the curation edits so the user lands back in their table.
+        self._resume_from_project()
+
+    def _resume_from_project(self) -> None:
+        """Resume the project's most recent scan version (curation resume).
+
+        No-op when the project has no scan yet. Each scan of a source folder is
+        its own version with an isolated curation bundle; this loads the latest
+        and refreshes the version picker. Older versions stay reachable via the
+        toolbar Scan picker.
+        """
+        if self._bids_root is None:
+            return
+        from ..project import workspace
+        versions = workspace.list_versions(self._bids_root)
+        if versions:
+            self._load_version(versions[-1])
+        self._refresh_scans_combo()
+
+    def _load_version(self, version, *, clear_redo: bool = True) -> None:
+        """Open one scan version: load its inventory + replay its edit history.
+
+        ``clear_redo`` is False only for the same-version reloads that Undo / Redo
+        trigger, so the redo stack survives across them; switching to a different
+        version (or a fresh scan) clears it.
+        """
+        from ..project import Project
+        if clear_redo:
+            self._redo_stack.clear()
+        try:
+            proj = Project.open(version.dir)
+            df = pd.read_csv(version.inventory, sep="\t", dtype=str).fillna("")
+        except Exception as exc:  # never block; leave the current view in place
+            self.log_message.emit(
+                f"Could not load scan '{version.version_id}': {exc}"
+            )
+            return
+        self._project = proj
+        self._properties.set_project(proj)
+        self._active_version_dir = Path(version.dir)
+        if version.raw_root:
+            self._raw_root = Path(version.raw_root)
+            raw_ok = Path(version.raw_root).exists()
+            self._raw_pathbar.set_value(version.raw_root, ok=raw_ok)
+            if not raw_ok:
+                # Moved-data detection: the table still loads (curation can
+                # continue), but convert will need the source. Point the user at
+                # the fix instead of failing silently later.
+                self.log_message.emit(
+                    f"Source folder for scan '{version.version_id}' is no longer "
+                    f"at {version.raw_root}. Use 'change…' on Raw input to relocate "
+                    f"it (or re-scan) before converting."
+                )
+        # The model is rebuilt with this version's project, so its event overlay
+        # (cell / entity / include edits) replays automatically.
+        self.load_inventory(df, output_tsv=version.inventory)
+        self.log_message.emit(f"Resumed scan '{version.version_id}'")
+
+    def _refresh_scans_combo(self) -> None:
+        """Repopulate the toolbar scan-version picker (project mode only)."""
+        combo = getattr(self, "_scans_combo", None)
+        if combo is None:
+            return
+        in_project = self._bids_root is not None
+        # In project mode the free-path TSV-filename field is irrelevant.
+        self._tsv_label.setVisible(not in_project)
+        self._tsv_filename_edit.setVisible(not in_project)
+
+        # Undo / Redo are project-mode curation actions (act on the active
+        # version's event log); show them once a table is loaded.
+        show_edit = in_project and self._model is not None
+        self._undo_btn.setVisible(show_edit)
+        self._redo_btn.setVisible(show_edit)
+        self._redo_btn.setEnabled(bool(self._redo_stack))
+
+        if not in_project:
+            self._scans_label.setVisible(False)
+            combo.setVisible(False)
+            return
+
+        from ..project import workspace
+        versions = workspace.list_versions(self._bids_root)
+        combo.blockSignals(True)
+        combo.clear()
+        active = 0
+        for i, v in enumerate(versions):
+            combo.addItem(v.version_id, userData=str(v.dir))
+            if self._active_version_dir is not None and \
+                    Path(v.dir) == Path(self._active_version_dir):
+                active = i
+        if versions:
+            combo.setCurrentIndex(active)
+        combo.blockSignals(False)
+        has = bool(versions)
+        self._scans_label.setVisible(has)
+        combo.setVisible(has)
+
+    def _on_scans_combo_activated(self, idx: int) -> None:
+        data = self._scans_combo.itemData(idx)
+        if not data:
+            return
+        version_dir = Path(data)
+        if self._active_version_dir is not None and \
+                version_dir == Path(self._active_version_dir):
+            return  # already showing this version
+        from ..project import workspace
+        for v in workspace.list_versions(self._bids_root):
+            if Path(v.dir) == version_dir:
+                self._load_version(v)
+                self._refresh_scans_combo()
+                break
+
+    def _on_undo(self) -> None:
+        """Undo the last curation edit; stash it for Redo."""
+        if self._project is None:
+            self.log_message.emit("Nothing to undo")
+            return
+        event = self._project.undo_last_user_edit()
+        if event is not None:
+            self._redo_stack.append(event)
+            self._reload_active_version()
+            self.log_message.emit("Undid last edit")
+        else:
+            self.log_message.emit("Nothing to undo")
+        self._update_undo_redo()
+
+    def _on_redo(self) -> None:
+        """Re-apply the most recently undone edit."""
+        if self._project is None or not self._redo_stack:
+            return
+        event = self._redo_stack.pop()
+        self._project.append(event)
+        self._reload_active_version()
+        self.log_message.emit("Redid edit")
+        self._update_undo_redo()
+
+    def _on_user_edited(self) -> None:
+        """A fresh edit diverges the timeline: previously-undone edits are gone."""
+        if self._redo_stack:
+            self._redo_stack.clear()
+        self._update_undo_redo()
+
+    def _update_undo_redo(self) -> None:
+        """Sync the Redo button's enabled state with the redo stack."""
+        if hasattr(self, "_redo_btn"):
+            self._redo_btn.setEnabled(bool(self._redo_stack))
+
+    def _reload_active_version(self) -> None:
+        """Reload the active version so the model reflects the truncated log."""
+        if self._active_version_dir is None or self._bids_root is None:
+            return
+        from ..project import workspace
+        for v in workspace.list_versions(self._bids_root):
+            if Path(v.dir) == Path(self._active_version_dir):
+                # Preserve the redo stack across the undo/redo reload.
+                self._load_version(v, clear_redo=False)
+                self._refresh_scans_combo()
+                return
+
+    def load_inventory(self, df: pd.DataFrame, output_tsv: Optional[Path] = None) -> None:
+        """Swap in a fresh DataFrame as the table's data source.
+
+        Called by :meth:`_on_scan_finished` and by tests / controllers
+        that want to skip the scan worker (e.g. by loading a
+        pre-generated TSV from disk).
+        """
+        self._model = InventoryTableModel(df, project=self._project, parent=self)
+
     def load_inventory(self, df: pd.DataFrame, output_tsv: Optional[Path] = None) -> None:
         """Swap in a fresh DataFrame as the table's data source.
 
@@ -310,6 +515,8 @@ class ConverterPanel(QWidget):
             self._rebuild_bids_preview()
             self._update_stats_label()
         self._model.dataChanged.connect(_on_model_changed)
+        # A fresh user edit invalidates the redo stack (timeline diverged).
+        self._model.userEdited.connect(self._on_user_edited)
         # Per-row acquisition overrides (device / institution) live in the
         # recording-metadata scaffold, not a TSV column. Persist it whenever the
         # model reports one changed so the convert verb (which reloads the
@@ -423,9 +630,9 @@ class ConverterPanel(QWidget):
         # so the inventory ends up next to the converted BIDS tree, not
         # cluttering the raw data folder. Filename only; ``<bids_parent>``
         # is set independently via the path bar below.
-        tsv_label = QLabel("TSV:")
-        tsv_label.setObjectName("tb-mini-label")
-        lay.addWidget(tsv_label)
+        self._tsv_label = QLabel("TSV:")
+        self._tsv_label.setObjectName("tb-mini-label")
+        lay.addWidget(self._tsv_label)
         self._tsv_filename_edit = QLineEdit()
         self._tsv_filename_edit.setObjectName("tb-input")
         self._tsv_filename_edit.setPlaceholderText("inventory.tsv")
@@ -433,6 +640,42 @@ class ConverterPanel(QWidget):
         self._tsv_filename_edit.setMaximumWidth(150)
         self._tsv_filename_edit.editingFinished.connect(self._on_tsv_filename_edited)
         lay.addWidget(self._tsv_filename_edit)
+
+        # Scan-version picker (project mode): switch between scans of different
+        # source folders within this dataset. Hidden until a project has >=1
+        # scan; replaces the free-path TSV filename field in project mode.
+        self._scans_label = QLabel("Scan:")
+        self._scans_label.setObjectName("tb-mini-label")
+        self._scans_label.setVisible(False)
+        lay.addWidget(self._scans_label)
+        self._scans_combo = QComboBox()
+        self._scans_combo.setObjectName("tb-input")
+        self._scans_combo.setMinimumWidth(190)
+        self._scans_combo.setToolTip("Switch between scans in this project")
+        self._scans_combo.setVisible(False)
+        self._scans_combo.activated.connect(self._on_scans_combo_activated)
+        lay.addWidget(self._scans_combo)
+
+        # Undo the last curation edit (project mode). Rides the active version's
+        # event log so it reverts one cell / entity / include edit.
+        self._undo_btn = QPushButton("  Undo")
+        self._undo_btn.setObjectName("tb-btn-ghost")
+        self._undo_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        icons.apply_button(self._undo_btn, "undo")
+        self._undo_btn.setToolTip("Undo the last edit")
+        self._undo_btn.setVisible(False)
+        self._undo_btn.clicked.connect(self._on_undo)
+        lay.addWidget(self._undo_btn)
+
+        self._redo_btn = QPushButton("  Redo")
+        self._redo_btn.setObjectName("tb-btn-ghost")
+        self._redo_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        icons.apply_button(self._redo_btn, "redo")
+        self._redo_btn.setToolTip("Redo the last undone edit")
+        self._redo_btn.setVisible(False)
+        self._redo_btn.setEnabled(False)
+        self._redo_btn.clicked.connect(self._on_redo)
+        lay.addWidget(self._redo_btn)
 
         lay.addWidget(VSep())
 
@@ -1101,21 +1344,35 @@ class ConverterPanel(QWidget):
                 return
         # 3. Compute the scan-TSV path from the filename input + the
         # BIDS output folder.
-        filename = self._tsv_filename_edit.text().strip() or "inventory.tsv"
-        if not filename.lower().endswith(".tsv"):
-            filename += ".tsv"
-        self._output_tsv = self._bids_parent / filename
-        # 4. Pick up the latest persisted settings on every scan so a
-        # user who changed defaults in the Settings dialog without
-        # restarting still gets the new values. The scan stamps every
-        # row's ``dataset`` column with a slug derived from the raw
-        # folder name; the user partitions rows across datasets by
-        # editing that column in the inspector after the scan.
+        # 3. Pick up the latest persisted settings on every scan so a user who
+        # changed defaults in the Settings dialog without restarting still gets
+        # the new values.
         s = AppSettings.load()
+        # 4. Compute the scan-TSV path + dataset name. With a project open the
+        # inventory lives in the project bundle and the dataset name is the
+        # project's folder name (output is locked to the project root). The
+        # free-path case keeps the toolbar filename + chosen BIDS-output folder
+        # and the user partitions datasets by editing the ``dataset`` column.
+        if self._bids_root is not None:
+            # Scan into a fresh staging dir; on success it is promoted to a new
+            # version under .bidsmgr/project/scans/ (so a second source scan
+            # never overwrites the first). A failed scan just leaves staging to
+            # be cleared by the next run.
+            staging = self._bids_root / ".bidsmgr" / "project" / ".scan_staging"
+            shutil.rmtree(staging, ignore_errors=True)
+            staging.mkdir(parents=True, exist_ok=True)
+            self._output_tsv = staging / "inventory.tsv"
+            dataset = self._bids_root.name
+        else:
+            filename = self._tsv_filename_edit.text().strip() or "inventory.tsv"
+            if not filename.lower().endswith(".tsv"):
+                filename += ".tsv"
+            self._output_tsv = self._bids_parent / filename
+            dataset = (s.dataset_slug or None)
         self.start_scan(
             self._raw_root,
             self._output_tsv,
-            dataset=(s.dataset_slug or None),
+            dataset=dataset,
             # line_freq / montage are recording metadata now (per-row dropdown
             # columns + the Recording-metadata editor), not scan settings.
             n_jobs=s.scan_n_jobs,
@@ -1145,6 +1402,19 @@ class ConverterPanel(QWidget):
         self._raw_root = Path(d)
         self._raw_pathbar.set_value(str(self._raw_root), ok=True)
         AppSettings.remember_raw_root(self._raw_root)
+        # Relocate: if a scan version is active, persist the new source location
+        # to its descriptor so the move sticks across reopen (moved-data
+        # recovery for EEG/MEG, whose source paths are relative to this root).
+        if self._active_version_dir is not None:
+            from ..project import workspace
+            meta = workspace.read_version_meta(self._active_version_dir)
+            workspace.write_version_meta(
+                self._active_version_dir,
+                source_label=meta.get("source_label") or self._active_version_dir.name,
+                raw_root=str(self._raw_root),
+                status=meta.get("status") or "curating",
+            )
+            self.log_message.emit(f"Relocated source for the active scan to {d}")
         # Live preview of the picked folder before any scan runs.
         self._raw_pane.set_root(self._raw_root)
 
@@ -1494,12 +1764,17 @@ class ConverterPanel(QWidget):
         # signal — the dispatcher's per-row writes already trigger them.
 
     def _on_scan_finished(self, df: pd.DataFrame, output_tsv: Path) -> None:
+        # Project mode: promote the staged scan to a new version with its own
+        # isolated curation bundle, and make it the active project.
+        if self._bids_root is not None:
+            output_tsv = self._promote_scan_to_version(Path(output_tsv))
         self.load_inventory(df, output_tsv)
         if self._project is not None:
             row_ids = self._collect_row_ids(df)
             self._project.append(ScanImported(
                 inventory_tsv=str(output_tsv),
                 row_ids=tuple(row_ids),
+                raw_root=str(self._raw_root) if self._raw_root else None,
             ))
             self._project.append(StageCompleted(
                 stage="scan",
@@ -1510,7 +1785,52 @@ class ConverterPanel(QWidget):
                     "rows": int(len(df)),
                 },
             ))
+        self._refresh_scans_combo()
         self.scan_finished.emit(df, output_tsv)
+
+    def _promote_scan_to_version(self, staged_tsv: Path) -> Path:
+        """Move a freshly-staged scan into a new version dir; bind it as active.
+
+        Creates ``.bidsmgr/project/scans/<NNNN>__<slug>/`` (its own Project
+        bundle), moves the inventory + recording-meta scaffold + files_by_uid
+        sidecar into it, records the version descriptor, and points
+        ``self._project`` / ``self._output_tsv`` at the new version. Returns the
+        inventory path inside the version dir.
+        """
+        from ..project import Project, workspace
+        from ..recording_meta import scaffold_sidecar_path
+
+        staged_tsv = Path(staged_tsv)
+        source_label = self._raw_root.name if self._raw_root else "scan"
+        version_dir = workspace.allocate_version_dir(self._bids_root, source_label)
+        proj = Project.create(version_dir, name=self._bids_root.name)
+
+        dest_inv = workspace.version_inventory(version_dir)
+        self._move_if_exists(staged_tsv, dest_inv)
+        self._move_if_exists(
+            scaffold_sidecar_path(staged_tsv), scaffold_sidecar_path(dest_inv),
+        )
+        self._move_if_exists(
+            Path(str(staged_tsv) + ".files_by_uid.json.gz"),
+            Path(str(dest_inv) + ".files_by_uid.json.gz"),
+        )
+        workspace.write_version_meta(
+            version_dir,
+            source_label=source_label,
+            raw_root=str(self._raw_root) if self._raw_root else None,
+            status="curating",
+        )
+        self._project = proj
+        self._properties.set_project(proj)
+        self._active_version_dir = version_dir
+        return dest_inv
+
+    @staticmethod
+    def _move_if_exists(src: Path, dst: Path) -> None:
+        src, dst = Path(src), Path(dst)
+        if src.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
 
     @staticmethod
     def _collect_row_ids(df: pd.DataFrame) -> list[str]:

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -310,6 +310,11 @@ class ConverterPanel(QWidget):
             self._rebuild_bids_preview()
             self._update_stats_label()
         self._model.dataChanged.connect(_on_model_changed)
+        # Per-row acquisition overrides (device / institution) live in the
+        # recording-metadata scaffold, not a TSV column. Persist it whenever the
+        # model reports one changed so the convert verb (which reloads the
+        # scaffold) sees the edit.
+        self._model.recordingSpecChanged.connect(self._persist_recording_spec)
         # Default-select row 0 if any rows exist so the Properties panel
         # has something to show without the user having to click first.
         if self._model.rowCount() > 0:
@@ -359,6 +364,19 @@ class ConverterPanel(QWidget):
         self._raw_root = Path(dicom_root)
         self._output_tsv = Path(output_tsv)
         self._raw_pathbar.set_value(str(self._raw_root), ok=True)
+
+        # A fresh scan starts from clean metadata: drop any stale
+        # recording-metadata scaffold left at this output path by a PREVIOUS
+        # scan of different data (otherwise its defaults / event labels would
+        # leak onto the new dataset). The scan re-seeds the scaffold from the
+        # newly-detected event codes.
+        from ..recording_meta import scaffold_sidecar_path
+        stale = scaffold_sidecar_path(self._output_tsv)
+        try:
+            if stale.exists():
+                stale.unlink()
+        except OSError:
+            log.warning("could not remove stale recording-metadata scaffold %s", stale)
 
         self._spinner.set_busy(True, message=f"Scanning {self._raw_root.name}…")
         worker = ScanWorker(
@@ -739,7 +757,11 @@ class ConverterPanel(QWidget):
         from .recording_meta_dialog import RecordingMetaDialog
 
         scaffold = scaffold_sidecar_path(self._output_tsv)
-        dlg = RecordingMetaDialog(scaffold, self._present_datatypes(), self)
+        dlg = RecordingMetaDialog(
+            scaffold, self._present_datatypes(), self,
+            montage_suggestions=self._montage_suggestions(),
+            manufacturer_suggestions=self._manufacturer_suggestions(),
+        )
         if dlg.exec() and self._model is not None:
             # Re-flow the saved dataset defaults into every inherited row.
             self._model.set_global_spec(self._load_global_spec())
@@ -760,6 +782,28 @@ class ConverterPanel(QWidget):
                     pass
         return default_spec()
 
+    def _persist_recording_spec(self) -> None:
+        """Write the model's live recording-metadata spec to the scaffold.
+
+        Called when a per-row acquisition override changes. The scaffold sits
+        beside the inventory TSV (the same file the scan seeds, the dialog
+        edits, and the convert verb auto-discovers), so per-row device /
+        institution edits survive to conversion time. No-op without an
+        inventory anchor or a spec.
+        """
+        if self._model is None or self._output_tsv is None:
+            return
+        spec = self._model.global_spec()
+        if spec is None:
+            return
+        from ..recording_meta import dump_spec, scaffold_sidecar_path
+        try:
+            path = scaffold_sidecar_path(self._output_tsv)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(dump_spec(spec), encoding="utf-8")
+        except OSError:
+            log.warning("could not persist recording-metadata scaffold", exc_info=True)
+
     def _present_datatypes(self) -> set[str]:
         """The set of ``proposed_datatype`` values across the loaded model."""
         if self._model is None:
@@ -768,6 +812,35 @@ class ConverterPanel(QWidget):
         if "proposed_datatype" not in df.columns:
             return set()
         return {str(v).strip().lower() for v in df["proposed_datatype"] if str(v).strip()}
+
+    def _montage_suggestions(self) -> list[str]:
+        """Distinct per-recording montage suggestions found at scan (for the
+        dataset dialog's read-only summary). Order-preserving, deduplicated."""
+        if self._model is None:
+            return []
+        df = self._model.dataframe()
+        if "montage_suggestion" not in df.columns:
+            return []
+        return self._distinct_column("montage_suggestion")
+
+    def _manufacturer_suggestions(self) -> list[str]:
+        """Distinct per-recording manufacturer suggestions found at scan (header
+        for EEG, file-format inference for MEG), for the dialog's summary hint."""
+        return self._distinct_column("manufacturer_suggestion")
+
+    def _distinct_column(self, column: str) -> list[str]:
+        """Order-preserving distinct non-blank values of a model column."""
+        if self._model is None:
+            return []
+        df = self._model.dataframe()
+        if column not in df.columns:
+            return []
+        seen: list[str] = []
+        for v in df[column]:
+            s = str(v).strip()
+            if s and s.lower() not in ("nan", "none") and s not in seen:
+                seen.append(s)
+        return seen
 
     def _update_meta_button_state(self) -> None:
         """Enable the Dataset-metadata button whenever an inventory is loaded.

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -1568,6 +1568,7 @@ class ConverterPanel(QWidget):
             on_existing=self._app_settings.convert_on_existing,
             raw_root=self._raw_root,
             skip_residuals=self._app_settings.convert_skip_residuals,
+            force_edf=self._app_settings.convert_force_edf,
             parent=self,
         )
         worker.progress.connect(self._on_progress)

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -335,6 +335,8 @@ class ConverterPanel(QWidget):
         n_jobs: int = 1,
         probe_convert: bool = False,
         skip_bids_guess: bool = False,
+        user_hints=None,
+        exclusions=None,
     ) -> ScanWorker:
         """Kick off a background scan.
 
@@ -359,6 +361,8 @@ class ConverterPanel(QWidget):
             n_jobs=n_jobs,
             probe_convert=probe_convert,
             skip_bids_guess=skip_bids_guess,
+            user_hints=user_hints,
+            exclusions=exclusions,
             parent=self,
         )
         worker.progress.connect(self._on_progress)
@@ -953,6 +957,8 @@ class ConverterPanel(QWidget):
             n_jobs=s.scan_n_jobs,
             probe_convert=s.scan_probe_convert,
             skip_bids_guess=s.scan_skip_bids_guess,
+            user_hints=s.to_user_hints(),
+            exclusions=s.to_exclusions(),
         )
 
     def _on_tsv_filename_edited(self) -> None:

--- a/bidsmgr/gui/delegates/__init__.py
+++ b/bidsmgr/gui/delegates/__init__.py
@@ -20,6 +20,7 @@ Shared helpers:
 """
 
 from .bids_tree import BADGE_ROLE, BidsTreeDelegate
+from .choice_delegate import ChoiceDelegate, builtin_montages
 from .inspection_cells import (
     PAYLOAD_ROLE,
     CellTextDelegate,
@@ -28,6 +29,7 @@ from .inspection_cells import (
 )
 from .row_state import (
     HIGHLIGHT_ROLE,
+    INHERITED_ROLE,
     ROW_STATE_ROLE,
     paint_highlight,
     paint_row_state,
@@ -36,9 +38,12 @@ from .row_state import (
 __all__ = [
     "BADGE_ROLE",
     "BidsTreeDelegate",
+    "ChoiceDelegate",
+    "builtin_montages",
     "CellTextDelegate",
     "CheckboxDelegate",
     "HIGHLIGHT_ROLE",
+    "INHERITED_ROLE",
     "PAYLOAD_ROLE",
     "ROW_STATE_ROLE",
     "StatusDelegate",

--- a/bidsmgr/gui/delegates/choice_delegate.py
+++ b/bidsmgr/gui/delegates/choice_delegate.py
@@ -1,0 +1,101 @@
+"""Combobox cell delegate for constrained-choice inventory columns.
+
+``montage`` and ``line_freq`` must never be free-typed: a montage name has to
+be one MNE recognises, and a power-line frequency is one of the two grid
+conventions. This delegate paints exactly like :class:`CellTextDelegate` (so the
+column looks identical) but opens a non-editable ``QComboBox`` for editing.
+
+A leading "blank" entry maps to the empty string, so a user can clear the cell
+back to "use the dataset default".
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable, Sequence, Union
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QComboBox
+
+from .inspection_cells import CellTextDelegate
+
+_FALLBACK_MONTAGES = [
+    "standard_1005", "standard_1020", "biosemi16", "biosemi32", "biosemi64",
+    "biosemi128", "easycap-M1", "easycap-M10", "GSN-HydroCel-64_1.0",
+    "GSN-HydroCel-128", "GSN-HydroCel-256",
+]
+
+
+@functools.lru_cache(maxsize=1)
+def builtin_montages() -> list[str]:
+    """The MNE built-in montage names (lazy + cached; fallback if MNE absent)."""
+    try:
+        import mne
+
+        names = list(mne.channels.get_builtin_montages())
+        return names or list(_FALLBACK_MONTAGES)
+    except Exception:
+        return list(_FALLBACK_MONTAGES)
+
+
+class ChoiceDelegate(CellTextDelegate):
+    """Dropdown editor for a constrained column; paints like a text cell.
+
+    Parameters
+    ----------
+    choices
+        Either a list of option strings or a zero-arg callable returning one
+        (callable lets the montage list load lazily on first edit).
+    role
+        Paint role forwarded to :class:`CellTextDelegate`.
+    blank_label
+        The label shown for the empty-string value (always the first item).
+    """
+
+    def __init__(
+        self,
+        choices: Union[Sequence[str], Callable[[], Sequence[str]]],
+        *,
+        role: str = "plain",
+        blank_label: str = "(none)",
+        parent=None,
+    ) -> None:
+        super().__init__(role, parent)
+        self._choices = choices
+        self._blank_label = blank_label
+
+    def _options(self) -> list[str]:
+        raw = self._choices() if callable(self._choices) else self._choices
+        return [self._blank_label] + [str(x) for x in raw]
+
+    def createEditor(self, parent, option, index):  # noqa: N802 (Qt signature)
+        cb = QComboBox(parent)
+        cb.setEditable(False)  # dropdown-only: never hand-typed
+        cb.addItems(self._options())
+        return cb
+
+    def setEditorData(self, editor, index):  # noqa: N802
+        value = str(
+            index.data(Qt.ItemDataRole.EditRole)
+            or index.data(Qt.ItemDataRole.DisplayRole)
+            or ""
+        ).strip()
+        if not value:
+            editor.setCurrentIndex(0)
+            return
+        pos = editor.findText(value)
+        if pos < 0:
+            # Preserve an existing-but-unlisted value (e.g. a custom montage
+            # name set via the CLI) rather than silently dropping it.
+            editor.addItem(value)
+            pos = editor.findText(value)
+        editor.setCurrentIndex(pos)
+
+    def setModelData(self, editor, model, index):  # noqa: N802
+        text = editor.currentText()
+        if text == self._blank_label:
+            text = ""
+        model.setData(index, text, Qt.ItemDataRole.EditRole)
+
+
+__all__ = ["ChoiceDelegate", "builtin_montages"]

--- a/bidsmgr/gui/delegates/inspection_cells.py
+++ b/bidsmgr/gui/delegates/inspection_cells.py
@@ -27,6 +27,7 @@ from ..theme_manager import CUR, scaled_px
 from ..widgets.status_badge import badge_paint
 from .row_state import (
     HIGHLIGHT_ROLE,
+    INHERITED_ROLE,
     ROW_STATE_ROLE,
     paint_highlight,
     paint_row_state,
@@ -188,6 +189,13 @@ class CellTextDelegate(QStyledItemDelegate):
 
         if row_state == "skip":
             color = QColor(pal["muted"])
+
+        # A value inherited from the dataset default (no per-row override)
+        # is shown muted + italic so it reads as "inherited, not set here".
+        if index.data(INHERITED_ROLE):
+            color = QColor(pal["dim"])
+            f.setItalic(True)
+            painter.setFont(f)
 
         painter.setPen(color)
         r = option.rect.adjusted(8, 0, -8, 0)

--- a/bidsmgr/gui/delegates/row_state.py
+++ b/bidsmgr/gui/delegates/row_state.py
@@ -39,9 +39,9 @@ def paint_row_state(
 ) -> None:
     """Tint the cell's background according to ``row_state``.
 
-    Recognised values: ``"selected"``, ``"warn"``, ``"err"``, ``"skip"``.
-    Anything else (including ``None`` / ``""``) is a no-op so the model
-    can omit the role for non-special rows.
+    Recognised values: ``"selected"``, ``"warn"``, ``"err"``, ``"skip"``,
+    ``"noimg"``. Anything else (including ``None`` / ``""``) is a no-op so
+    the model can omit the role for non-special rows.
     """
     if not row_state:
         return
@@ -54,6 +54,11 @@ def paint_row_state(
         painter.fillRect(option.rect, rgba(pal["error"], 0.06))
     elif row_state == "skip":
         painter.fillRect(option.rect, QColor(pal["bg"]))
+    elif row_state == "noimg":
+        # DERIVED non-image object (no pixel data; excluded from convert).
+        # A distinct teal wash so it reads as "flagged / informational"
+        # rather than the de-emphasised grey of an ordinary skip.
+        painter.fillRect(option.rect, rgba(pal["teal"], 0.14))
 
 
 def paint_highlight(

--- a/bidsmgr/gui/delegates/row_state.py
+++ b/bidsmgr/gui/delegates/row_state.py
@@ -30,6 +30,10 @@ from ..theme_manager import CUR, rgba
 ROW_STATE_ROLE: int = Qt.ItemDataRole.UserRole + 1
 # Bool role: ``True`` paints a purple tint on top of the row-state tint.
 HIGHLIGHT_ROLE: int = Qt.ItemDataRole.UserRole + 3
+# Bool role: ``True`` means the cell shows a value INHERITED from the dataset
+# default (no per-row override). Delegates paint it muted to distinguish it
+# from an explicit override.
+INHERITED_ROLE: int = Qt.ItemDataRole.UserRole + 4
 
 
 def paint_row_state(

--- a/bidsmgr/gui/editor_issues_dialog.py
+++ b/bidsmgr/gui/editor_issues_dialog.py
@@ -77,8 +77,13 @@ class _FileCard(QFrame):
         self._title_btn.setObjectName("issue-card-title")
         self._title_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self._title_btn.setFlat(True)
+        self._title_btn.setToolTip(title_text)
+        # Ignored horizontal policy: a long path must not force the dialog
+        # wide. The button clips to the available width (full path stays in
+        # the tooltip) so the chips dialog stays compact.
+        self._title_btn.setMinimumWidth(40)
         self._title_btn.setSizePolicy(
-            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred,
+            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred,
         )
         self._title_btn.clicked.connect(
             lambda: self.activated.emit(self._path)
@@ -149,7 +154,8 @@ class EditorIssuesDialog(QDialog):
         self.setWindowTitle(
             f"{title} · {count} file{'s' if count != 1 else ''}"
         )
-        self.resize(700, 640)
+        self.resize(560, 620)
+        self.setMinimumWidth(360)
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -26,7 +26,6 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QFrame,
     QHBoxLayout,
-    QLabel,
     QPushButton,
     QSplitter,
     QStackedWidget,
@@ -42,13 +41,14 @@ from .widgets import (
     BusySpinner,
     Chip,
     NiftiViewerPane,
-    PaneHeader,
     PanelFrame,
     PathBar,
+    RecordingViewerPane,
     SidecarFormPane,
     TsvViewerPane,
     ValidationPane,
     VSep,
+    is_recording_path,
 )
 
 log = logging.getLogger(__name__)
@@ -104,10 +104,16 @@ class EditorPanel(QWidget):
         self._sidecar_form = SidecarFormPane()
         self._tsv_viewer = TsvViewerPane()
         self._nifti_viewer = NiftiViewerPane()
+        self._recording_viewer = RecordingViewerPane()
         self._center_stack = QStackedWidget()
         self._center_stack.addWidget(self._sidecar_form)
         self._center_stack.addWidget(self._tsv_viewer)
         self._center_stack.addWidget(self._nifti_viewer)
+        self._center_stack.addWidget(self._recording_viewer)
+        # Threaded panes drive the toolbar busy spinner + status bar.
+        self._tsv_viewer.loading_changed.connect(self._on_pane_loading)
+        self._recording_viewer.loading_changed.connect(self._on_pane_loading)
+        self._recording_viewer.status_message.connect(self.log_message)
         # Undo/redo toolbar buttons follow the active editable pane.
         self._sidecar_form.history_changed.connect(self._sync_undo_redo)
         self._tsv_viewer.history_changed.connect(self._sync_undo_redo)
@@ -390,6 +396,7 @@ class EditorPanel(QWidget):
         self._sidecar_form.set_file(None, None, None)
         self._tsv_viewer.set_file(None, None)
         self._nifti_viewer.set_file(None, None)
+        self._recording_viewer.set_file(None, None)
         self._center_stack.setCurrentWidget(self._sidecar_form)
         self._validation_pane.set_report(None)
         self._validation_pane.set_current_file(None, None)
@@ -614,18 +621,26 @@ class EditorPanel(QWidget):
         * ``.tsv`` / ``.tsv.gz`` → :class:`TsvViewerPane` (table).
         * ``.nii`` / ``.nii.gz`` → :class:`NiftiViewerPane` (2-D slice
           viewer with orientation buttons + brightness/contrast).
-        * everything else (JSON sidecars, EEG/MEG, …) →
-          :class:`SidecarFormPane`. The sidecar pane shows the form
-          for JSON and a "no sidecar form for this file type" hint
-          for other kinds (MEG / EEG viewers are future work).
+        * EEG / MEG / iEEG recordings (``.fif``, ``.edf``, ``.set``,
+          ``.vhdr``, ``.cnt``, CTF ``.ds``, …) →
+          :class:`RecordingViewerPane` (metadata card + threaded
+          time-series viewer).
+        * everything else (JSON sidecars, …) → :class:`SidecarFormPane`.
         """
         if path.is_dir():
-            # Directories don't carry sidecars. We still push the
+            # CTF .ds / EGI .mff are directory-shaped recordings — route
+            # them to the recording viewer instead of the dir-clear path.
+            if is_recording_path(path):
+                self._show_recording(path)
+                self._validation_pane.set_current_file(path, self.current_root())
+                return
+            # Plain directories don't carry sidecars. We still push the
             # folder down to the validation panel so its "Folder"
             # section can reflect the user's focus.
             self._sidecar_form.set_file(None, None, None)
             self._tsv_viewer.set_file(None, None)
             self._nifti_viewer.set_file(None, None)
+            self._recording_viewer.set_file(None, None)
             self._center_stack.setCurrentWidget(self._sidecar_form)
             self._validation_pane.set_current_file(path, self.current_root())
             return
@@ -637,18 +652,43 @@ class EditorPanel(QWidget):
             # show stale state for a different file.
             self._sidecar_form.set_file(None, None, None)
             self._nifti_viewer.set_file(None, None)
+            self._recording_viewer.set_file(None, None)
             self._center_stack.setCurrentWidget(self._tsv_viewer)
         elif name.endswith(".nii") or name.endswith(".nii.gz"):
             self._nifti_viewer.set_file(path, root)
             self._sidecar_form.set_file(None, None, None)
             self._tsv_viewer.set_file(None, None)
+            self._recording_viewer.set_file(None, None)
             self._center_stack.setCurrentWidget(self._nifti_viewer)
+        elif is_recording_path(path):
+            self._show_recording(path)
         else:
             self._sidecar_form.set_file(path, root, self._report)
             self._tsv_viewer.set_file(None, None)
             self._nifti_viewer.set_file(None, None)
+            self._recording_viewer.set_file(None, None)
             self._center_stack.setCurrentWidget(self._sidecar_form)
         self._validation_pane.set_current_file(path, root)
+
+    def _show_recording(self, path: Path) -> None:
+        """Route an EEG/MEG/iEEG recording to the recording viewer."""
+        root = self.current_root()
+        self._recording_viewer.set_file(path, root)
+        self._sidecar_form.set_file(None, None, None)
+        self._tsv_viewer.set_file(None, None)
+        self._nifti_viewer.set_file(None, None)
+        self._center_stack.setCurrentWidget(self._recording_viewer)
+
+    def _on_pane_loading(self, busy: bool, message: str) -> None:
+        """Mirror a center pane's threaded load onto the toolbar spinner.
+
+        Only drives the spinner; it does not touch the validate buttons
+        (those are owned by :meth:`_set_busy`). When a dataset validation
+        is in flight we leave the spinner under its control.
+        """
+        if self._report_worker is not None and self._report_worker.isRunning():
+            return
+        self._spinner.set_busy(busy, message=message)
 
     # ------------------------------------------------------------------
     # Theme cascade (called by MainWindow._on_palette_changed)
@@ -760,6 +800,7 @@ class EditorPanel(QWidget):
         self._sidecar_form.repaint_for_palette(pal)
         self._tsv_viewer.repaint_for_palette(pal)
         self._nifti_viewer.repaint_for_palette(pal)
+        self._recording_viewer.repaint_for_palette(pal)
         self._validation_pane.repaint_for_palette(pal)
         for frame in getattr(self, "_panel_frames", []):
             frame._refresh_icons()

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -108,6 +108,10 @@ class EditorPanel(QWidget):
         self._center_stack.addWidget(self._sidecar_form)
         self._center_stack.addWidget(self._tsv_viewer)
         self._center_stack.addWidget(self._nifti_viewer)
+        # Undo/redo toolbar buttons follow the active editable pane.
+        self._sidecar_form.history_changed.connect(self._sync_undo_redo)
+        self._tsv_viewer.history_changed.connect(self._sync_undo_redo)
+        self._center_stack.currentChanged.connect(self._sync_undo_redo)
         self._validation_pane = ValidationPane()
         self._validation_pane.fix_requested.connect(self._on_fix_requested)
         # The BIDS tree folds to the left, the validation pane to the right,
@@ -239,6 +243,27 @@ class EditorPanel(QWidget):
         icons.apply_button(self._open_btn, "open_folder")
         self._open_btn.clicked.connect(self._on_change_root)
         lay.addWidget(self._open_btn)
+
+        lay.addWidget(VSep())
+
+        # Undo / Redo for in-memory edits to the active center pane (JSON
+        # sidecar + TSV table). They delegate to whichever editable pane is
+        # showing; disabled when nothing is undoable (or a NIfTI is shown).
+        self._undo_btn = QPushButton("  Undo")
+        self._undo_btn.setObjectName("tb-btn-ghost")
+        icons.apply_button(self._undo_btn, "undo")
+        self._undo_btn.setToolTip("Undo the last edit (JSON / TSV)")
+        self._undo_btn.setEnabled(False)
+        self._undo_btn.clicked.connect(self._on_editor_undo)
+        lay.addWidget(self._undo_btn)
+
+        self._redo_btn = QPushButton("  Redo")
+        self._redo_btn.setObjectName("tb-btn-ghost")
+        icons.apply_button(self._redo_btn, "redo")
+        self._redo_btn.setToolTip("Redo the last undone edit")
+        self._redo_btn.setEnabled(False)
+        self._redo_btn.clicked.connect(self._on_editor_redo)
+        lay.addWidget(self._redo_btn)
 
         lay.addWidget(VSep())
 
@@ -691,6 +716,33 @@ class EditorPanel(QWidget):
 
     # ------------------------------------------------------------------
 
+    # ------------------------------------------------------------------
+    # Undo / redo (delegates to the active editable center pane)
+    # ------------------------------------------------------------------
+
+    def _active_history_pane(self):
+        """The current center pane if it supports undo/redo, else None."""
+        w = self._center_stack.currentWidget()
+        if w in (self._sidecar_form, self._tsv_viewer):
+            return w
+        return None
+
+    def _sync_undo_redo(self, *args) -> None:
+        del args
+        pane = self._active_history_pane()
+        self._undo_btn.setEnabled(bool(pane) and pane.can_undo())
+        self._redo_btn.setEnabled(bool(pane) and pane.can_redo())
+
+    def _on_editor_undo(self) -> None:
+        pane = self._active_history_pane()
+        if pane is not None:
+            pane.undo()
+
+    def _on_editor_redo(self) -> None:
+        pane = self._active_history_pane()
+        if pane is not None:
+            pane.redo()
+
     def showEvent(self, event) -> None:  # noqa: N802
         """Refresh the tree when the Editor becomes visible.
 
@@ -714,6 +766,8 @@ class EditorPanel(QWidget):
         # Re-tint toolbar icons after the icon cache is cleared in
         # ``MainWindow._on_palette_changed``.
         icons.apply_button(self._open_btn, "open_folder")
+        icons.apply_button(self._undo_btn, "undo")
+        icons.apply_button(self._redo_btn, "redo")
         icons.apply_button(self._validate_dataset_btn, "dataset")
         icons.apply_button(self._strict_btn, "strict")
         # The two partial-validate buttons get their tint from the

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -691,6 +691,18 @@ class EditorPanel(QWidget):
 
     # ------------------------------------------------------------------
 
+    def showEvent(self, event) -> None:  # noqa: N802
+        """Refresh the tree when the Editor becomes visible.
+
+        A conversion (or any external change) may have written into the open
+        dataset while the user was in the Converter tab. ``refresh`` re-walks
+        the root while preserving the user's expand / selection state, so the
+        editor reflects the current disk contents the moment it is shown (and
+        the live ``QFileSystemWatcher`` keeps it current thereafter).
+        """
+        super().showEvent(event)
+        self._tree_pane.refresh()
+
     def repaint_for_palette(self, pal: dict) -> None:
         self._tree_pane.repaint_for_palette(pal)
         self._sidecar_form.repaint_for_palette(pal)

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -43,6 +43,7 @@ from .widgets import (
     Chip,
     NiftiViewerPane,
     PaneHeader,
+    PanelFrame,
     PathBar,
     SidecarFormPane,
     TsvViewerPane,
@@ -109,13 +110,31 @@ class EditorPanel(QWidget):
         self._center_stack.addWidget(self._nifti_viewer)
         self._validation_pane = ValidationPane()
         self._validation_pane.fix_requested.connect(self._on_fix_requested)
-        self._splitter.addWidget(self._tree_pane)
-        self._splitter.addWidget(self._center_stack)
-        self._splitter.addWidget(self._validation_pane)
+        # The BIDS tree folds to the left, the validation pane to the right,
+        # and the center viewer grows into the freed space. The viewer is
+        # not collapsible (it's the main surface) but IS detachable so the
+        # JSON / TSV / NIfTI view can pop out into its own window.
+        self._tree_frame = PanelFrame(self._tree_pane, "BIDS tree", edge="left")
+        self._center_frame = PanelFrame(
+            self._center_stack, "Viewer", collapsible=False, detachable=True,
+            hide_inner_header=False,
+        )
+        self._validation_frame = PanelFrame(
+            self._validation_pane, "Validation", edge="right",
+        )
+        self._panel_frames = [
+            self._tree_frame, self._center_frame, self._validation_frame,
+        ]
+        self._splitter.addWidget(self._tree_frame)
+        self._splitter.addWidget(self._center_frame)
+        self._splitter.addWidget(self._validation_frame)
         self._splitter.setStretchFactor(0, 0)
         self._splitter.setStretchFactor(1, 1)
         self._splitter.setStretchFactor(2, 0)
         self._splitter.setSizes([320, 700, 380])
+        # Collapsing the tree / validation hands width to the center viewer.
+        self._tree_frame.attach_splitter(self._splitter, grow_target=self._center_frame)
+        self._validation_frame.attach_splitter(self._splitter, grow_target=self._center_frame)
         v.addWidget(self._splitter, 1)
 
         # Restore last-opened root if available.
@@ -678,6 +697,8 @@ class EditorPanel(QWidget):
         self._tsv_viewer.repaint_for_palette(pal)
         self._nifti_viewer.repaint_for_palette(pal)
         self._validation_pane.repaint_for_palette(pal)
+        for frame in getattr(self, "_panel_frames", []):
+            frame._refresh_icons()
         # Re-tint toolbar icons after the icon cache is cleared in
         # ``MainWindow._on_palette_changed``.
         icons.apply_button(self._open_btn, "open_folder")

--- a/bidsmgr/gui/icons.py
+++ b/bidsmgr/gui/icons.py
@@ -98,6 +98,17 @@ NAMES: dict[str, tuple[str, str]] = {
     "dataset":      ("mdi6.database-search-outline",  "accent"),
     "strict":       ("mdi6.lightning-bolt-outline",   "warning"),
 
+    # ---- Editor MEG/EEG recording viewer ----
+    "load_signal":  ("mdi6.play-circle-outline",      "success"),
+    "filter":       ("mdi6.tune-variant",             "accent"),
+    "resample":     ("mdi6.sine-wave",                "accent"),
+    "psd":          ("mdi6.chart-bell-curve",         "purple"),
+    "reset_view":   ("mdi6.backup-restore",           "text"),
+    "close_data":   ("mdi6.close-box-outline",        "error"),
+    "channels":     ("mdi6.format-list-checks",       "text"),
+    "events":       ("mdi6.flag-outline",             "warning"),
+    "waveform":     ("mdi6.chart-line-variant",       "text"),
+
     # ---- File-tree node icons (Converter raw + output, Editor BIDS) ----
     "tree_folder":  ("ph.folder-simple-light",        "accent"),
     "tree_nifti":   ("ph.brain-light",                "text"),
@@ -163,6 +174,43 @@ def icon(name: str, color: Optional[str] = None) -> QIcon:
     return ico
 
 
+# EEG / MEG / iEEG recording file extensions that get the "brain + signal"
+# composite tree icon (mirrors the Editor viewer's openable file set; the
+# directory formats .ds / .mff render as folders in the tree).
+_RECORDING_TREE_EXTS: tuple[str, ...] = (
+    ".fif.gz", ".fif", ".con", ".sqd", ".kdf",
+    ".vhdr", ".edf", ".bdf", ".gdf", ".set", ".cnt", ".egi", ".mef", ".nwb",
+)
+
+
+def _recording_tree_icon() -> QIcon:
+    """Composite brain (like NIfTI) + a small signal squiggle badge.
+
+    Signals a recording the Editor can open in the time-series viewer.
+    Cached + theme-tinted like the rest of the icon set.
+    """
+    pal = CUR()
+    brain = pal.get("text", "#e6edf3")
+    signal = pal.get("accent", "#58a6ff")
+    key = ("__recording_tree__", f"{brain}|{signal}")
+    cached = _CACHE.get(key)
+    if cached is not None:
+        return cached
+    try:
+        ico = qta.icon(
+            "ph.brain-light", "mdi6.pulse",
+            options=[
+                {"color": brain},
+                {"color": signal, "scale_factor": 0.62, "offset": (0.22, 0.26)},
+            ],
+        )
+    except Exception as exc:  # pragma: no cover - fall back to plain brain
+        log.debug("recording tree icon failed: %s", exc)
+        ico = icon("tree_nifti")
+    _CACHE[key] = ico
+    return ico
+
+
 def icon_for_path(name: str, *, is_dir: bool = False) -> QIcon:
     """Return the tree-node ``QIcon`` for a file path / name.
 
@@ -171,15 +219,21 @@ def icon_for_path(name: str, *, is_dir: bool = False) -> QIcon:
     Unknown extensions return an empty ``QIcon`` rather than a default
     so generic files don't pick up a misleading glyph.
     """
-    if is_dir:
-        return icon("tree_folder")
     lower = name.lower()
+    if is_dir:
+        # Directory-shaped recordings (CTF .ds, EGI .mff) are recordings,
+        # not plain folders - give them the brain + signal icon too.
+        if lower.endswith(".ds") or lower.endswith(".mff"):
+            return _recording_tree_icon()
+        return icon("tree_folder")
     if lower.endswith(".nii.gz") or lower.endswith(".nii"):
         return icon("tree_nifti")
     if lower.endswith(".json"):
         return icon("tree_json")
     if lower.endswith(".tsv.gz") or lower.endswith(".tsv"):
         return icon("tree_tsv")
+    if lower.endswith(_RECORDING_TREE_EXTS):
+        return _recording_tree_icon()
     return QIcon()
 
 

--- a/bidsmgr/gui/icons.py
+++ b/bidsmgr/gui/icons.py
@@ -76,7 +76,9 @@ NAMES: dict[str, tuple[str, str]] = {
     "scan":         ("mdi6.magnify-scan",             "accent"),
     "settings":     ("mdi6.cog-outline",              "text"),
     "run":          ("mdi6.play",                     "success"),
+    "stop":         ("mdi6.stop-circle-outline",      "error"),
     "bulk_edit":    ("mdi6.pencil-outline",           "text"),
+    "columns":      ("mdi6.view-column-outline",      "text"),
     "highlight":    ("mdi6.flag-outline",             "warning"),
 
     # ---- Converter bottom tabs ----
@@ -107,6 +109,13 @@ NAMES: dict[str, tuple[str, str]] = {
     "info":         ("mdi6.information-outline",      "accent"),
     "close":        ("mdi6.close",                    "text"),
     "check":        ("mdi6.check",                    "success"),
+
+    # ---- Collapsible / detachable panel frame ----
+    "panel_collapse": ("mdi6.chevron-down",           "text"),
+    "panel_expand":   ("mdi6.chevron-right",          "text"),
+    "chevron_left":   ("mdi6.chevron-left",           "text"),
+    "detach":         ("mdi6.open-in-new",            "text"),
+    "reattach":       ("mdi6.dock-window",            "text"),
 }
 
 

--- a/bidsmgr/gui/icons.py
+++ b/bidsmgr/gui/icons.py
@@ -80,6 +80,8 @@ NAMES: dict[str, tuple[str, str]] = {
     "bulk_edit":    ("mdi6.pencil-outline",           "text"),
     "columns":      ("mdi6.view-column-outline",      "text"),
     "highlight":    ("mdi6.flag-outline",             "warning"),
+    "undo":         ("mdi6.undo-variant",             "text"),
+    "redo":         ("mdi6.redo-variant",             "text"),
 
     # ---- Converter bottom tabs ----
     "log":          ("mdi6.text-box-outline",         "text"),

--- a/bidsmgr/gui/icons.py
+++ b/bidsmgr/gui/icons.py
@@ -83,6 +83,7 @@ NAMES: dict[str, tuple[str, str]] = {
     "undo":         ("mdi6.undo-variant",             "text"),
     "redo":         ("mdi6.redo-variant",             "text"),
     "revalidate":   ("mdi6.refresh",                  "accent"),
+    "project":      ("mdi6.folder-multiple-outline",  "accent"),
 
     # ---- Converter bottom tabs ----
     "log":          ("mdi6.text-box-outline",         "text"),

--- a/bidsmgr/gui/icons.py
+++ b/bidsmgr/gui/icons.py
@@ -82,6 +82,7 @@ NAMES: dict[str, tuple[str, str]] = {
     "highlight":    ("mdi6.flag-outline",             "warning"),
     "undo":         ("mdi6.undo-variant",             "text"),
     "redo":         ("mdi6.redo-variant",             "text"),
+    "revalidate":   ("mdi6.refresh",                  "accent"),
 
     # ---- Converter bottom tabs ----
     "log":          ("mdi6.text-box-outline",         "text"),

--- a/bidsmgr/gui/main_window.py
+++ b/bidsmgr/gui/main_window.py
@@ -72,6 +72,7 @@ from ..project import Project
 from .converter_panel import ConverterPanel
 from .editor_panel import EditorPanel
 from .theme_manager import ThemeManager
+from .welcome_panel import WelcomePanel
 
 log = logging.getLogger(__name__)
 
@@ -142,6 +143,9 @@ class _TopHeader(QFrame):
         # View pills — Converter | Editor. The button group keeps the
         # two checkable buttons mutually exclusive; ``idClicked`` fires
         # whichever was just selected so we can re-emit a typed signal.
+        self._welcome_btn = QPushButton("Home")
+        self._welcome_btn.setObjectName("view-pill")
+        self._welcome_btn.setCheckable(True)
         self._converter_btn = QPushButton("Converter")
         self._converter_btn.setObjectName("view-pill")
         self._converter_btn.setCheckable(True)
@@ -151,9 +155,11 @@ class _TopHeader(QFrame):
         self._editor_btn.setCheckable(True)
         self._pill_group = QButtonGroup(self)
         self._pill_group.setExclusive(True)
+        self._pill_group.addButton(self._welcome_btn, 2)
         self._pill_group.addButton(self._converter_btn, 0)
         self._pill_group.addButton(self._editor_btn, 1)
         self._pill_group.idClicked.connect(self._on_pill_clicked)
+        h.addWidget(self._welcome_btn)
         h.addWidget(self._converter_btn)
         h.addWidget(self._editor_btn)
 
@@ -189,11 +195,15 @@ class _TopHeader(QFrame):
 
     def set_active_view(self, view: str) -> None:
         """Programmatically toggle the pills (no signal emitted)."""
-        target = self._editor_btn if view == "editor" else self._converter_btn
+        target = {
+            "welcome": self._welcome_btn,
+            "editor": self._editor_btn,
+        }.get(view, self._converter_btn)
         target.setChecked(True)
 
     def _on_pill_clicked(self, idx: int) -> None:
-        self.view_changed.emit("editor" if idx == 1 else "converter")
+        view = {2: "welcome", 1: "editor"}.get(idx, "converter")
+        self.view_changed.emit(view)
 
     def _on_toggle(self) -> None:
         from .app_settings import AppSettings
@@ -327,19 +337,26 @@ class MainWindow(QMainWindow):
         self.stack = QStackedWidget()
         self.converter = ConverterPanel(project=project)
         self.editor = EditorPanel()
+        self.welcome = WelcomePanel()
         self.stack.addWidget(self.converter)   # index 0 → "converter"
         self.stack.addWidget(self.editor)      # index 1 → "editor"
+        self.stack.addWidget(self.welcome)     # index 2 → "welcome"
         v.addWidget(self.stack, 1)
 
         self._header.view_changed.connect(self._on_view_changed)
         self._header.about_requested.connect(self._show_about_dialog)
         self._header.settings_requested.connect(self._open_settings)
+        self.welcome.project_opened.connect(self._on_project_opened)
 
-        # Restore the user's last view. Pills are syncronised silently
-        # so we don't fire a redundant ``view_changed`` on startup.
+        # Land on the Welcome (Home) tab when no project is bound (the
+        # project-first entry point). When a project was passed in (the
+        # ``--project`` path) restore the user's last Converter/Editor view.
         from .app_settings import AppSettings
         settings = AppSettings.load()
-        self._apply_active_view(settings.active_view, persist=False)
+        if self._project is not None:
+            self._apply_active_view(settings.active_view, persist=False)
+        else:
+            self._apply_active_view("welcome", persist=False)
 
         # Status bar — forwards the Converter's log messages so the
         # user sees scan / convert progress. The bottom-right corner
@@ -420,13 +437,34 @@ class MainWindow(QMainWindow):
 
     def _apply_active_view(self, view: str, *, persist: bool) -> None:
         """Switch the stacked widget and (optionally) persist the choice."""
-        if view not in ("converter", "editor"):
+        if view not in ("welcome", "converter", "editor"):
             view = "converter"
-        self.stack.setCurrentIndex(1 if view == "editor" else 0)
+        index = {"welcome": 2, "editor": 1}.get(view, 0)
+        self.stack.setCurrentIndex(index)
         self._header.set_active_view(view)
-        if persist:
+        # Only the working views are persisted; "welcome" is a transient
+        # landing, not a remembered preference.
+        if persist and view in ("converter", "editor"):
             from .app_settings import AppSettings
             AppSettings.remember_active_view(view)
+
+    def _on_project_opened(self, project: Project, bids_root: Path) -> None:
+        """Bind the project the user created/opened on Welcome and switch in.
+
+        The Converter's output is locked to ``bids_root`` (soft lock) and the
+        Editor is pointed at the same root so both views work inside the project.
+        """
+        self._project = project
+        self.converter.set_project(project, Path(bids_root))
+        # Point the Editor at the same root so both views work inside the
+        # project. ``_set_root`` is the Editor's open-root primitive.
+        set_root = getattr(self.editor, "_set_root", None)
+        if callable(set_root):
+            try:
+                set_root(Path(bids_root), persist=False)
+            except Exception as exc:  # never block entering the project
+                log.warning("editor could not open %s: %s", bids_root, exc)
+        self._apply_active_view("converter", persist=True)
 
     def _on_palette_changed(self, pal: dict) -> None:
         """Re-render every widget that holds palette-baked styling.
@@ -450,6 +488,8 @@ class MainWindow(QMainWindow):
             self.converter.repaint_for_palette(pal)
         if hasattr(self, "editor"):
             self.editor.repaint_for_palette(pal)
+        if hasattr(self, "welcome"):
+            self.welcome.repaint_for_palette(pal)
         # Force a viewport repaint on every delegate-driven view in
         # the window so cells / badges / row tints pick up new colors.
         for view in self.findChildren(QAbstractItemView):

--- a/bidsmgr/gui/main_window.py
+++ b/bidsmgr/gui/main_window.py
@@ -60,12 +60,14 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QMenu,
     QPushButton,
     QStackedWidget,
     QStatusBar,
     QTreeWidget,
     QVBoxLayout,
     QWidget,
+    QWidgetAction,
 )
 
 from ..project import Project
@@ -98,6 +100,44 @@ class _ClickableLabel(QLabel):
         super().mouseReleaseEvent(event)
 
 
+class _ProjectMenuRow(QWidget):
+    """A two-line row (dataset name + path) for the project-switcher menu.
+
+    Used both for the current project (display only) and for each recent
+    project (clickable -> switch). Emits :pyattr:`clicked` on release when
+    clickable. Styling is QSS-driven (object names ``proj-menu-*``).
+    """
+
+    clicked = pyqtSignal()
+
+    def __init__(self, name: str, path: str, *, current: bool, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("proj-menu-row-current" if current else "proj-menu-row")
+        self._clickable = not current
+        # A plain QWidget paints a QSS ``background`` (and its ``:hover``
+        # variant) only with WA_StyledBackground; WA_Hover delivers the hover
+        # events. Together they give the brighten-on-hover effect the home
+        # recents have.
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_Hover, True)
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(14, 6, 14, 6)
+        lay.setSpacing(1)
+        n = QLabel(name)
+        n.setObjectName("proj-menu-name")
+        p = QLabel(path)
+        p.setObjectName("proj-menu-path")
+        lay.addWidget(n)
+        lay.addWidget(p)
+        if self._clickable:
+            self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def mouseReleaseEvent(self, event) -> None:  # noqa: N802
+        if self._clickable and event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mouseReleaseEvent(event)
+
+
 class _TopHeader(QFrame):
     """Brand header with a Converter/Editor pill switcher and theme toggle.
 
@@ -112,6 +152,8 @@ class _TopHeader(QFrame):
     view_changed = pyqtSignal(str)  # "converter" | "editor"
     about_requested = pyqtSignal()
     settings_requested = pyqtSignal()
+    # A recent project was chosen from the project-switcher dropdown (Path).
+    project_switch_requested = pyqtSignal(object)
 
     def __init__(self, theme: ThemeManager, parent=None) -> None:
         super().__init__(parent)
@@ -163,6 +205,32 @@ class _TopHeader(QFrame):
         h.addWidget(self._converter_btn)
         h.addWidget(self._editor_btn)
 
+        # Project switcher (PyCharm-style), set apart from the Editor pill.
+        # Shows the current dataset name + a project icon; its dropdown lists
+        # the current project (name + path) and recent projects you can switch
+        # to. Hidden until a project is open.
+        h.addSpacing(18)
+        from . import icons as _icons
+        self._project_btn = QPushButton("(no project)")
+        self._project_btn.setObjectName("project-switcher")
+        self._project_btn.setToolTip("Current project. Click to switch.")
+        _icons.apply_button(self._project_btn, "project")
+        self._project_menu = QMenu(self)
+        self._project_menu.setObjectName("project-menu")
+        # Frameless + translucent so the QSS border-radius renders rounded
+        # corners cleanly (no square OS background / shadow behind them).
+        self._project_menu.setWindowFlags(
+            self._project_menu.windowFlags()
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.NoDropShadowWindowHint
+        )
+        self._project_menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self._project_menu.aboutToShow.connect(self._rebuild_project_menu)
+        self._project_btn.setMenu(self._project_menu)
+        self._project_btn.setVisible(False)
+        self._active_project_root: Optional[Path] = None
+        h.addWidget(self._project_btn)
+
         h.addStretch(1)
 
         self._theme = theme
@@ -204,6 +272,80 @@ class _TopHeader(QFrame):
     def _on_pill_clicked(self, idx: int) -> None:
         view = {2: "welcome", 1: "editor"}.get(idx, "converter")
         self.view_changed.emit(view)
+
+    # ------------------------------------------------------------------
+    # Project switcher
+    # ------------------------------------------------------------------
+
+    def set_active_project(self, name: str, root: Path) -> None:
+        """Show the switcher with ``name`` as the current project."""
+        self._active_project_root = Path(root)
+        self._project_btn.setText(name)
+        self._project_btn.setToolTip(f"{name}\n{root}\n\nClick to switch projects.")
+        self._project_btn.setVisible(True)
+
+    def clear_active_project(self) -> None:
+        """Hide the switcher (no project open)."""
+        self._active_project_root = None
+        self._project_btn.setVisible(False)
+
+    def _rebuild_project_menu(self) -> None:
+        """Repopulate the dropdown: current project header + recent projects."""
+        from .app_settings import AppSettings
+        from .welcome_panel import _dataset_display_name
+
+        menu = self._project_menu
+        menu.clear()
+
+        # Current project header (display only).
+        if self._active_project_root is not None:
+            cur = self._active_project_root
+            header = _ProjectMenuRow(
+                _dataset_display_name(cur), str(cur), current=True, parent=menu,
+            )
+            wa = QWidgetAction(menu)
+            wa.setDefaultWidget(header)
+            wa.setEnabled(False)
+            menu.addAction(wa)
+            menu.addSeparator()
+
+        # Recent projects (excluding the current one).
+        recents = [
+            p for p in AppSettings.load().recent_projects
+            if self._active_project_root is None
+            or Path(p) != self._active_project_root
+        ]
+        if recents:
+            label = QLabel("Recent projects")
+            label.setObjectName("proj-menu-section")
+            la = QWidgetAction(menu)
+            la.setDefaultWidget(label)
+            la.setEnabled(False)
+            menu.addAction(la)
+            for p in recents:
+                exists = Path(p).exists()
+                name = _dataset_display_name(Path(p)) if exists else Path(p).name
+                row = _ProjectMenuRow(
+                    name + ("   (missing)" if not exists else ""),
+                    str(p), current=False, parent=menu,
+                )
+                wa = QWidgetAction(menu)
+                wa.setDefaultWidget(row)
+                wa.setEnabled(exists)
+                if exists:
+                    row.clicked.connect(
+                        lambda _=False, path=Path(p): self._on_recent_chosen(path)
+                    )
+                menu.addAction(wa)
+            menu.addSeparator()
+
+        # Always offer the Home tab (open / create another).
+        open_act = menu.addAction("Open or create another… (Home)")
+        open_act.triggered.connect(lambda: self.view_changed.emit("welcome"))
+
+    def _on_recent_chosen(self, path: Path) -> None:
+        self._project_menu.close()
+        self.project_switch_requested.emit(path)
 
     def _on_toggle(self) -> None:
         from .app_settings import AppSettings
@@ -294,6 +436,7 @@ class _TopHeader(QFrame):
         self._apply_logo_pixmap(pal)
         from . import icons
         icons.apply_button(self._settings_btn, "settings")
+        icons.apply_button(self._project_btn, "project")
         icons.apply_button(
             self._theme_btn,
             "sun" if self._theme.name == "dark" else "moon",
@@ -347,6 +490,9 @@ class MainWindow(QMainWindow):
         self._header.about_requested.connect(self._show_about_dialog)
         self._header.settings_requested.connect(self._open_settings)
         self.welcome.project_opened.connect(self._on_project_opened)
+        # Project-switcher dropdown: opening a recent reuses the Welcome
+        # open-project flow (which re-emits project_opened -> _on_project_opened).
+        self._header.project_switch_requested.connect(self._on_switch_project)
 
         # Land on the Welcome (Home) tab when no project is bound (the
         # project-first entry point). When a project was passed in (the
@@ -464,7 +610,23 @@ class MainWindow(QMainWindow):
                 set_root(Path(bids_root), persist=False)
             except Exception as exc:  # never block entering the project
                 log.warning("editor could not open %s: %s", bids_root, exc)
+        # Reveal + label the header project switcher.
+        from .welcome_panel import _dataset_display_name
+        self._header.set_active_project(
+            _dataset_display_name(Path(bids_root)), Path(bids_root),
+        )
         self._apply_active_view("converter", persist=True)
+
+    def _on_switch_project(self, path: Path) -> None:
+        """A recent project was chosen from the header switcher.
+
+        Reuse the Welcome open-project flow so the bundle is opened/adopted and
+        ``project_opened`` re-binds both views (and re-labels the switcher).
+        """
+        try:
+            self.welcome.open_project(Path(path))
+        except Exception as exc:
+            log.warning("could not switch to project %s: %s", path, exc)
 
     def _on_palette_changed(self, pal: dict) -> None:
         """Re-render every widget that holds palette-baked styling.

--- a/bidsmgr/gui/main_window.py
+++ b/bidsmgr/gui/main_window.py
@@ -110,6 +110,7 @@ class _TopHeader(QFrame):
 
     view_changed = pyqtSignal(str)  # "converter" | "editor"
     about_requested = pyqtSignal()
+    settings_requested = pyqtSignal()
 
     def __init__(self, theme: ThemeManager, parent=None) -> None:
         super().__init__(parent)
@@ -159,10 +160,22 @@ class _TopHeader(QFrame):
         h.addStretch(1)
 
         self._theme = theme
+        from . import icons
+
+        # Settings gear, immediately left of the theme toggle. Lives in the
+        # header (not the converter toolbar) so it reads as a global control
+        # alongside the theme toggle and is reachable from either view.
+        self._settings_btn = QPushButton()
+        self._settings_btn.setObjectName("theme-toggle")  # same compact icon-button style
+        self._settings_btn.setToolTip("Settings")
+        self._settings_btn.setFixedSize(32, 28)
+        icons.apply_button(self._settings_btn, "settings")
+        self._settings_btn.clicked.connect(self.settings_requested.emit)
+        h.addWidget(self._settings_btn)
+
         # Icon-only toggle. ``sun`` glyph in dark mode (click to lighten),
         # ``moon`` glyph in light mode (click to darken). Re-tinted in
         # ``repaint_for_palette`` on every theme swap.
-        from . import icons
         self._theme_btn = QPushButton()
         self._theme_btn.setObjectName("theme-toggle")
         self._theme_btn.setToolTip("Toggle light / dark theme")
@@ -270,6 +283,7 @@ class _TopHeader(QFrame):
         """Reload the logo under the new palette (inverts when dark)."""
         self._apply_logo_pixmap(pal)
         from . import icons
+        icons.apply_button(self._settings_btn, "settings")
         icons.apply_button(
             self._theme_btn,
             "sun" if self._theme.name == "dark" else "moon",
@@ -319,6 +333,7 @@ class MainWindow(QMainWindow):
 
         self._header.view_changed.connect(self._on_view_changed)
         self._header.about_requested.connect(self._show_about_dialog)
+        self._header.settings_requested.connect(self._open_settings)
 
         # Restore the user's last view. Pills are syncronised silently
         # so we don't fire a redundant ``view_changed`` on startup.
@@ -353,6 +368,28 @@ class MainWindow(QMainWindow):
         # at construction time (delegate paints, inline ``setStyleSheet``)
         # repaint with the new palette without requiring an app restart.
         theme.add_listener(self._on_palette_changed)
+
+    def _open_settings(self) -> None:
+        """Open the Settings dialog (triggered by the header gear).
+
+        Lives on the window because the gear now sits in the global header
+        next to the theme toggle, so it must work from either view. On Save
+        we apply the font scale + theme live (the window owns the
+        ``ThemeManager``) and let the Converter pick up new scan / convert
+        defaults on its next run.
+        """
+        from .app_settings import AppSettings
+        from .settings_dialog import SettingsDialog
+        s = AppSettings.load()
+        dlg = SettingsDialog(s, self)
+        if dlg.exec() == dlg.DialogCode.Accepted:
+            # Font scale first, then theme — a single Save can change both
+            # and the theme re-apply re-substitutes the scaled QSS template.
+            self.apply_font_scale(s.font_scale)
+            self.apply_theme(s.theme)
+            reload_fn = getattr(self.converter, "reload_app_settings", None)
+            if callable(reload_fn):
+                reload_fn()
 
     def apply_theme(self, theme: str) -> None:
         """Switch the live theme. Called by the Settings dialog on save."""

--- a/bidsmgr/gui/metadata_help.py
+++ b/bidsmgr/gui/metadata_help.py
@@ -1,0 +1,83 @@
+"""Schema-sourced tooltips for the recording-metadata fields.
+
+Every editable metadata field maps to a real BIDS sidecar key (or a documented
+BIDS convention). The tooltip text is pulled live from the ``bidsschematools``
+schema so it always matches the installed BIDS version - which also guarantees
+the field we expose is a genuine schema key. A small set of fallbacks covers the
+handful of fields that are conventions (montage) or participants.tsv columns
+rather than sidecar-metadata keys.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+
+from .. import schema as schema_mod
+
+# UI field key -> BIDS ``objects.metadata`` key. ``None`` means the field is a
+# convention / non-metadata column; use ``_FALLBACKS``.
+_FIELD_BIDS_KEY: dict[str, str] = {
+    "manufacturer": "Manufacturer",
+    "amplifier_model": "ManufacturersModelName",
+    "software_versions": "SoftwareVersions",
+    "institution_name": "InstitutionName",
+    "institution_dept": "InstitutionalDepartmentName",
+    "line_freq": "PowerLineFrequency",
+    "eeg_reference": "EEGReference",
+    "eeg_ground": "EEGGround",
+    "cap_manufacturer": "CapManufacturer",
+    "cap_model": "CapManufacturersModelName",
+    # MEG-specific (manual only - channel-derived MEG fields are left to mne-bids)
+    "dewar_position": "DewarPosition",
+    "associated_empty_room": "AssociatedEmptyRoom",
+    "subject_artefact_description": "SubjectArtefactDescription",
+    "manufacturer_suggestion": "Manufacturer",
+}
+
+# Fields that are BIDS conventions or participants.tsv columns (not sidecar
+# metadata keys), so they are not in ``objects.metadata``.
+_FALLBACKS: dict[str, str] = {
+    "montage": (
+        "MNE montage applied on conversion; sets the electrode positions written "
+        "to electrodes.tsv. A BIDS convention, not a sidecar key."
+    ),
+    "PatientSex": "Participant sex (M / F / O). Written to participants.tsv (sex column).",
+    "PatientAge": "Participant age in years at acquisition. Written to participants.tsv (age column).",
+    "Handedness": "Participant handedness (R / L / A). Written to participants.tsv (handedness column).",
+    "event": (
+        "Map a recorded trigger code to a human-readable trial_type label in "
+        "events.tsv. Blank labels are left untouched."
+    ),
+}
+
+
+def _clean(text: str) -> str:
+    """Strip BIDS markdown (links, backticks) and collapse whitespace."""
+    t = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)  # [label](url) -> label
+    t = t.replace("`", "")
+    return re.sub(r"\s+", " ", t).strip()
+
+
+@functools.lru_cache(maxsize=256)
+def bids_tooltip(bids_key: str) -> str:
+    """Cleaned ``<display name>: <description>`` from the schema, or ``""``."""
+    try:
+        fi = schema_mod.field_metadata(bids_key)
+    except Exception:
+        return ""
+    desc = _clean(fi.description)
+    return f"{fi.display_name}: {desc}" if desc else fi.display_name
+
+
+def tooltip_for(ui_field_key: str) -> str:
+    """Tooltip for a metadata UI field (schema description, else a fallback)."""
+    bids_key = _FIELD_BIDS_KEY.get(ui_field_key)
+    if bids_key:
+        t = bids_tooltip(bids_key)
+        if t:
+            return t
+    return _FALLBACKS.get(ui_field_key, "")
+
+
+__all__ = ["bids_tooltip", "tooltip_for"]

--- a/bidsmgr/gui/models/__init__.py
+++ b/bidsmgr/gui/models/__init__.py
@@ -9,6 +9,7 @@
 """
 
 from .inventory import (
+    COLUMN_DESCRIPTIONS,
     COLUMNS,
     MANDATORY_COLUMN_KEYS,
     ColumnSpec,
@@ -17,6 +18,7 @@ from .inventory import (
 
 __all__ = [
     "COLUMNS",
+    "COLUMN_DESCRIPTIONS",
     "ColumnSpec",
     "InventoryTableModel",
     "MANDATORY_COLUMN_KEYS",

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -86,6 +86,48 @@ _ACQ_OVERRIDE_FIELDS: dict[str, str] = {
 
 
 # ---------------------------------------------------------------------------
+# Live entity-validation (re-runs on every user edit)
+# ---------------------------------------------------------------------------
+#
+# ``proposed_issues`` carries two kinds of note. *Static* notes describe the
+# source and cannot change once scanned (suspected_abort, B0 reroute, fmap
+# multi-output, non-image series, user-excluded, mixed-study / collision
+# hints). *Managed* notes are the schema entity-validation issues derived from
+# (entities, datatype, suffix); these DO change when the user edits a row, so
+# the model recomputes them on every edit and splices them back in, leaving the
+# static notes untouched. That keeps the valid / warning / error chips live.
+
+# Prefixes (the part before ``": "``) of a managed entity-validation issue.
+# Mirror ``schema.validate_entity_set`` rule_ids plus the scan's
+# ``build_basename: <exc>`` note. Kept narrow so a static note never matches.
+_MANAGED_ISSUE_PREFIXES: tuple[str, ...] = (
+    "datatype.",
+    "suffix.",
+    "entity.",
+    "basename.",
+    "build_basename",
+)
+# Managed notes that carry no ``": "`` separator.
+_MANAGED_ISSUE_EXACT: frozenset[str] = frozenset({"BIDS_name missing"})
+
+# Sentinel values the scan inserts for a missing required entity (see
+# ``cli/scan._placeholder_for_entity``). Live validation treats them as still
+# missing so a freshly-scanned row stays flagged until the user supplies a real
+# value, and reverts to valid the moment they do.
+_ENTITY_PLACEHOLDERS: dict[str, str] = {"task": "TASK", "subject": "TBD"}
+_DEFAULT_PLACEHOLDER = "TBD"
+
+
+def _is_managed_issue(token: str) -> bool:
+    """True when ``token`` is a recomputable entity-validation issue."""
+    t = token.strip()
+    if t in _MANAGED_ISSUE_EXACT:
+        return True
+    head = t.split(":", 1)[0].strip()
+    return head.startswith(_MANAGED_ISSUE_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
 # Column specification
 # ---------------------------------------------------------------------------
 
@@ -121,7 +163,10 @@ COLUMNS: tuple[ColumnSpec, ...] = (
     ColumnSpec("status",    "",                       "status",   False, 28),
     ColumnSpec("id",        "id",                     "mono",     False, 50, df_column="BIDS_name"),
     # Default-visible curated set.
-    ColumnSpec("dataset",   "dataset",                "plain",    True,  100, df_column="dataset"),
+    # Read-only: the dataset name is owned by the project (the locked output
+    # folder). Editing it by hand would point conversion at the wrong folder,
+    # so it is informative only and excluded from bulk edits.
+    ColumnSpec("dataset",   "dataset",                "plain",    False, 100, df_column="dataset"),
     ColumnSpec("ses",       "ses",                    "mono",     True,  50, df_column="session"),
     ColumnSpec("mod",       "mod",                    "plain",    False, 38, df_column="modality"),
     ColumnSpec("datatype",  "data",                   "plain",    True,  50, df_column="proposed_datatype"),
@@ -272,6 +317,14 @@ class InventoryTableModel(QAbstractTableModel):
 
         if project is not None:
             self._apply_project_overlay(project.state())
+
+        # Normalise ``proposed_issues`` to the live entity-validation state so a
+        # freshly-loaded TSV and a user-edited one read identically (load ==
+        # edit). Static scan notes are preserved; only the schema-validation
+        # segment is recomputed. Pure DataFrame mutation, no signals (we build
+        # the row-state cache from the result immediately below).
+        for i in range(len(self._df)):
+            self._revalidate_row(i)
 
         # Cache per-row state so delegates don't re-derive on every paint.
         # Invalidated for one row by :meth:`refresh_row`.
@@ -736,7 +789,8 @@ class InventoryTableModel(QAbstractTableModel):
     # targets (subject, dataset, task) come first.
     BULK_EDITABLE_KEYS: tuple[str, ...] = (
         "id",        # → subject entity + BIDS_name
-        "dataset",
+        # "dataset" is intentionally excluded: it is owned by the project /
+        # locked output folder and must never be changed by hand (see ColumnSpec).
         "ses",
         "task",
         "run",
@@ -861,16 +915,40 @@ class InventoryTableModel(QAbstractTableModel):
         """Re-derive cached state for ``row`` and notify the view.
 
         Call after any mutation that could affect row state (include
-        toggle, entity edit). Emits ``dataChanged`` for every column of
-        the row so per-row tints, badges, and mirror-cell text refresh
-        together.
+        toggle, entity edit). Re-runs live entity-validation first so the
+        warn / err / valid state reflects the edit, then emits
+        ``dataChanged`` for every column of the row so per-row tints,
+        badges, and mirror-cell text refresh together.
         """
         if not (0 <= row < len(self._df)):
             return
+        self._revalidate_row(row)
         self._row_states[row] = self._derive_row_state(row)
         left = self.index(row, 0)
         right = self.index(row, self.columnCount() - 1)
         self.dataChanged.emit(left, right)
+
+    def revalidate_all(self) -> None:
+        """Recompute every row's validation issues + state, then repaint.
+
+        Forces a full live re-validation: for each row the schema entity checks
+        run against its current entities / datatype / suffix, the managed
+        segment of ``proposed_issues`` is refreshed (static scan notes kept),
+        and the cached row state is rebuilt. Emits one ``dataChanged`` over the
+        whole table so delegates repaint and the controller's chip / preview /
+        stats listeners recompute. Backs the Converter's "Re-validate" button so
+        the valid / warning / error tallies are guaranteed current after any
+        batch of edits, no matter which edit path produced them.
+        """
+        if self.rowCount() == 0:
+            return
+        for i in range(len(self._df)):
+            self._revalidate_row(i)
+            self._row_states[i] = self._derive_row_state(i)
+        self.dataChanged.emit(
+            self.index(0, 0),
+            self.index(self.rowCount() - 1, self.columnCount() - 1),
+        )
 
     def dataframe(self) -> pd.DataFrame:
         """Return the live working DataFrame.
@@ -1059,6 +1137,80 @@ class InventoryTableModel(QAbstractTableModel):
         # ".97" — no leading zero, two decimal places.
         s = f"{v:.2f}"
         return s[1:] if s.startswith("0.") else s
+
+    # -------- live entity-validation --------
+
+    def _live_entity_issues(self, row: int) -> list[str]:
+        """Schema entity-validation issues for the row's *current* entities.
+
+        Returns the same ``"<rule_id>: <message>"`` strings the scan emits, so
+        they slot straight back into ``proposed_issues``. Skipped rows and rows
+        without a datatype/suffix produce none. Placeholder sentinels are
+        treated as missing (see :data:`_ENTITY_PLACEHOLDERS`).
+        """
+        if not (0 <= row < len(self._df)):
+            return []
+        if not self._read_include(row):
+            return []
+        # A row the scanner marked skip is not converted; don't validate it.
+        if "bids_guess_skip" in self._df.columns:
+            v = self._df.at[row, "bids_guess_skip"]
+            if isinstance(v, str):
+                if v.strip() in ("1", "true", "True"):
+                    return []
+            elif not pd.isna(v) and bool(v):
+                return []
+
+        datatype, suffix = self.datatype_suffix(row)
+        if not datatype or not suffix:
+            return []
+        # Derivatives use a bespoke path that the schema entity validator
+        # rejects wholesale; leave their notes to the scanner.
+        if datatype == "derivatives":
+            return []
+
+        ents = self.entities(row)
+        cleaned = {
+            k: v
+            for k, v in ents.items()
+            if v and v != _ENTITY_PLACEHOLDERS.get(k, _DEFAULT_PLACEHOLDER)
+        }
+        try:
+            verdicts = schema_mod.validate_entity_set(cleaned, datatype, suffix)
+        except Exception:  # pragma: no cover - schema lookups are defensive
+            log.debug("live entity validation failed for row %d", row, exc_info=True)
+            return []
+        return [
+            f"{v.rule_id}: {v.message}"
+            for v in verdicts
+            if v.severity is schema_mod.Severity.ERROR
+        ]
+
+    def _revalidate_row(self, row: int) -> bool:
+        """Recompute the managed (entity-validation) segment of ``proposed_issues``.
+
+        Static scan notes are preserved verbatim; only the schema-validation
+        issues are replaced with a fresh recompute of the row's current
+        entities. Mutates the DataFrame in place (no signal) and returns
+        ``True`` when the cell changed. Callers emit ``dataChanged`` via
+        :meth:`refresh_row`.
+        """
+        if not (0 <= row < len(self._df)):
+            return False
+        if "proposed_issues" not in self._df.columns:
+            return False
+        old_val = "" if pd.isna(self._df.at[row, "proposed_issues"]) else str(
+            self._df.at[row, "proposed_issues"]
+        )
+        existing = [t.strip() for t in old_val.split(" | ") if t.strip()]
+        static = [t for t in existing if not _is_managed_issue(t)]
+        fresh = self._live_entity_issues(row)
+        # Validation issues first (matches the scan's ordering), then static.
+        new_val = " | ".join(fresh + static)
+        if new_val == old_val:
+            return False
+        self._df.at[row, "proposed_issues"] = new_val
+        return True
 
     # -------- per-row state --------
 

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -123,6 +123,46 @@ COLUMNS: tuple[ColumnSpec, ...] = (
 MANDATORY_COLUMN_KEYS: frozenset[str] = frozenset({"include", "status", "id"})
 
 
+# Plain-language description per column, surfaced in the "Manage columns"
+# dialog so a non-technical user understands what each one means. Keyed by
+# ``ColumnSpec.key``.
+COLUMN_DESCRIPTIONS: dict[str, str] = {
+    "include":   "Whether this row is converted. Untick to skip the series.",
+    "status":    "At-a-glance state badge: ok, warning, error, skipped, non-image, or physio.",
+    "id":        "Subject label (sub-XXX) the row converts under.",
+    "dataset":   "BIDS dataset slug. Rows with different datasets become sibling BIDS roots.",
+    "ses":       "Session label (ses-XXX). Blank when the study has no sessions.",
+    "mod":       "Detected modality (mri, eeg, meg, physio, ...).",
+    "datatype":  "BIDS datatype folder the row lands in (anat, func, dwi, fmap, eeg, ...).",
+    "suffix":    "BIDS suffix (T1w, bold, dwi, physio, ...).",
+    "task":      "Task entity (task-XXX) for func / eeg / meg rows.",
+    "run":       "Run index (run-N) when a series was repeated.",
+    "conf":      "Classifier confidence (0-1) for the predicted datatype + suffix.",
+    "sequence":  "Scanner sequence name / source description used for classification.",
+    "basename":  "Full predicted BIDS filename (without extension).",
+    "backend":   "Converter backend that will handle the row: dcm2niix, mne-bids, or bidsphysio.",
+    "source_file": "Source recording path (EEG / MEG). Blank for DICOM rows.",
+    "n_files":   "Number of source files in the series.",
+    "acq_time":  "Acquisition time from the DICOM / recording header.",
+    "image_type": "DICOM ImageType (ORIGINAL / DERIVED, MAGNITUDE / PHASE, ...).",
+    "study_date": "Study date, used to cluster longitudinal sessions.",
+    "PatientID": "DICOM PatientID, a key part of subject identity.",
+    "GivenName": "Patient given name from the header.",
+    "FamilyName": "Patient family name from the header.",
+    "PatientSex": "Patient sex from the header.",
+    "PatientAge": "Patient age from the header.",
+    "n_channels": "EEG / MEG channel count.",
+    "sfreq":     "Sampling frequency (Hz) of the recording.",
+    "duration_sec": "Recording duration in seconds.",
+    "line_freq": "Power-line frequency (Hz) written to the sidecar. Editable.",
+    "montage":   "EEG / MEG montage applied on conversion. Editable.",
+    "probe_n_nifti": "NIfTI files dcm2niix actually produced in a --probe-convert run.",
+    "probe_n_vols":  "Volumes dcm2niix actually produced in a --probe-convert run.",
+    "repetition_type": "Repeat classification, e.g. suspected_abort (operator restart).",
+    "proposed_issues": "Scanner-detected notes: non-image series, B0 reroute, missing entity, ...",
+}
+
+
 # ---------------------------------------------------------------------------
 # Model
 # ---------------------------------------------------------------------------
@@ -155,6 +195,20 @@ class InventoryTableModel(QAbstractTableModel):
         super().__init__(parent)
         self._df: pd.DataFrame = df.reset_index(drop=True).copy()
         self._project: Optional[Project] = project
+
+        # Populate the mirror cells (session / task / run) from each row's
+        # ``entities`` JSON on load. A fresh ``bidsmgr-scan`` TSV carries the
+        # entities in JSON but leaves the mirror columns blank. Without this
+        # pass, editing one mirror cell (e.g. ``task``) runs
+        # ``rebuild_from_columns``, which reads the *other* still-blank mirror
+        # cells (e.g. ``run``) as "user cleared it" and drops those entities —
+        # so changing the task silently deleted ``run``. Mirroring entities →
+        # cells up front means a later single-cell edit only ever changes the
+        # field the user actually touched; every other entity is preserved.
+        # This matches what ``cli/convert.py`` does in memory before reading
+        # rows. Idempotent: ``proposed_basename`` is rebuilt from the same
+        # entities, so a well-formed scan TSV is unchanged.
+        rebuild_from_entities(self._df, in_place=True)
 
         if project is not None:
             self._apply_project_overlay(project.state())
@@ -842,4 +896,10 @@ class InventoryTableModel(QAbstractTableModel):
         return "ok"
 
 
-__all__ = ["COLUMNS", "ColumnSpec", "InventoryTableModel"]
+__all__ = [
+    "COLUMNS",
+    "COLUMN_DESCRIPTIONS",
+    "ColumnSpec",
+    "InventoryTableModel",
+    "MANDATORY_COLUMN_KEYS",
+]

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -606,16 +606,12 @@ class InventoryTableModel(QAbstractTableModel):
         """Return a stable per-row identifier used in project events.
 
         Prefers ``series_uid`` (MRI) → ``source_file`` (EEG/MEG) →
-        ``f"row-{row}"``. The fallback is purely positional so it
-        survives reopen only when the row order does; in practice
-        every real row carries one of the first two identifiers.
+        ``f"row-{row}"``. Delegates to the shared, Qt-free
+        :func:`bidsmgr.project.orchestration.row_id` so GUI-recorded edits
+        replay identically in the CLI (``--project``).
         """
-        for col in ("series_uid", "source_file"):
-            if col in self._df.columns:
-                v = self._df.at[row, col]
-                if isinstance(v, str) and v.strip():
-                    return v.strip()
-        return f"row-{row}"
+        from ...project.orchestration import row_id as _row_id
+        return _row_id(self._df, row)
 
     def entities(self, row: int) -> dict[str, str]:
         """Return the row's parsed entities dict, or empty if malformed.
@@ -965,60 +961,14 @@ class InventoryTableModel(QAbstractTableModel):
     def _apply_project_overlay(self, state: ProjectState) -> None:
         """Apply a ``ProjectState`` overlay to the working DataFrame.
 
-        Reverses the on-save semantics: for each row whose ``row_id``
-        appears in ``state``, the saved overrides are written back into
-        the DataFrame so the view shows the same thing as before the
-        save. Unknown row_ids are ignored (the inventory may have been
-        rescanned, dropping rows the project remembers).
+        Replays the saved curation edits (entity / cell / include overrides)
+        onto the table so reopening a project shows the same thing as before.
+        Delegates to the shared, Qt-free
+        :func:`bidsmgr.project.orchestration.apply_project_state` so the CLI
+        (``--project``) replays edits identically.
         """
-        if (
-            not state.cell_overrides
-            and not state.include_overrides
-            and not state.entity_overrides
-        ):
-            return
-
-        # Build row_id → df_index map once.
-        index_for_rid: dict[str, int] = {
-            self.row_id(i): i for i in range(len(self._df))
-        }
-
-        # Entity edits first (e.g. subject renames, task / session / run, and
-        # mirror-less entities like acquisition / direction). Mirrors
-        # ``set_entity`` without re-emitting events: update the entities JSON,
-        # keep ``BIDS_name`` in sync with ``subject``, then rebuild mirror cells.
-        if "entities" in self._df.columns:
-            for rid, ents in state.entity_overrides.items():
-                r = index_for_rid.get(rid)
-                if r is None:
-                    continue
-                current = self.entities(r)
-                for ent, val in ents.items():
-                    if val:
-                        current[ent] = val
-                    else:
-                        current.pop(ent, None)
-                    if ent == "subject" and "BIDS_name" in self._df.columns:
-                        self._df.at[r, "BIDS_name"] = f"sub-{val}" if val else ""
-                self._df.at[r, "entities"] = json.dumps(current, sort_keys=True)
-                self._rebuild_one_row(r, direction="entities")
-
-        for rid, cells in state.cell_overrides.items():
-            r = index_for_rid.get(rid)
-            if r is None:
-                continue
-            for col, val in cells.items():
-                if col in self._df.columns:
-                    self._df.at[r, col] = val
-            # Force a rebuild for the row so derived cells stay consistent.
-            self._rebuild_one_row(r)
-
-        if "include" in self._df.columns:
-            for rid, inc in state.include_overrides.items():
-                r = index_for_rid.get(rid)
-                if r is None:
-                    continue
-                self._df.at[r, "include"] = 1 if inc else 0
+        from ...project.orchestration import apply_project_state
+        apply_project_state(self._df, state)
 
     def _rebuild_one_row(self, row: int, *, direction: str = "columns") -> None:
         """Reconcile ``entities`` ↔ display cells for a single row.

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -45,9 +45,21 @@ from ...project import (
     UserToggleInclude,
 )
 from ...project.types import ProjectState
-from ..delegates import HIGHLIGHT_ROLE, PAYLOAD_ROLE, ROW_STATE_ROLE
+from ...recording_meta import RecordingMetaSpec
+from ..delegates import HIGHLIGHT_ROLE, INHERITED_ROLE, PAYLOAD_ROLE, ROW_STATE_ROLE
 
 log = logging.getLogger(__name__)
+
+# Per-row columns whose value inherits from the dataset-wide recording-metadata
+# default when the cell is blank. Maps the TSV/df column -> the attribute on
+# ``RecordingMetaSpec.defaults`` that supplies the default. Editing a cell to a
+# value equal to the default clears it back to "inherited".
+_INHERITANCE_FIELDS: dict[str, str] = {
+    "line_freq": "power_line_freq",
+    "montage": "montage",
+    "eeg_reference": "eeg_reference",
+    "eeg_ground": "eeg_ground",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -106,13 +118,17 @@ COLUMNS: tuple[ColumnSpec, ...] = (
     ColumnSpec("PatientID",    "PatientID",   "mono",  False, 100, df_column="PatientID",   default_visible=False),
     ColumnSpec("GivenName",    "GivenName",   "plain", False, 100, df_column="GivenName",   default_visible=False),
     ColumnSpec("FamilyName",   "FamilyName",  "plain", False, 100, df_column="FamilyName",  default_visible=False),
-    ColumnSpec("PatientSex",   "sex",         "mono",  False, 40,  df_column="PatientSex",  default_visible=False),
-    ColumnSpec("PatientAge",   "age",         "mono",  False, 50,  df_column="PatientAge",  default_visible=False),
+    ColumnSpec("PatientSex",   "sex",         "mono",  True,  40,  df_column="PatientSex",  default_visible=False),
+    ColumnSpec("PatientAge",   "age",         "mono",  True,  50,  df_column="PatientAge",  default_visible=False),
+    ColumnSpec("Handedness",   "hand",        "mono",  True,  50,  df_column="Handedness",  default_visible=False),
     ColumnSpec("n_channels",   "n_chan",      "mono",  False, 60,  df_column="n_channels",  default_visible=False),
     ColumnSpec("sfreq",        "sfreq",       "mono",  False, 70,  df_column="sfreq",       default_visible=False),
     ColumnSpec("duration_sec", "duration",    "mono",  False, 70,  df_column="duration_sec", default_visible=False),
     ColumnSpec("line_freq",    "line_freq",   "mono",  True,  60,  df_column="line_freq",   default_visible=False),
     ColumnSpec("montage",      "montage",     "plain", True,  100, df_column="montage",     default_visible=False),
+    ColumnSpec("eeg_reference","reference",   "plain", True,  90,  df_column="eeg_reference", default_visible=False),
+    ColumnSpec("eeg_ground",   "ground",      "plain", True,  90,  df_column="eeg_ground",  default_visible=False),
+    ColumnSpec("companion_files","companion", "plain", True,  140, df_column="companion_files", default_visible=False),
     ColumnSpec("probe_n_nifti","probe_nifti", "mono",  False, 80,  df_column="probe_n_nifti", default_visible=False),
     ColumnSpec("probe_n_vols", "probe_vols",  "mono",  False, 70,  df_column="probe_n_volumes", default_visible=False),
     ColumnSpec("repetition_type","repetition","plain", False, 110, df_column="repetition_type", default_visible=False),
@@ -149,13 +165,17 @@ COLUMN_DESCRIPTIONS: dict[str, str] = {
     "PatientID": "DICOM PatientID, a key part of subject identity.",
     "GivenName": "Patient given name from the header.",
     "FamilyName": "Patient family name from the header.",
-    "PatientSex": "Patient sex from the header.",
-    "PatientAge": "Patient age from the header.",
+    "PatientSex": "Participant sex (M/F/O). Seeded from the header; editable; written to participants.tsv.",
+    "PatientAge": "Participant age in years. Seeded from the header; editable; written to participants.tsv.",
+    "Handedness": "Participant handedness (R/L/A). Seeded from the recording header; editable.",
     "n_channels": "EEG / MEG channel count.",
     "sfreq":     "Sampling frequency (Hz) of the recording.",
     "duration_sec": "Recording duration in seconds.",
-    "line_freq": "Power-line frequency (Hz) written to the sidecar. Editable.",
-    "montage":   "EEG / MEG montage applied on conversion. Editable.",
+    "line_freq": "Power-line frequency (Hz) written to the sidecar. Dropdown (50 / 60); blank uses the dataset default.",
+    "montage":   "EEG / MEG montage applied on conversion. Dropdown of MNE built-in montages; blank leaves positions as-is.",
+    "eeg_reference": "Per-row EEG/iEEG reference electrode override (e.g. Cz). Blank uses the dataset default.",
+    "eeg_ground":    "Per-row EEG/iEEG ground electrode override. Blank uses the dataset default.",
+    "companion_files": "Already-curated companion files (events / beh / stim) linked to this row and copied into BIDS on convert. Edit via the Properties panel.",
     "probe_n_nifti": "NIfTI files dcm2niix actually produced in a --probe-convert run.",
     "probe_n_vols":  "Volumes dcm2niix actually produced in a --probe-convert run.",
     "repetition_type": "Repeat classification, e.g. suspected_abort (operator restart).",
@@ -195,6 +215,11 @@ class InventoryTableModel(QAbstractTableModel):
         super().__init__(parent)
         self._df: pd.DataFrame = df.reset_index(drop=True).copy()
         self._project: Optional[Project] = project
+        # Dataset-wide recording-metadata defaults. Per-row cells in the
+        # inheritance fields show this value (muted) when blank; set via
+        # :meth:`set_global_spec` when the scan scaffold loads / the dataset
+        # metadata dialog saves.
+        self._global_spec: Optional[RecordingMetaSpec] = None
 
         # Populate the mirror cells (session / task / run) from each row's
         # ``entities`` JSON on load. A fresh ``bidsmgr-scan`` TSV carries the
@@ -225,6 +250,53 @@ class InventoryTableModel(QAbstractTableModel):
         # These rows are already auto-unchecked by the scan, but
         # highlighting helps the user spot them at a glance.
         self._highlight_aborts: bool = False
+
+    # ------------------------------------------------------------------
+    # Recording-metadata inheritance (dataset default <- per-row override)
+    # ------------------------------------------------------------------
+
+    def set_global_spec(self, spec: Optional[RecordingMetaSpec]) -> None:
+        """Set the dataset-wide recording-metadata defaults and refresh display.
+
+        Inherited cells (blank in an inheritance field) now show the new
+        default; the underlying DataFrame is untouched. Emits ``dataChanged``
+        so every row re-renders with the new inherited values.
+        """
+        self._global_spec = spec
+        if len(self._df) and len(self.COLUMNS):
+            self.dataChanged.emit(
+                self.index(0, 0),
+                self.index(len(self._df) - 1, len(self.COLUMNS) - 1),
+            )
+
+    def _global_default(self, df_col: str) -> str:
+        """The dataset default for an inheritance field, as a display string."""
+        attr = _INHERITANCE_FIELDS.get(df_col)
+        if attr is None or self._global_spec is None:
+            return ""
+        val = getattr(self._global_spec.defaults, attr, None)
+        if val is None:
+            return ""
+        if isinstance(val, float):
+            return str(int(val)) if val == int(val) else str(val)
+        return str(val)
+
+    def _raw_cell(self, row: int, df_col: str) -> str:
+        if df_col not in self._df.columns or not (0 <= row < len(self._df)):
+            return ""
+        v = self._df.at[row, df_col]
+        return "" if pd.isna(v) else str(v)
+
+    def is_inherited(self, row: int, df_col: str) -> bool:
+        """True when an inheritance-field cell is blank and a default exists."""
+        if df_col not in _INHERITANCE_FIELDS:
+            return False
+        return not self._raw_cell(row, df_col).strip() and bool(self._global_default(df_col))
+
+    def effective_value(self, row: int, df_col: str) -> str:
+        """The per-row override (cell) when set, else the inherited default."""
+        cell = self._raw_cell(row, df_col).strip()
+        return cell if cell else self._global_default(df_col)
 
     # ------------------------------------------------------------------
     # Qt model API
@@ -290,6 +362,17 @@ class InventoryTableModel(QAbstractTableModel):
                 return self._status_kind(row)
             return None
 
+        # Inheritance fields: a blank cell shows the dataset default (and the
+        # delegate paints it muted via INHERITED_ROLE).
+        if spec.df_column in _INHERITANCE_FIELDS:
+            if role == INHERITED_ROLE:
+                return self.is_inherited(row, spec.df_column)
+            if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
+                eff = self.effective_value(row, spec.df_column)
+                if eff:
+                    return eff
+                return "—" if role == Qt.ItemDataRole.DisplayRole else ""
+
         if role == Qt.ItemDataRole.DisplayRole:
             return self._display_value(row, spec)
         if role == Qt.ItemDataRole.EditRole:
@@ -314,6 +397,11 @@ class InventoryTableModel(QAbstractTableModel):
         if df_col is None:
             return False
         new_str = "" if value is None else str(value)
+        # Inheritance fields: writing a value equal to the dataset default
+        # clears the cell back to "inherited" instead of storing a redundant
+        # per-row override (the convert/display layers re-resolve the default).
+        if df_col in _INHERITANCE_FIELDS and new_str == self._global_default(df_col):
+            new_str = ""
         old_str = "" if pd.isna(self._df.at[row, df_col]) else str(self._df.at[row, df_col])
         if new_str == old_str:
             return False
@@ -533,6 +621,12 @@ class InventoryTableModel(QAbstractTableModel):
         "suffix",
         "line_freq",
         "montage",
+        "eeg_reference",
+        "eeg_ground",
+        "PatientSex",
+        "PatientAge",
+        "Handedness",
+        "companion_files",
     )
 
     def bulk_set(

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -138,6 +138,7 @@ COLUMNS: tuple[ColumnSpec, ...] = (
     ColumnSpec("acq_time",     "acq_time",    "mono",  False, 80,  df_column="acq_time",    default_visible=False),
     ColumnSpec("image_type",   "image_type",  "mono",  False, 120, df_column="image_type",  default_visible=False),
     ColumnSpec("study_date",   "study_date",  "mono",  False, 90,  df_column="study_date",  default_visible=False),
+    ColumnSpec("StudyDescription", "study name", "plain", False, 160, df_column="StudyDescription", default_visible=False),
     ColumnSpec("PatientID",    "PatientID",   "mono",  False, 100, df_column="PatientID",   default_visible=False),
     ColumnSpec("GivenName",    "GivenName",   "plain", False, 100, df_column="GivenName",   default_visible=False),
     ColumnSpec("FamilyName",   "FamilyName",  "plain", False, 100, df_column="FamilyName",  default_visible=False),
@@ -185,6 +186,7 @@ COLUMN_DESCRIPTIONS: dict[str, str] = {
     "acq_time":  "Acquisition time from the DICOM / recording header.",
     "image_type": "DICOM ImageType (ORIGINAL / DERIVED, MAGNITUDE / PHASE, ...).",
     "study_date": "Study date, used to cluster longitudinal sessions.",
+    "StudyDescription": "DICOM StudyDescription (the study / protocol name). Read-only, MRI only. Not a BIDS entity; shown for awareness. Multiple distinct values in one scan raise a warning.",
     "PatientID": "DICOM PatientID, a key part of subject identity.",
     "GivenName": "Patient given name from the header.",
     "FamilyName": "Patient family name from the header.",
@@ -234,6 +236,10 @@ class InventoryTableModel(QAbstractTableModel):
     # persists the recording-metadata scaffold to disk so the convert verb,
     # which reloads it, sees the edit.
     recordingSpecChanged = pyqtSignal()
+    # Emitted whenever the user makes a curation edit (cell / entity / include).
+    # The converter uses it to invalidate its redo stack: a fresh edit diverges
+    # the timeline, so previously-undone edits can no longer be redone.
+    userEdited = pyqtSignal()
 
     def __init__(
         self,
@@ -520,15 +526,14 @@ class InventoryTableModel(QAbstractTableModel):
             return False
 
         # Order: record the event first (durable), then mutate.
-        if self._project is not None:
-            self._project.append(
-                UserSetCell(
-                    row_id=self.row_id(row),
-                    column=df_col,
-                    value=new_str,
-                    previous=old_str,
-                )
+        self._record_edit(
+            UserSetCell(
+                row_id=self.row_id(row),
+                column=df_col,
+                value=new_str,
+                previous=old_str,
             )
+        )
         self._df.at[row, df_col] = new_str
 
         # Mirror cells (session / task / run) feed the entities JSON.
@@ -582,6 +587,12 @@ class InventoryTableModel(QAbstractTableModel):
             return {}
         return {k: str(v) for k, v in data.items()} if isinstance(data, dict) else {}
 
+    def _record_edit(self, event) -> None:
+        """Append a user-edit event to the project (if any) and signal it."""
+        if self._project is not None:
+            self._project.append(event)
+        self.userEdited.emit()
+
     def set_entity(
         self,
         row: int,
@@ -612,15 +623,14 @@ class InventoryTableModel(QAbstractTableModel):
         if new_value == previous:
             return False
 
-        if self._project is not None:
-            self._project.append(
-                UserSetEntity(
-                    row_id=self.row_id(row),
-                    entity=entity,
-                    value=new_value or None,
-                    previous=previous or None,
-                )
+        self._record_edit(
+            UserSetEntity(
+                row_id=self.row_id(row),
+                entity=entity,
+                value=new_value or None,
+                previous=previous or None,
             )
+        )
 
         if new_value:
             current[entity] = new_value
@@ -832,15 +842,14 @@ class InventoryTableModel(QAbstractTableModel):
             new = str(val)
             if new == old:
                 continue
-            if self._project is not None:
-                self._project.append(
-                    UserSetCell(
-                        row_id=self.row_id(row),
-                        column=col,
-                        value=new,
-                        previous=old,
-                    )
+            self._record_edit(
+                UserSetCell(
+                    row_id=self.row_id(row),
+                    column=col,
+                    value=new,
+                    previous=old,
                 )
+            )
             self._df.at[row, col] = new
             changed = True
         if changed:
@@ -884,13 +893,37 @@ class InventoryTableModel(QAbstractTableModel):
         save. Unknown row_ids are ignored (the inventory may have been
         rescanned, dropping rows the project remembers).
         """
-        if not state.cell_overrides and not state.include_overrides:
+        if (
+            not state.cell_overrides
+            and not state.include_overrides
+            and not state.entity_overrides
+        ):
             return
 
         # Build row_id → df_index map once.
         index_for_rid: dict[str, int] = {
             self.row_id(i): i for i in range(len(self._df))
         }
+
+        # Entity edits first (e.g. subject renames, task / session / run, and
+        # mirror-less entities like acquisition / direction). Mirrors
+        # ``set_entity`` without re-emitting events: update the entities JSON,
+        # keep ``BIDS_name`` in sync with ``subject``, then rebuild mirror cells.
+        if "entities" in self._df.columns:
+            for rid, ents in state.entity_overrides.items():
+                r = index_for_rid.get(rid)
+                if r is None:
+                    continue
+                current = self.entities(r)
+                for ent, val in ents.items():
+                    if val:
+                        current[ent] = val
+                    else:
+                        current.pop(ent, None)
+                    if ent == "subject" and "BIDS_name" in self._df.columns:
+                        self._df.at[r, "BIDS_name"] = f"sub-{val}" if val else ""
+                self._df.at[r, "entities"] = json.dumps(current, sort_keys=True)
+                self._rebuild_one_row(r, direction="entities")
 
         for rid, cells in state.cell_overrides.items():
             r = index_for_rid.get(rid)
@@ -949,10 +982,9 @@ class InventoryTableModel(QAbstractTableModel):
 
     def _set_include(self, row: int, included: bool) -> None:
         """Persist a new include flag (event first, then DataFrame)."""
-        if self._project is not None:
-            self._project.append(
-                UserToggleInclude(row_id=self.row_id(row), include=included)
-            )
+        self._record_edit(
+            UserToggleInclude(row_id=self.row_id(row), include=included)
+        )
         if "include" not in self._df.columns:
             self._df["include"] = 1
         self._df.at[row, "include"] = 1 if included else 0

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -214,6 +214,17 @@ class InventoryTableModel(QAbstractTableModel):
         if role == HIGHLIGHT_ROLE:
             return self._highlight_aborts and self.is_row_aborted(row)
 
+        # Hovering any cell of a flagged row surfaces the scanner's
+        # ``proposed_issues`` (e.g. the "non-image series" reason) so the
+        # user sees *why* a row is highlighted without unhiding the issues
+        # column. Newline-split the `` | ``-joined notes for readability.
+        if role == Qt.ItemDataRole.ToolTipRole:
+            if "proposed_issues" in self._df.columns:
+                issues = str(self._df.at[row, "proposed_issues"] or "").strip()
+                if issues:
+                    return issues.replace(" | ", "\n")
+            return None
+
         # Checkbox and status cells communicate via PAYLOAD_ROLE instead
         # of DisplayRole; they have no text body.
         if spec.role == "checkbox":
@@ -764,6 +775,17 @@ class InventoryTableModel(QAbstractTableModel):
         Drives the row tint applied by every delegate. Selection is
         applied by the view at paint time, not stored here.
         """
+        # Non-image DERIVED objects (no pixel data; e.g. a Siemens TENSOR
+        # map) are flagged by the scanner via the ``non-image series``
+        # token in ``proposed_issues`` (see ``cli/scan.NONIMAGE_ISSUE_TOKEN``).
+        # They are excluded from conversion (include=0) but must still read
+        # as a deliberate, highlighted "not an image" state rather than a
+        # de-emphasised skip — so this check wins over the include check.
+        if "proposed_issues" in self._df.columns:
+            issues_l = str(self._df.at[row, "proposed_issues"] or "").lower()
+            if "non-image series" in issues_l:
+                return "noimg"
+
         if not self._read_include(row):
             return "skip"
 
@@ -807,6 +829,8 @@ class InventoryTableModel(QAbstractTableModel):
         keep their distinct icon.
         """
         state = self._row_states[row]
+        if state == "noimg":
+            return "noimg"
         if state == "skip":
             return "skip"
         if state == "err":

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import pandas as pd
-from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
 
 from ... import schema as schema_mod
 from ...inventory.rebuild import rebuild_from_columns, rebuild_from_entities
@@ -45,7 +45,7 @@ from ...project import (
     UserToggleInclude,
 )
 from ...project.types import ProjectState
-from ...recording_meta import RecordingMetaSpec
+from ...recording_meta import AcquisitionSpec, RecordingMetaSpec
 from ..delegates import HIGHLIGHT_ROLE, INHERITED_ROLE, PAYLOAD_ROLE, ROW_STATE_ROLE
 
 log = logging.getLogger(__name__)
@@ -59,6 +59,29 @@ _INHERITANCE_FIELDS: dict[str, str] = {
     "montage": "montage",
     "eeg_reference": "eeg_reference",
     "eeg_ground": "eeg_ground",
+}
+
+# Per-row recording-acquisition fields that live in the recording-metadata
+# scaffold's ``overrides[row_id]`` block rather than a TSV column (the convert
+# step's ``resolve_effective`` already layers them over the dataset defaults and
+# the enrichment fixup writes them into the EEG/MEG sidecar). These are the
+# device / institution values that can differ between subjects but are too
+# low-frequency to warrant a spreadsheet column. Maps the panel key -> the
+# attribute on ``AcquisitionSpec``. A blank override inherits the dataset
+# default; setting a value equal to the default clears the override.
+# Device fields are modality-specific (the EEG amplifier and the MEG system are
+# different devices); institution is agnostic and lives at dataset level in the
+# Dataset-metadata dialog, NOT here. MEG fields are only the ones mne-bids
+# cannot derive. All are string-valued.
+_ACQ_OVERRIDE_FIELDS: dict[str, str] = {
+    "manufacturer": "manufacturer",
+    "amplifier_model": "amplifier_model",
+    "software_versions": "software_versions",
+    "cap_manufacturer": "cap_manufacturer",
+    # MEG-specific (manual only)
+    "dewar_position": "dewar_position",
+    "associated_empty_room": "associated_empty_room",
+    "subject_artefact_description": "subject_artefact_description",
 }
 
 
@@ -206,6 +229,12 @@ class InventoryTableModel(QAbstractTableModel):
 
     COLUMNS: tuple[ColumnSpec, ...] = COLUMNS
 
+    # Emitted when a per-row acquisition override changes (set/cleared via
+    # :meth:`set_acq_override`). The controller (ConverterPanel) listens and
+    # persists the recording-metadata scaffold to disk so the convert verb,
+    # which reloads it, sees the edit.
+    recordingSpecChanged = pyqtSignal()
+
     def __init__(
         self,
         df: pd.DataFrame,
@@ -297,6 +326,90 @@ class InventoryTableModel(QAbstractTableModel):
         """The per-row override (cell) when set, else the inherited default."""
         cell = self._raw_cell(row, df_col).strip()
         return cell if cell else self._global_default(df_col)
+
+    # ------------------------------------------------------------------
+    # Per-row acquisition overrides (recording-metadata scaffold-backed)
+    # ------------------------------------------------------------------
+    #
+    # These device / institution fields are NOT TSV columns; they live in the
+    # scaffold's ``overrides[row_id]`` and inherit from ``defaults`` the same
+    # way the TSV-backed inheritance fields do. The convert step's
+    # ``resolve_effective`` already merges them and the enrichment fixup writes
+    # them into the EEG/MEG sidecar.
+
+    def global_spec(self) -> Optional[RecordingMetaSpec]:
+        """The live recording-metadata spec (defaults + per-row overrides)."""
+        return self._global_spec
+
+    def acq_default(self, field: str) -> str:
+        """The dataset default for an acquisition-override field, as a string."""
+        attr = _ACQ_OVERRIDE_FIELDS.get(field)
+        if attr is None or self._global_spec is None:
+            return ""
+        val = getattr(self._global_spec.defaults, attr, None)
+        return "" if val is None else str(val)
+
+    def _row_override(self, row: int) -> Optional[AcquisitionSpec]:
+        if self._global_spec is None:
+            return None
+        return self._global_spec.overrides.get(self.row_id(row))
+
+    def acq_override(self, row: int, field: str) -> str:
+        """The raw per-row override for an acquisition field (``""`` if unset)."""
+        attr = _ACQ_OVERRIDE_FIELDS.get(field)
+        if attr is None:
+            return ""
+        over = self._row_override(row)
+        if over is None:
+            return ""
+        val = getattr(over, attr, None)
+        return "" if val is None else str(val)
+
+    def acq_effective(self, row: int, field: str) -> str:
+        """Per-row override when set, else the inherited dataset default."""
+        ov = self.acq_override(row, field)
+        return ov if ov else self.acq_default(field)
+
+    def acq_is_inherited(self, row: int, field: str) -> bool:
+        """True when no per-row override is set and a dataset default exists."""
+        return not self.acq_override(row, field) and bool(self.acq_default(field))
+
+    def set_acq_override(self, row: int, field: str, value: str) -> bool:
+        """Set or clear a per-row acquisition override in the scaffold spec.
+
+        Writing a value equal to the dataset default (or an empty value) clears
+        the override so the row inherits again. Mutates the live spec and emits
+        :attr:`recordingSpecChanged` (the controller persists the scaffold) plus
+        ``dataChanged`` for the row. Returns ``True`` if anything changed.
+        """
+        attr = _ACQ_OVERRIDE_FIELDS.get(field)
+        if attr is None or not (0 <= row < len(self._df)):
+            return False
+        if self._global_spec is None:
+            self._global_spec = RecordingMetaSpec()
+
+        new_val = (value or "").strip()
+        # Equal to the dataset default -> inherit (store no override).
+        if new_val == self.acq_default(field):
+            new_val = ""
+
+        if new_val == self.acq_override(row, field):
+            return False
+
+        rid = self.row_id(row)
+        overrides = dict(self._global_spec.overrides)
+        current = overrides.get(rid) or AcquisitionSpec()
+        updated = current.model_copy(update={attr: (new_val or None)})
+
+        if updated == AcquisitionSpec():
+            overrides.pop(rid, None)
+        else:
+            overrides[rid] = updated
+        self._global_spec = self._global_spec.model_copy(update={"overrides": overrides})
+
+        self.recordingSpecChanged.emit()
+        self.refresh_row(row)
+        return True
 
     # ------------------------------------------------------------------
     # Qt model API

--- a/bidsmgr/gui/output_fs_pane.py
+++ b/bidsmgr/gui/output_fs_pane.py
@@ -376,16 +376,18 @@ class OutputFsPane(QWidget):
         pal = CUR()
         root_item = _render_node(result.root, pal)
         self._tree.addTopLevelItem(root_item)
-        root_item.setExpanded(True)
 
         if snap is None:
-            # First-time render: auto-expand the first level
-            # (each ``<dataset>/`` folder) so the user immediately
-            # sees the converted shape.
+            # First-time render: expand the root + first level so the user
+            # immediately sees the shape.
+            root_item.setExpanded(True)
             for i in range(root_item.childCount()):
                 root_item.child(i).setExpanded(True)
         else:
-            # Subsequent rebuilds — defer to whatever the user had open.
+            # Subsequent rebuilds (watcher-triggered during convert, etc.) must
+            # respect whatever the user had open -- including a collapsed root.
+            # Do NOT force the root expanded here, or a refresh re-expands a
+            # folder the user just collapsed.
             self._restore_state(snap)
 
         self._last_rendered_root = self._root

--- a/bidsmgr/gui/properties_panel.py
+++ b/bidsmgr/gui/properties_panel.py
@@ -53,7 +53,9 @@ import pandas as pd
 
 from .. import schema as schema_mod
 from ..project import Project
+from ..recording_meta import COMMON_CAP_MANUFACTURERS, COMMON_MANUFACTURERS
 from .delegates import builtin_montages
+from .metadata_help import tooltip_for
 from .models import InventoryTableModel
 from .theme_manager import CUR, scaled_px
 from .widgets import PaneHeader, ValMessage
@@ -61,6 +63,15 @@ from .widgets import PaneHeader, ValMessage
 # Datatypes that carry recording-metadata (the per-row section appears only
 # for these). MEG has no scalp montage / reference / ground concept.
 _EEG_MEG_DATATYPES = frozenset({"eeg", "meg", "ieeg", "nirs"})
+
+# Human display names for the datatypes that carry a recording sidecar.
+_MODALITY_NAMES = {"eeg": "EEG", "meg": "MEG", "ieeg": "iEEG", "nirs": "NIRS"}
+
+
+def _modality_label(datatype: str) -> str:
+    """Display name for a single datatype (``eeg`` -> ``EEG``)."""
+    return _MODALITY_NAMES.get(datatype, datatype.upper())
+
 
 log = logging.getLogger(__name__)
 
@@ -317,20 +328,27 @@ class PropertiesPanel(QWidget):
         for vmsg in self._build_validation_messages(datatype, suffix, entities):
             self._body_layout.addWidget(vmsg)
 
-        # 5. Per-row metadata, grouped by destination file. The participant
-        # section is modality-agnostic (every row, incl. MRI); the recording
-        # sidecar section only for EEG/MEG/iEEG/NIRS.
+        # 5. Per-row metadata, split into two clearly-separated regions:
+        # modality-agnostic (participant demographics + companion files, written
+        # for any modality incl. MRI) and modality-specific (the recording
+        # sidecar, EEG/MEG/iEEG/NIRS only). Sections within each region are
+        # labelled by their BIDS destination file.
+        self._append_metadata_title()
+        self._append_region_label("Modality-agnostic", agnostic=True)
         self._append_participant_section(row)
-        if datatype in _EEG_MEG_DATATYPES:
-            self._append_recording_section(row, datatype)
         self._append_companion_section(row)
+        if datatype in _EEG_MEG_DATATYPES:
+            self._append_region_label("Modality-specific", agnostic=False)
+            self._append_recording_section(row, datatype)
 
         self._body_layout.addStretch(1)
 
     def _build_combo_row(self, label_text: str, value: str, *, options: list[str],
                          required: bool, slot) -> QWidget:
         row = QWidget()
-        row.setStyleSheet("background: transparent;")
+        # Scoped so the transparent bg does not cascade into the combo popup.
+        row.setObjectName("meta-row")
+        row.setStyleSheet("#meta-row { background: transparent; }")
         h = QHBoxLayout(row)
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(8)
@@ -540,12 +558,63 @@ class PropertiesPanel(QWidget):
     # Per-row metadata, grouped by destination file
     # ------------------------------------------------------------------
 
-    def _section_header(self, title: str, destination: str) -> QWidget:
-        """A section title plus a dim ``-> <destination file>`` annotation."""
+    def _region_label(self, text: str, *, agnostic: bool) -> QWidget:
+        """A bold, colour-coded region divider separating the two metadata
+        regions (modality-agnostic vs modality-specific)."""
         pal = CUR()
+        color = pal["teal"] if agnostic else pal["purple"]
         lbl = QLabel(
-            f'<span style="color:{pal["text"]};font-weight:600;">{title}</span>'
-            f'<span style="color:{pal["dim"]};"> &rarr; {destination}</span>'
+            f'<span style="color:{color};font-weight:800;'
+            f'letter-spacing:0.6px;">{text.upper()}</span>'
+        )
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        lbl.setStyleSheet(
+            f"font-size: {scaled_px(10)}px; background: transparent; "
+            f"border-bottom: 1px solid {color}; padding-bottom: 2px;"
+        )
+        return lbl
+
+    def _append_region_label(self, text: str, *, agnostic: bool) -> None:
+        self._body_layout.addSpacing(10)
+        self._body_layout.addWidget(self._region_label(text, agnostic=agnostic))
+
+    def _append_metadata_title(self) -> None:
+        """Heading that frames the per-row metadata block as the minimal,
+        BIDS-recommended set (everything below is optional and inherits the
+        dataset defaults)."""
+        pal = CUR()
+        self._body_layout.addSpacing(12)
+        self._body_layout.addWidget(self._divider())
+        title = QLabel("MINIMAL METADATA")
+        title.setStyleSheet(
+            f"color: {pal['text']}; font-weight: 800; letter-spacing: 0.6px; "
+            f"font-size: {scaled_px(11)}px; background: transparent;"
+        )
+        self._body_layout.addWidget(title)
+        sub = QLabel(
+            "Essential BIDS fields for this recording. All optional; blank "
+            "fields inherit the dataset defaults set in Dataset metadata."
+        )
+        sub.setWordWrap(True)
+        sub.setStyleSheet(
+            f"color: {pal['dim']}; font-size: {scaled_px(9)}px; background: transparent;"
+        )
+        self._body_layout.addWidget(sub)
+
+    def _section_header(
+        self, title: str, destination: str, *, agnostic: bool, tag: str,
+    ) -> QWidget:
+        """A colour-coded section title plus a dim ``<tag> -> <destination>`` note.
+
+        ``agnostic`` colours the title; ``tag`` states which modalities the
+        section applies to (``any modality`` for agnostic sections, or the
+        recording's modality such as ``EEG``) so the destination is unambiguous.
+        """
+        pal = CUR()
+        color = pal["teal"] if agnostic else pal["purple"]
+        lbl = QLabel(
+            f'<span style="color:{color};font-weight:700;">{title}</span>'
+            f'<span style="color:{pal["dim"]};"> &middot; {tag} &rarr; {destination}</span>'
         )
         lbl.setTextFormat(Qt.TextFormat.RichText)
         lbl.setStyleSheet(f"font-size: {scaled_px(10)}px; background: transparent;")
@@ -559,7 +628,8 @@ class PropertiesPanel(QWidget):
         """
         self._body_layout.addSpacing(8)
         self._body_layout.addWidget(self._divider())
-        self._body_layout.addWidget(self._section_header("PARTICIPANT", "participants.tsv"))
+        self._body_layout.addWidget(self._section_header(
+            "PARTICIPANT", "participants.tsv", agnostic=True, tag="any modality"))
         self._body_layout.addWidget(self._meta_combo_row(
             "sex", "PatientSex", ["", "M", "F", "O"], self._cell(row, "PatientSex"), "",
         ))
@@ -571,38 +641,140 @@ class PropertiesPanel(QWidget):
         ))
 
     def _append_recording_section(self, row: int, datatype: str) -> None:
-        """EEG/MEG/iEEG/NIRS sidecar fields -> sub-..._<datatype>.json.
+        """EEG/MEG/iEEG/NIRS recording-sidecar fields -> sub-..._<datatype>.json.
 
-        Inheritance fields show the EFFECTIVE value (per-row override, else the
-        dataset default); writing the default clears the override. Fields that
-        do not apply to the datatype are not shown (MEG has no scalp montage /
-        reference / ground).
+        Up to three BIDS-aligned sub-sections: an Acquisition block (device +
+        line frequency - shared by all electrophysiology sidecars), a Reference
+        & montage block (EEG/iEEG only - MEG and NIRS have no scalp
+        reference/ground/montage), and a MEG-acquisition block (MEG only).
+        Institution is agnostic and lives in the Dataset-metadata dialog, NOT
+        here. Inheritance fields show the EFFECTIVE value (per-row override, else
+        the dataset default); writing the default clears the override.
         """
+        mod = _modality_label(datatype)
+        show_montage = datatype in ("eeg", "ieeg")
+        show_ref_ground = datatype in ("eeg", "ieeg")
+        show_cap = datatype == "eeg"
+
+        # --- Acquisition: device + line frequency (the recording's hardware).
+        # Institution is agnostic (set once for the dataset in Dataset metadata),
+        # NOT here. Device overrides live in the scaffold's overrides[row_id]
+        # (not a TSV column); each inherits the dataset default until set, and
+        # clearing it (or matching the default) restores inheritance.
         self._body_layout.addSpacing(8)
         self._body_layout.addWidget(self._divider())
         self._body_layout.addWidget(self._section_header(
-            "RECORDING", f"sub-..._{datatype}.json"))
-
-        show_montage = datatype in ("eeg", "ieeg", "nirs")
-        show_ref_ground = datatype in ("eeg", "ieeg")
-
-        if show_montage:
-            self._body_layout.addWidget(self._meta_combo_row(
-                "montage", "montage",
-                ["(none)"] + builtin_montages(), self._eff(row, "montage"), "(none)",
-            ))
+            "ACQUISITION", f"sub-..._{datatype}.json", agnostic=False, tag=mod))
         lf = self._eff(row, "line_freq")
         lf = lf[:-2] if lf.endswith(".0") else lf
         self._body_layout.addWidget(self._meta_combo_row(
             "line_freq", "line_freq", ["(blank)", "50", "60"], lf, "(blank)",
         ))
-        if show_ref_ground:
-            self._body_layout.addWidget(self._meta_edit_row(
-                "reference", "eeg_reference", self._eff(row, "eeg_reference"),
+        self._body_layout.addWidget(self._meta_combo_row(
+            "manufacturer", "manufacturer",
+            [""] + list(COMMON_MANUFACTURERS), self._acq_eff(row, "manufacturer"), "",
+            setter=self._on_acq_field_changed, editable=True,
+        ))
+        # Scan-detected/inferred manufacturer, shown like the montage match (a
+        # read-only suggestion; not auto-applied - mne-bids fills MEG itself).
+        manuf_sugg = self._cell(row, "manufacturer_suggestion")
+        if manuf_sugg:
+            self._body_layout.addWidget(
+                self._scan_hint("manufacturer", "scan detected", manuf_sugg))
+        self._body_layout.addWidget(self._meta_edit_row(
+            "model", "amplifier_model", self._acq_eff(row, "amplifier_model"),
+            setter=self._on_acq_field_changed,
+        ))
+        self._body_layout.addWidget(self._meta_edit_row(
+            "software", "software_versions", self._acq_eff(row, "software_versions"),
+            setter=self._on_acq_field_changed,
+        ))
+
+        # --- Reference & montage: EEG/iEEG scalp fields only.
+        if show_montage or show_ref_ground:
+            self._body_layout.addSpacing(8)
+            self._body_layout.addWidget(self._divider())
+            self._body_layout.addWidget(self._section_header(
+                "REFERENCE & MONTAGE",
+                f"sub-..._{datatype}.json + electrodes.tsv",
+                agnostic=False, tag=mod))
+            if show_ref_ground:
+                self._body_layout.addWidget(self._meta_edit_row(
+                    "reference", "eeg_reference", self._eff(row, "eeg_reference"),
+                ))
+                self._body_layout.addWidget(self._meta_edit_row(
+                    "ground", "eeg_ground", self._eff(row, "eeg_ground"),
+                ))
+            if show_montage:
+                self._body_layout.addWidget(self._meta_combo_row(
+                    "montage", "montage",
+                    ["(none)"] + builtin_montages(), self._eff(row, "montage"), "(none)",
+                ))
+                # Surface the scan's best channel-name match as a read-only hint
+                # so the user can pick the montage with confidence (the scan does
+                # not auto-fill it).
+                suggestion = self._cell(row, "montage_suggestion")
+                if suggestion:
+                    self._body_layout.addWidget(self._montage_hint(suggestion))
+            if show_cap:
+                self._body_layout.addWidget(self._meta_combo_row(
+                    "cap", "cap_manufacturer",
+                    [""] + list(COMMON_CAP_MANUFACTURERS),
+                    self._acq_eff(row, "cap_manufacturer"), "",
+                    setter=self._on_acq_field_changed, editable=True,
+                ))
+
+        # --- MEG-specific acquisition (MEG only). Only fields mne-bids cannot
+        # derive from the recording: dewar position, the empty-room link, and
+        # the artefact note. Channel-derived MEG facts (head localization,
+        # digitized landmarks/head points, ...) are filled by mne-bids.
+        if datatype == "meg":
+            self._body_layout.addSpacing(8)
+            self._body_layout.addWidget(self._divider())
+            self._body_layout.addWidget(self._section_header(
+                "MEG ACQUISITION", f"sub-..._{datatype}.json", agnostic=False, tag=mod))
+            self._body_layout.addWidget(self._meta_combo_row(
+                "dewar", "dewar_position", ["", "upright", "supine"],
+                self._acq_eff(row, "dewar_position"), "",
+                setter=self._on_acq_field_changed, editable=True,
             ))
             self._body_layout.addWidget(self._meta_edit_row(
-                "ground", "eeg_ground", self._eff(row, "eeg_ground"),
+                "empty room", "associated_empty_room",
+                self._acq_eff(row, "associated_empty_room"),
+                setter=self._on_acq_field_changed,
             ))
+            self._body_layout.addWidget(self._meta_edit_row(
+                "artefacts", "subject_artefact_description",
+                self._acq_eff(row, "subject_artefact_description"),
+                setter=self._on_acq_field_changed,
+            ))
+
+    def _montage_hint(self, suggestion: str) -> QWidget:
+        return self._scan_hint("montage", "best montage match (from scan)", suggestion)
+
+    def _scan_hint(self, field_key: str, prefix: str, value: str) -> QWidget:
+        """A read-only scan-suggestion hint row (e.g. montage match, detected
+        manufacturer). Aligned under the field column; not auto-applied. Carries
+        an explicit QToolTip background so it never renders transparent."""
+        pal = CUR()
+        lbl = QLabel(
+            f'<span style="color:{pal["dim"]};">{prefix}: </span>'
+            f'<span style="color:{pal["teal"]};font-weight:700;">{value}</span>'
+        )
+        lbl.setObjectName("scan-hint")
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        lbl.setWordWrap(True)
+        # Scoped (objectName) so the transparent background does not leak into
+        # this label's tooltip; the tooltip then uses the app QToolTip styling.
+        lbl.setStyleSheet(
+            f"#scan-hint {{ font-size: {scaled_px(10)}px; background: transparent; "
+            "margin-left: 84px; }"
+        )
+        lbl.setToolTip(
+            "Suggestion computed at scan; not applied automatically. Pick it in "
+            "the field above if appropriate."
+        )
+        return lbl
 
     def _append_companion_section(self, row: int) -> None:
         """Link already-curated companion files (events/beh/stim/...) for a row.
@@ -613,7 +785,8 @@ class PropertiesPanel(QWidget):
         self._body_layout.addSpacing(8)
         self._body_layout.addWidget(self._divider())
         self._body_layout.addWidget(self._section_header(
-            "COMPANION FILES", "events / beh / stim (copied into BIDS)"))
+            "COMPANION FILES", "events / beh / stim (copied into BIDS)",
+            agnostic=True, tag="any modality"))
 
         self._companion_list = QListWidget()
         self._companion_list.setMaximumHeight(72)
@@ -622,11 +795,13 @@ class PropertiesPanel(QWidget):
         self._body_layout.addWidget(self._companion_list)
 
         ctl = QWidget()
-        ctl.setStyleSheet("background: transparent;")
+        ctl.setObjectName("companion-ctl")
+        ctl.setStyleSheet("#companion-ctl { background: transparent; }")
         h = QHBoxLayout(ctl)
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(6)
         self._companion_suffix = QComboBox()
+        self._companion_suffix.setObjectName("ent-input")  # opaque popup styling
         self._companion_suffix.addItems(
             ["events", "beh", "stim", "physio", "channels", "electrodes"]
         )
@@ -682,20 +857,32 @@ class PropertiesPanel(QWidget):
             self._write_companions(row, items)
 
     def _meta_combo_row(self, label: str, key: str, options: list[str],
-                        current: str, blank_label: str) -> QWidget:
+                        current: str, blank_label: str, *,
+                        setter=None, editable: bool = False) -> QWidget:
         row_w = QWidget()
-        row_w.setStyleSheet("background: transparent;")
+        # Scope the transparent background to THIS container only (objectName
+        # selector) so it does not cascade into child combo popups / tooltips
+        # and make them transparent. Those then use the app theme styling.
+        row_w.setObjectName("meta-row")
+        row_w.setStyleSheet("#meta-row { background: transparent; }")
         h = QHBoxLayout(row_w)
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(8)
+        tip = tooltip_for(key)
         lbl = QLabel(label)
         lbl.setMinimumWidth(76)
         lbl.setMaximumWidth(76)
         lbl.setStyleSheet(f"color: {CUR()['dim']};")
+        if tip:
+            lbl.setToolTip(tip)
         h.addWidget(lbl)
 
+        on_change = setter or self._on_meta_field_changed
         combo = QComboBox()
         combo.setObjectName("ent-input")
+        if tip:
+            combo.setToolTip(tip)
+        combo.setEditable(editable)
         combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         combo.addItems(options)
         cur = current.strip()
@@ -707,27 +894,44 @@ class PropertiesPanel(QWidget):
             combo.setCurrentText(cur)
         combo.activated.connect(
             lambda _i, c=combo, k=key, bl=blank_label:
-            self._on_meta_field_changed(k, "" if c.currentText() == bl else c.currentText())
+            on_change(k, "" if c.currentText() == bl else c.currentText())
         )
+        if editable:
+            # An editable combo also commits a free-typed value on focus loss.
+            combo.lineEdit().editingFinished.connect(
+                lambda c=combo, k=key, bl=blank_label:
+                on_change(k, "" if c.currentText() == bl else c.currentText().strip())
+            )
         h.addWidget(combo, 1)
         return row_w
 
-    def _meta_edit_row(self, label: str, key: str, current: str) -> QWidget:
+    def _meta_edit_row(self, label: str, key: str, current: str, *,
+                       setter=None) -> QWidget:
         row_w = QWidget()
-        row_w.setStyleSheet("background: transparent;")
+        # Scope the transparent background to THIS container only (objectName
+        # selector) so it does not cascade into child combo popups / tooltips
+        # and make them transparent. Those then use the app theme styling.
+        row_w.setObjectName("meta-row")
+        row_w.setStyleSheet("#meta-row { background: transparent; }")
         h = QHBoxLayout(row_w)
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(8)
+        tip = tooltip_for(key)
         lbl = QLabel(label)
         lbl.setMinimumWidth(76)
         lbl.setMaximumWidth(76)
         lbl.setStyleSheet(f"color: {CUR()['dim']};")
+        if tip:
+            lbl.setToolTip(tip)
         h.addWidget(lbl)
+        on_change = setter or self._on_meta_field_changed
         edit = QLineEdit(current)
         edit.setObjectName("ent-input")
         edit.setPlaceholderText("—")
+        if tip:
+            edit.setToolTip(tip)
         edit.editingFinished.connect(
-            lambda e=edit, k=key: self._on_meta_field_changed(k, e.text().strip())
+            lambda e=edit, k=key: on_change(k, e.text().strip())
         )
         h.addWidget(edit, 1)
         return row_w
@@ -737,6 +941,12 @@ class PropertiesPanel(QWidget):
         if self._model is None:
             return ""
         return self._model.effective_value(row, col)
+
+    def _acq_eff(self, row: int, field: str) -> str:
+        """Effective per-row acquisition value (scaffold override else default)."""
+        if self._model is None:
+            return ""
+        return self._model.acq_effective(row, field)
 
     def _cell(self, row: int, col: str) -> str:
         if self._model is None:
@@ -754,6 +964,12 @@ class PropertiesPanel(QWidget):
         if self._suppress_writeback or self._model is None or self._row is None:
             return
         self._model.bulk_set([self._row], key, value)
+
+    def _on_acq_field_changed(self, key: str, value: str) -> None:
+        """Commit a per-row device / institution override into the scaffold spec."""
+        if self._suppress_writeback or self._model is None or self._row is None:
+            return
+        self._model.set_acq_override(self._row, key, value)
 
     def _on_model_data_changed(self, top_left, bottom_right, _roles=()) -> None:
         if self._model is None or self._row is None:

--- a/bidsmgr/gui/properties_panel.py
+++ b/bidsmgr/gui/properties_panel.py
@@ -33,7 +33,6 @@ import logging
 from typing import Optional
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QComboBox,
     QFileDialog,
@@ -144,6 +143,9 @@ class PropertiesPanel(QWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("pane")
+        # Low floor so the user can squeeze the Properties pane down and give
+        # the inspection table more room (the splitter honours this).
+        self.setMinimumWidth(56)
         self._model: Optional[InventoryTableModel] = None
         self._project: Optional[Project] = None
         self._row: Optional[int] = None
@@ -412,9 +414,9 @@ class PropertiesPanel(QWidget):
     ) -> QWidget:
         f = QFrame()
         f.setObjectName("path-preview")
-        l = QVBoxLayout(f)
-        l.setContentsMargins(11, 9, 11, 9)
-        l.setSpacing(0)
+        lay = QVBoxLayout(f)
+        lay.setContentsMargins(11, 9, 11, 9)
+        lay.setSpacing(0)
         pal = CUR()
 
         # Compose the same token list the prototype rendered, derived
@@ -468,7 +470,7 @@ class PropertiesPanel(QWidget):
             f'font-size: {scaled_px(11)}px; color: {pal["text"]}; '
             'background: transparent;'
         )
-        l.addWidget(lbl)
+        lay.addWidget(lbl)
         return f
 
     @staticmethod

--- a/bidsmgr/gui/properties_panel.py
+++ b/bidsmgr/gui/properties_panel.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import Optional
 
 from PyQt6.QtCore import Qt
@@ -41,6 +42,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QListWidget,
+    QMessageBox,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -53,11 +55,12 @@ import pandas as pd
 from .. import schema as schema_mod
 from ..project import Project
 from ..recording_meta import COMMON_CAP_MANUFACTURERS, COMMON_MANUFACTURERS
+from . import icons
 from .delegates import builtin_montages
 from .metadata_help import tooltip_for
 from .models import InventoryTableModel
 from .theme_manager import CUR, scaled_px
-from .widgets import PaneHeader, ValMessage
+from .widgets import BusySpinner, PaneHeader, ValMessage
 
 # Datatypes that carry recording-metadata (the per-row section appears only
 # for these). MEG has no scalp montage / reference / ground concept.
@@ -151,6 +154,16 @@ class PropertiesPanel(QWidget):
         self._row: Optional[int] = None
         self._suppress_writeback = False
         self._entity_rows: list[_EntityRow] = []
+        # Raw input root, used to resolve a row's relative ``source_file`` to an
+        # absolute recording path for the in-panel PSD compute (set by the
+        # ConverterPanel whenever the scanned root changes).
+        self._raw_root: Optional[Path] = None
+        # Background PSD computation state. Only one runs at a time; the worker
+        # is parented to this panel so it survives body rebuilds, and
+        # ``_psd_row_id`` identifies which recording is computing so the button
+        # renders its busy state even across a re-render.
+        self._psd_worker = None
+        self._psd_row_id: Optional[str] = None
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -200,6 +213,17 @@ class PropertiesPanel(QWidget):
     def set_project(self, project: Optional[Project]) -> None:
         """Attach a project for provenance lookups. Not used yet for writes."""
         self._project = project
+
+    def set_raw_root(self, root: Optional[Path]) -> None:
+        """Set the raw input root used to resolve relative ``source_file`` paths.
+
+        The ConverterPanel calls this whenever the scanned root changes so the
+        per-row PSD button can locate the recording on disk. Re-renders the
+        current row so the button's enabled state reflects path availability.
+        """
+        self._raw_root = Path(root) if root is not None else None
+        if self._row is not None:
+            self.set_selected_row(self._row)
 
     def repaint_for_palette(self, _pal: dict) -> None:
         """Rebuild the body so inline palette reads pick up new colors.
@@ -701,6 +725,10 @@ class PropertiesPanel(QWidget):
         self._body_layout.addWidget(self._meta_combo_row(
             "line_freq", "line_freq", ["(blank)", "50", "60"], lf, "(blank)",
         ))
+        # Compute-PSD action, directly below the line-frequency field. Reads the
+        # recording on a background thread and shows the same interactive PSD
+        # dialog as the Editor's recording viewer.
+        self._body_layout.addWidget(self._build_psd_row(row))
         self._body_layout.addWidget(self._meta_combo_row(
             "manufacturer", "manufacturer",
             [""] + list(COMMON_MANUFACTURERS), self._acq_eff(row, "manufacturer"), "",
@@ -779,6 +807,151 @@ class PropertiesPanel(QWidget):
                 self._acq_eff(row, "subject_artefact_description"),
                 setter=self._on_acq_field_changed,
             ))
+
+    # ------------------------------------------------------------------
+    # PSD compute (per-row, threaded, mirrors the Editor recording viewer)
+    # ------------------------------------------------------------------
+
+    def _build_psd_row(self, row: int) -> QWidget:
+        """A ``[Compute PSD] [spinner]`` action row, left-aligned under the
+        field column. Disabled when no source recording can be located. While
+        this row's recording is computing it shows the busy spinner; only one
+        PSD runs at a time."""
+        row_w = QWidget()
+        row_w.setObjectName("meta-row")
+        row_w.setStyleSheet("#meta-row { background: transparent; }")
+        h = QHBoxLayout(row_w)
+        # 76px label column + 8px spacing aligns the button under the field.
+        h.setContentsMargins(84, 2, 0, 2)
+        h.setSpacing(8)
+
+        is_computing = (
+            self._psd_worker is not None
+            and self._model is not None
+            and self._psd_row_id is not None
+            and self._psd_row_id == self._model.row_id(row)
+        )
+        path = self._resolve_source_path(row)
+
+        btn = QPushButton("  Compute PSD")
+        btn.setObjectName("tb-btn")
+        icons.apply_button(btn, "psd")
+        btn.setToolTip(
+            "Compute the power spectral density of this recording. Reads the "
+            "file on a background thread and opens the same interactive PSD "
+            "viewer as the Editor."
+        )
+        if is_computing:
+            btn.setText("  Computing PSD…")
+            btn.setEnabled(False)
+        elif path is None:
+            btn.setEnabled(False)
+            btn.setToolTip("No readable source recording found for this row.")
+        else:
+            btn.clicked.connect(lambda _=False, r=row: self._on_compute_psd(r))
+        h.addWidget(btn)
+
+        spinner = BusySpinner()
+        if is_computing:
+            spinner.set_busy(True, message="")
+        h.addWidget(spinner)
+        h.addStretch(1)
+        return row_w
+
+    def _resolve_source_path(self, row: int) -> Optional[Path]:
+        """Resolve a row's ``source_file`` to an existing absolute path.
+
+        Mirrors the converter's resolution order: an absolute path as-is, else
+        relative to the raw input root, the CWD, or ``.resolve()``. Returns
+        ``None`` when nothing on disk matches (DICOM rows have no source_file)."""
+        src = self._cell(row, "source_file").strip()
+        if not src:
+            return None
+        p = Path(src)
+        if p.is_absolute():
+            return p if p.exists() else None
+        candidates: list[Path] = []
+        if self._raw_root is not None:
+            candidates.append(self._raw_root / p)
+        candidates.append(Path.cwd() / p)
+        try:
+            candidates.append(p.resolve())
+        except Exception:
+            pass
+        for c in candidates:
+            if c.exists():
+                return c
+        return None
+
+    def _on_compute_psd(self, row: int) -> None:
+        if self._model is None or self._psd_worker is not None:
+            return
+        path = self._resolve_source_path(row)
+        if path is None:
+            QMessageBox.warning(
+                self, "PSD", "No readable source recording found for this row."
+            )
+            return
+        from ..workers import RecordingComputeWorker
+
+        self._psd_row_id = self._model.row_id(row)
+
+        def _compute(p=path):
+            import mne
+            import numpy as np
+
+            from .widgets.recording_viewer_pane import _read_raw
+
+            raw = _read_raw(p, preload=True)
+            sfreq = float(raw.info["sfreq"])
+            fmax = min(sfreq / 2.0, 150.0)
+            psd = raw.compute_psd(fmin=0.1, fmax=fmax, verbose=False)
+            data = np.asarray(psd.get_data())
+            freqs = np.asarray(psd.freqs)
+            # compute_psd returns only data channels, in its own order - rows
+            # align with psd.ch_names, not the raw channel list. Derive types
+            # from the raw info by name so labels/types stay correct.
+            names = list(psd.ch_names)
+            raw_names = list(raw.ch_names)
+            types = []
+            for ch in names:
+                try:
+                    types.append(mne.channel_type(raw.info, raw_names.index(ch)))
+                except ValueError:
+                    types.append("misc")
+            n = min(data.shape[0], len(names), len(types))
+            return {
+                "freqs": freqs,
+                "data": data[:n],
+                "ch_names": names[:n],
+                "ch_types": types[:n],
+            }
+
+        worker = RecordingComputeWorker(_compute, parent=self)
+        worker.finished_with_result.connect(self._on_psd_ready)
+        worker.failed.connect(self._on_psd_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._psd_worker = worker
+        worker.start()
+        # Re-render so the button shows its busy state (spinner + disabled).
+        self.set_selected_row(row)
+
+    def _on_psd_ready(self, result) -> None:
+        self._psd_worker = None
+        self._psd_row_id = None
+        from .widgets.recording_viewer_pane import _PsdDialog
+
+        dlg = _PsdDialog(result, parent=self)
+        dlg.show()
+        if self._row is not None:
+            self.set_selected_row(self._row)
+
+    def _on_psd_failed(self, msg) -> None:
+        self._psd_worker = None
+        self._psd_row_id = None
+        QMessageBox.warning(self, "PSD error", str(msg))
+        if self._row is not None:
+            self.set_selected_row(self._row)
 
     def _montage_hint(self, suggestion: str) -> QWidget:
         return self._scan_hint("montage", "best montage match (from scan)", suggestion)

--- a/bidsmgr/gui/properties_panel.py
+++ b/bidsmgr/gui/properties_panel.py
@@ -379,6 +379,34 @@ class PropertiesPanel(QWidget):
         h.addWidget(combo, 1)
         return row
 
+    # Source recording extensions, longest-first so ``.fif.gz`` wins over ``.fif``.
+    _RECORDING_EXTS: tuple[str, ...] = (
+        ".fif.gz", ".vhdr", ".edf", ".bdf", ".gdf", ".set", ".cnt", ".fif",
+        ".con", ".sqd", ".ds", ".mff", ".snirf", ".nwb", ".mef",
+    )
+    # Fallback BIDS extension per non-MRI datatype when the source path is blank.
+    _DATATYPE_DEFAULT_EXT: dict[str, str] = {
+        "meg": ".fif", "eeg": ".edf", "ieeg": ".edf", "nirs": ".snirf",
+    }
+
+    def _preview_extension(self, row: int, datatype: str, suffix: str) -> str:
+        """Pick the extension shown in the predicted-path preview.
+
+        MRI datatypes render ``.nii.gz``; physio renders ``.tsv.gz``; EEG / MEG /
+        iEEG / NIRS render the source recording's own extension (what mne-bids
+        keeps by default) with a per-datatype fallback. Fixes the preview always
+        showing ``.nii.gz`` for electrophysiology rows.
+        """
+        if suffix == "physio":
+            return ".tsv.gz"
+        if datatype in ("eeg", "ieeg", "meg", "nirs"):
+            src = self._cell(row, "source_file").lower()
+            for ext in self._RECORDING_EXTS:
+                if src.endswith(ext):
+                    return ext
+            return self._DATATYPE_DEFAULT_EXT.get(datatype, "")
+        return ".nii.gz"
+
     def _build_path_preview(
         self, row: int, datatype: str, suffix: str, entities: dict[str, str],
     ) -> QWidget:
@@ -395,7 +423,8 @@ class PropertiesPanel(QWidget):
         if datatype and suffix and entities.get("subject"):
             try:
                 rel = str(schema_mod.build_relative_path(
-                    entities, datatype, suffix, ".nii.gz",
+                    entities, datatype, suffix,
+                    self._preview_extension(row, datatype, suffix),
                 ))
                 # Insert a newline between the directory part and the
                 # basename so the preview wraps clearly.

--- a/bidsmgr/gui/properties_panel.py
+++ b/bidsmgr/gui/properties_panel.py
@@ -28,6 +28,7 @@ the panel auto-refreshes when the model emits ``dataChanged``.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Optional
 
@@ -35,21 +36,31 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QComboBox,
+    QFileDialog,
     QFrame,
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QListWidget,
+    QPushButton,
     QScrollArea,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 
+import pandas as pd
+
 from .. import schema as schema_mod
 from ..project import Project
+from .delegates import builtin_montages
 from .models import InventoryTableModel
 from .theme_manager import CUR, scaled_px
 from .widgets import PaneHeader, ValMessage
+
+# Datatypes that carry recording-metadata (the per-row section appears only
+# for these). MEG has no scalp montage / reference / ground concept.
+_EEG_MEG_DATATYPES = frozenset({"eeg", "meg", "ieeg", "nirs"})
 
 log = logging.getLogger(__name__)
 
@@ -306,6 +317,14 @@ class PropertiesPanel(QWidget):
         for vmsg in self._build_validation_messages(datatype, suffix, entities):
             self._body_layout.addWidget(vmsg)
 
+        # 5. Per-row metadata, grouped by destination file. The participant
+        # section is modality-agnostic (every row, incl. MRI); the recording
+        # sidecar section only for EEG/MEG/iEEG/NIRS.
+        self._append_participant_section(row)
+        if datatype in _EEG_MEG_DATATYPES:
+            self._append_recording_section(row, datatype)
+        self._append_companion_section(row)
+
         self._body_layout.addStretch(1)
 
     def _build_combo_row(self, label_text: str, value: str, *, options: list[str],
@@ -516,6 +535,225 @@ class PropertiesPanel(QWidget):
         datatype, _sf = self._model.datatype_suffix(self._row)
         self._model.set_datatype_suffix(self._row, datatype, new_value)
         self.set_selected_row(self._row)
+
+    # ------------------------------------------------------------------
+    # Per-row metadata, grouped by destination file
+    # ------------------------------------------------------------------
+
+    def _section_header(self, title: str, destination: str) -> QWidget:
+        """A section title plus a dim ``-> <destination file>`` annotation."""
+        pal = CUR()
+        lbl = QLabel(
+            f'<span style="color:{pal["text"]};font-weight:600;">{title}</span>'
+            f'<span style="color:{pal["dim"]};"> &rarr; {destination}</span>'
+        )
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        lbl.setStyleSheet(f"font-size: {scaled_px(10)}px; background: transparent;")
+        return lbl
+
+    def _append_participant_section(self, row: int) -> None:
+        """Demographics for ANY row (incl. MRI) -> participants.tsv.
+
+        Modality-agnostic: every subject has a participants.tsv row. Handedness
+        is user-entered (never auto-assumed).
+        """
+        self._body_layout.addSpacing(8)
+        self._body_layout.addWidget(self._divider())
+        self._body_layout.addWidget(self._section_header("PARTICIPANT", "participants.tsv"))
+        self._body_layout.addWidget(self._meta_combo_row(
+            "sex", "PatientSex", ["", "M", "F", "O"], self._cell(row, "PatientSex"), "",
+        ))
+        self._body_layout.addWidget(self._meta_edit_row(
+            "age", "PatientAge", self._cell(row, "PatientAge"),
+        ))
+        self._body_layout.addWidget(self._meta_combo_row(
+            "hand", "Handedness", ["", "R", "L", "A"], self._cell(row, "Handedness"), "",
+        ))
+
+    def _append_recording_section(self, row: int, datatype: str) -> None:
+        """EEG/MEG/iEEG/NIRS sidecar fields -> sub-..._<datatype>.json.
+
+        Inheritance fields show the EFFECTIVE value (per-row override, else the
+        dataset default); writing the default clears the override. Fields that
+        do not apply to the datatype are not shown (MEG has no scalp montage /
+        reference / ground).
+        """
+        self._body_layout.addSpacing(8)
+        self._body_layout.addWidget(self._divider())
+        self._body_layout.addWidget(self._section_header(
+            "RECORDING", f"sub-..._{datatype}.json"))
+
+        show_montage = datatype in ("eeg", "ieeg", "nirs")
+        show_ref_ground = datatype in ("eeg", "ieeg")
+
+        if show_montage:
+            self._body_layout.addWidget(self._meta_combo_row(
+                "montage", "montage",
+                ["(none)"] + builtin_montages(), self._eff(row, "montage"), "(none)",
+            ))
+        lf = self._eff(row, "line_freq")
+        lf = lf[:-2] if lf.endswith(".0") else lf
+        self._body_layout.addWidget(self._meta_combo_row(
+            "line_freq", "line_freq", ["(blank)", "50", "60"], lf, "(blank)",
+        ))
+        if show_ref_ground:
+            self._body_layout.addWidget(self._meta_edit_row(
+                "reference", "eeg_reference", self._eff(row, "eeg_reference"),
+            ))
+            self._body_layout.addWidget(self._meta_edit_row(
+                "ground", "eeg_ground", self._eff(row, "eeg_ground"),
+            ))
+
+    def _append_companion_section(self, row: int) -> None:
+        """Link already-curated companion files (events/beh/stim/...) for a row.
+
+        Modality-agnostic: any recording can carry curated sidecar companions
+        the converter copies into the BIDS tree (place + name, no conversion).
+        """
+        self._body_layout.addSpacing(8)
+        self._body_layout.addWidget(self._divider())
+        self._body_layout.addWidget(self._section_header(
+            "COMPANION FILES", "events / beh / stim (copied into BIDS)"))
+
+        self._companion_list = QListWidget()
+        self._companion_list.setMaximumHeight(72)
+        for suffix, path in self._companions(row):
+            self._companion_list.addItem(f"{suffix}: {path}")
+        self._body_layout.addWidget(self._companion_list)
+
+        ctl = QWidget()
+        ctl.setStyleSheet("background: transparent;")
+        h = QHBoxLayout(ctl)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(6)
+        self._companion_suffix = QComboBox()
+        self._companion_suffix.addItems(
+            ["events", "beh", "stim", "physio", "channels", "electrodes"]
+        )
+        link = QPushButton("Link file…")
+        link.clicked.connect(lambda _=False, r=row: self._link_companion(r))
+        rem = QPushButton("Remove")
+        rem.clicked.connect(lambda _=False, r=row: self._remove_companion(r))
+        h.addWidget(self._companion_suffix)
+        h.addWidget(link)
+        h.addWidget(rem)
+        h.addStretch(1)
+        self._body_layout.addWidget(ctl)
+
+    def _companions(self, row: int) -> list[tuple[str, str]]:
+        raw = self._cell(row, "companion_files")
+        if not raw:
+            return []
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+        out: list[tuple[str, str]] = []
+        if isinstance(data, list):
+            for it in data:
+                if isinstance(it, dict) and it.get("suffix") and it.get("path"):
+                    out.append((str(it["suffix"]), str(it["path"])))
+        return out
+
+    def _write_companions(self, row: int, items: list[tuple[str, str]]) -> None:
+        if self._model is None:
+            return
+        payload = (
+            json.dumps([{"suffix": s, "path": p} for s, p in items]) if items else ""
+        )
+        # dataChanged from bulk_set re-renders this section with the new list.
+        self._model.bulk_set([row], "companion_files", payload)
+
+    def _link_companion(self, row: int) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Link a curated companion file", "", "All files (*)",
+        )
+        if not path:
+            return
+        items = self._companions(row)
+        items.append((self._companion_suffix.currentText(), path))
+        self._write_companions(row, items)
+
+    def _remove_companion(self, row: int) -> None:
+        sel = self._companion_list.currentRow()
+        items = self._companions(row)
+        if 0 <= sel < len(items):
+            items.pop(sel)
+            self._write_companions(row, items)
+
+    def _meta_combo_row(self, label: str, key: str, options: list[str],
+                        current: str, blank_label: str) -> QWidget:
+        row_w = QWidget()
+        row_w.setStyleSheet("background: transparent;")
+        h = QHBoxLayout(row_w)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(8)
+        lbl = QLabel(label)
+        lbl.setMinimumWidth(76)
+        lbl.setMaximumWidth(76)
+        lbl.setStyleSheet(f"color: {CUR()['dim']};")
+        h.addWidget(lbl)
+
+        combo = QComboBox()
+        combo.setObjectName("ent-input")
+        combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        combo.addItems(options)
+        cur = current.strip()
+        if not cur:
+            combo.setCurrentText(blank_label)
+        else:
+            if combo.findText(cur) < 0:
+                combo.addItem(cur)
+            combo.setCurrentText(cur)
+        combo.activated.connect(
+            lambda _i, c=combo, k=key, bl=blank_label:
+            self._on_meta_field_changed(k, "" if c.currentText() == bl else c.currentText())
+        )
+        h.addWidget(combo, 1)
+        return row_w
+
+    def _meta_edit_row(self, label: str, key: str, current: str) -> QWidget:
+        row_w = QWidget()
+        row_w.setStyleSheet("background: transparent;")
+        h = QHBoxLayout(row_w)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(8)
+        lbl = QLabel(label)
+        lbl.setMinimumWidth(76)
+        lbl.setMaximumWidth(76)
+        lbl.setStyleSheet(f"color: {CUR()['dim']};")
+        h.addWidget(lbl)
+        edit = QLineEdit(current)
+        edit.setObjectName("ent-input")
+        edit.setPlaceholderText("—")
+        edit.editingFinished.connect(
+            lambda e=edit, k=key: self._on_meta_field_changed(k, e.text().strip())
+        )
+        h.addWidget(edit, 1)
+        return row_w
+
+    def _eff(self, row: int, col: str) -> str:
+        """Effective value (per-row override else inherited dataset default)."""
+        if self._model is None:
+            return ""
+        return self._model.effective_value(row, col)
+
+    def _cell(self, row: int, col: str) -> str:
+        if self._model is None:
+            return ""
+        df = self._model.dataframe()
+        if col not in df.columns or not (0 <= row < len(df)):
+            return ""
+        v = df.iloc[row][col]
+        if v is None or (isinstance(v, float) and pd.isna(v)):
+            return ""
+        s = str(v)
+        return "" if s.lower() in ("nan", "none") else s
+
+    def _on_meta_field_changed(self, key: str, value: str) -> None:
+        if self._suppress_writeback or self._model is None or self._row is None:
+            return
+        self._model.bulk_set([self._row], key, value)
 
     def _on_model_data_changed(self, top_left, bottom_right, _roles=()) -> None:
         if self._model is None or self._row is None:

--- a/bidsmgr/gui/recording_meta_dialog.py
+++ b/bidsmgr/gui/recording_meta_dialog.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -37,23 +38,47 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from ..recording_meta import AcquisitionSpec, RecordingMetaSpec, dump_spec, load_spec
+from ..recording_meta import (
+    COMMON_CAP_MANUFACTURERS,
+    COMMON_MANUFACTURERS,
+    AcquisitionSpec,
+    RecordingMetaSpec,
+    dump_spec,
+    load_spec,
+)
 from .delegates import builtin_montages
+from .metadata_help import tooltip_for
+from .theme_manager import CUR
 
 _NONE = "(none)"
 _BLANK = "(blank)"
 
-# Common EEG + MEG amplifier/system manufacturers, offered as an editable
-# dropdown (the user can still type any other value). MEG names follow the BIDS
-# Manufacturer convention; EEG names are the common vendors.
-_MANUFACTURERS: tuple[str, ...] = (
-    # EEG
-    "Brain Products", "BioSemi", "EGI / Philips Neuro", "ANT Neuro",
-    "Compumedics Neuroscan", "g.tec", "Cognionics", "mBrainTrain", "OpenBCI",
-    # MEG (BIDS convention)
-    "MEGIN / Elekta / Neuromag", "CTF", "4D Neuroimaging / BTi",
-    "KIT / Yokogawa", "ITAB", "KRISS", "FieldLine", "QuSpin",
-)
+# Display names + an "EEG and MEG"-style joiner so a section whose field is
+# shared by several present modalities is labelled with all of them.
+_MODALITY_NAMES = {"eeg": "EEG", "meg": "MEG", "ieeg": "iEEG", "nirs": "NIRS"}
+_MODALITY_ORDER = ("eeg", "meg", "ieeg", "nirs")
+
+
+def _join_modalities(mods: list[str]) -> str:
+    names = [_MODALITY_NAMES.get(m, m.upper()) for m in mods]
+    if not names:
+        return ""
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + f" and {names[-1]}"
+
+
+def _tighten_form(form: QFormLayout) -> None:
+    """Compact a form layout so the stacked group boxes stay dense.
+
+    Keeps the default window showing as many of the metadata fields as fit
+    before the outer scroll area takes over for the rest.
+    """
+    form.setContentsMargins(8, 6, 8, 6)
+    form.setVerticalSpacing(4)
+    form.setHorizontalSpacing(8)
 
 
 class RecordingMetaDialog(QDialog):
@@ -64,9 +89,20 @@ class RecordingMetaDialog(QDialog):
         scaffold_path: Path,
         present_datatypes: Optional[set[str]] = None,
         parent: Optional[QWidget] = None,
+        montage_suggestions: Optional[list[str]] = None,
+        manufacturer_suggestions: Optional[list[str]] = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Dataset metadata")
+        # Distinct per-recording suggestions the scan found, surfaced as read-only
+        # hints beside the matching dataset defaults (not auto-applied).
+        self._montage_suggestions = list(montage_suggestions or [])
+        self._manufacturer_suggestions = list(manufacturer_suggestions or [])
+        # A fixed, modest default size. The whole body lives in a scroll area,
+        # so when the visible sections need more room the OUTER scroll bar moves
+        # the entire window content as one - the user asked for a scrollable
+        # window, not a window that resizes itself to the content or whose inner
+        # tables stretch. Still freely resizable (enlarge to see more at once).
         self.resize(560, 640)
         self._scaffold_path = Path(scaffold_path)
         # Datatypes the scanned dataset actually contains. Drives which sections
@@ -78,6 +114,7 @@ class RecordingMetaDialog(QDialog):
         self._spec = self._load()
 
         outer = QVBoxLayout(self)
+        outer.setSpacing(6)
         intro = QLabel(
             "Dataset-wide metadata, grouped by where it is written. "
             "Modality-agnostic sections apply to any dataset; modality-specific "
@@ -90,13 +127,25 @@ class RecordingMetaDialog(QDialog):
         body = QWidget()
         bl = QVBoxLayout(body)
         bl.setContentsMargins(0, 0, 0, 0)
-        # Modality-specific (non-agnostic) -> the datatype sidecar, split into a
-        # generic device/site block (all EEG/MEG) and an EEG-only montage block.
+        bl.setSpacing(8)
+        # Region 1 - MODALITY-SPECIFIC defaults (the recording sidecars): a
+        # device/site block (all electrophysiology) + an EEG/iEEG reference &
+        # montage block. The region header is hidden for a dataset with no
+        # EEG/MEG (only the agnostic region then shows).
+        self._specific_region = self._region_label(
+            "Modality-specific defaults", agnostic=False)
+        bl.addWidget(self._specific_region)
         self._device_box = self._build_device_group()
         self._eeg_box = self._build_eeg_group()
+        self._meg_box = self._build_meg_group()
         bl.addWidget(self._device_box)
         bl.addWidget(self._eeg_box)
-        # Modality-agnostic -> their own destination files.
+        bl.addWidget(self._meg_box)
+        # Region 2 - MODALITY-AGNOSTIC (apply to any dataset, incl. MRI):
+        # institution (site info, written to every modality's sidecar), events
+        # and phenotype, each writing to its own destination.
+        bl.addWidget(self._region_label("Modality-agnostic", agnostic=True))
+        bl.addWidget(self._build_institution_group())
         bl.addWidget(self._build_event_group())
         bl.addWidget(self._build_phenotype_group())
         bl.addStretch(1)
@@ -115,83 +164,196 @@ class RecordingMetaDialog(QDialog):
         self._populate()
         self._apply_modality_constraints()
 
+    def _region_label(self, text: str, *, agnostic: bool) -> QLabel:
+        """A bold, colour-coded region divider (agnostic = teal, modality-
+        specific = purple) separating the two metadata regions."""
+        pal = CUR()
+        color = pal["teal"] if agnostic else pal["purple"]
+        lbl = QLabel(
+            f'<span style="color:{color};font-weight:800;'
+            f'letter-spacing:0.6px;">{text.upper()}</span>'
+        )
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        lbl.setStyleSheet(
+            f"background: transparent; border-bottom: 1px solid {color}; "
+            "padding-bottom: 2px;"
+        )
+        return lbl
+
+    def _modalities_label(self, applicable: set[str]) -> str:
+        """"EEG and MEG"-style label of the PRESENT modalities a field applies
+        to (so a field shared by several modalities names them all)."""
+        present_app = [
+            m for m in _MODALITY_ORDER if m in self._present and m in applicable
+        ]
+        return _join_modalities(present_app)
+
     def _apply_modality_constraints(self) -> None:
         """Show/hide modality-specific sections by what was scanned.
 
         Both non-agnostic sections are hidden when the dataset has no
         EEG/MEG/iEEG/NIRS. The EEG montage/reference section is additionally
-        hidden for a dataset with no scalp-EEG (e.g. MEG-only).
+        hidden for a dataset with no scalp-EEG (e.g. MEG-only). The
+        modality-specific region header hides when neither block applies.
         """
         has_eeg_meg = bool(self._present & {"eeg", "meg", "ieeg", "nirs"})
         has_eeg = bool(self._present & {"eeg", "ieeg"})
+        has_meg = "meg" in self._present
         # Flags consulted by build_spec so a hidden section's loaded values are
         # preserved (not clobbered by the empty, never-shown widgets).
         self._device_applies = has_eeg_meg
         self._eeg_applies = has_eeg
+        self._meg_applies = has_meg
         self._device_box.setVisible(has_eeg_meg)
         self._eeg_box.setVisible(has_eeg)
+        self._meg_box.setVisible(has_meg)
+        self._specific_region.setVisible(has_eeg_meg)
 
     # ------------------------------------------------------------------
     # build
     # ------------------------------------------------------------------
 
+    def _form_row(self, form: QFormLayout, label_text: str, widget, ui_key: str) -> None:
+        """Add a labelled field row with the schema tooltip on BOTH the label
+        and the field (so hovering either shows the explanation)."""
+        tip = tooltip_for(ui_key)
+        label = QLabel(label_text)
+        if tip:
+            label.setToolTip(tip)
+            widget.setToolTip(tip)
+        form.addRow(label, widget)
+
     def _build_device_group(self) -> QGroupBox:
-        # Generic recording sidecar fields - apply to every EEG/MEG datatype's
-        # sidecar (Manufacturer / InstitutionName etc. are not scalp-specific).
+        # Acquisition-system fields - the DEVICE that produced the recording.
+        # These are modality-specific (the EEG amplifier and the MEG system are
+        # different devices). Institution is agnostic and lives in its own
+        # section. The title names every present modality (e.g. "EEG and MEG").
+        mods = self._modalities_label({"eeg", "meg", "ieeg", "nirs"}) or "EEG / MEG"
         box = QGroupBox(
-            "Device & institution  ·  modality-specific  →  sub-..._<datatype>.json"
+            f"Acquisition system  ·  {mods}  →  sub-..._<datatype>.json"
         )
         form = QFormLayout(box)
+        _tighten_form(form)
 
         self._manufacturer = QComboBox()
         self._manufacturer.setEditable(True)  # pick a default OR type another
         self._manufacturer.addItem("")
-        self._manufacturer.addItems(_MANUFACTURERS)
+        self._manufacturer.addItems(COMMON_MANUFACTURERS)
         self._amplifier_model = QLineEdit()
         self._software_versions = QLineEdit()
-        self._institution_name = QLineEdit()
-        self._institution_dept = QLineEdit()
         self._line_freq = QComboBox()
         self._line_freq.addItems([_BLANK, "50", "60"])
 
-        form.addRow("Manufacturer:", self._manufacturer)
-        form.addRow("Amplifier / system model:", self._amplifier_model)
-        form.addRow("Software versions:", self._software_versions)
-        form.addRow("Institution name:", self._institution_name)
-        form.addRow("Institution department:", self._institution_dept)
-        form.addRow("Default line frequency (Hz):", self._line_freq)
+        self._form_row(form, "Manufacturer:", self._manufacturer, "manufacturer")
+        # Read-only summary of the manufacturers the scan detected/inferred.
+        hint = self._suggestion_label(self._manufacturer_suggestions)
+        if hint is not None:
+            form.addRow("", hint)
+        self._form_row(form, "Amplifier / system model:", self._amplifier_model, "amplifier_model")
+        self._form_row(form, "Software versions:", self._software_versions, "software_versions")
+        self._form_row(form, "Power line frequency (Hz):", self._line_freq, "line_freq")
+        return box
+
+    def _build_institution_group(self) -> QGroupBox:
+        # Institution / site info is modality-AGNOSTIC: it belongs in every
+        # modality's sidecar (MRI gets it from DICOM; EEG/MEG from this default).
+        box = QGroupBox("Institution / site  ·  any modality  →  sidecar / dataset")
+        form = QFormLayout(box)
+        _tighten_form(form)
+        self._institution_name = QLineEdit()
+        self._institution_dept = QLineEdit()
+        self._form_row(form, "Institution name:", self._institution_name, "institution_name")
+        self._form_row(form, "Institution department:", self._institution_dept, "institution_dept")
         return box
 
     def _build_eeg_group(self) -> QGroupBox:
-        # Scalp-EEG / iEEG only sidecar fields.
+        # Scalp-EEG / iEEG only sidecar fields (MEG has no scalp reference /
+        # ground / montage). The title names the present EEG/iEEG modalities.
+        mods = self._modalities_label({"eeg", "ieeg"}) or "EEG / iEEG"
         box = QGroupBox(
-            "EEG montage & references  ·  EEG / iEEG only  →  sub-..._eeg.json + electrodes.tsv"
+            f"Reference, ground & montage  ·  {mods}  →  sub-..._eeg.json + electrodes.tsv"
         )
         form = QFormLayout(box)
+        _tighten_form(form)
 
-        self._cap_manufacturer = QLineEdit()
+        self._cap_manufacturer = QComboBox()
+        self._cap_manufacturer.setEditable(True)  # pick a default OR type another
+        self._cap_manufacturer.addItem("")
+        self._cap_manufacturer.addItems(COMMON_CAP_MANUFACTURERS)
         self._eeg_reference = QLineEdit()
         self._eeg_ground = QLineEdit()
         self._montage = QComboBox()
         self._montage.addItem(_NONE)
         self._montage.addItems(builtin_montages())
 
-        form.addRow("Default EEG reference:", self._eeg_reference)
-        form.addRow("Default EEG ground:", self._eeg_ground)
-        form.addRow("Default montage:", self._montage)
-        form.addRow("Cap manufacturer:", self._cap_manufacturer)
+        self._form_row(form, "Default EEG reference:", self._eeg_reference, "eeg_reference")
+        self._form_row(form, "Default EEG ground:", self._eeg_ground, "eeg_ground")
+        self._form_row(form, "Default montage:", self._montage, "montage")
+        # Read-only summary of the per-recording montage matches the scan found
+        # (the dataset default applies to all; this shows what was detected).
+        hint = self._suggestion_label(self._montage_suggestions)
+        if hint is not None:
+            form.addRow("", hint)
+        self._form_row(form, "Cap manufacturer:", self._cap_manufacturer, "cap_manufacturer")
+        return box
+
+    def _suggestion_label(self, suggestions: list[str]) -> Optional[QLabel]:
+        """A dim 'scan suggests: ...' summary of distinct per-recording scan
+        suggestions (montage or manufacturer), or ``None`` when there are none."""
+        if not suggestions:
+            return None
+        pal = CUR()
+        shown = suggestions[:3]
+        more = len(suggestions) - len(shown)
+        text = "; ".join(shown) + (f" (+{more} more)" if more > 0 else "")
+        lbl = QLabel(
+            f'<span style="color:{pal["dim"]};">scan suggests: </span>'
+            f'<span style="color:{pal["teal"]};">{text}</span>'
+        )
+        lbl.setTextFormat(Qt.TextFormat.RichText)
+        lbl.setWordWrap(True)
+        lbl.setToolTip(
+            "Detected per recording at scan. Set a dataset default above, or "
+            "override per recording in the inspection table; not auto-applied."
+        )
+        return lbl
+
+    def _build_meg_group(self) -> QGroupBox:
+        # MEG-only fields mne-bids CANNOT derive from the recording. The
+        # channel-derived MEG facts (continuous head localization, digitized
+        # landmarks / head points, head-coil frequency, ...) are filled by
+        # mne-bids and are intentionally NOT exposed here.
+        box = QGroupBox(
+            "MEG acquisition  ·  MEG  →  sub-..._meg.json"
+        )
+        form = QFormLayout(box)
+        _tighten_form(form)
+
+        self._dewar_position = QComboBox()
+        self._dewar_position.setEditable(True)
+        self._dewar_position.addItems(["", "upright", "supine"])
+        self._associated_empty_room = QLineEdit()
+        self._subject_artefact_description = QLineEdit()
+
+        self._form_row(form, "Dewar position:", self._dewar_position, "dewar_position")
+        self._form_row(form, "Associated empty-room:", self._associated_empty_room, "associated_empty_room")
+        self._form_row(form, "Subject artefact description:",
+                       self._subject_artefact_description, "subject_artefact_description")
         return box
 
     def _build_event_group(self) -> QGroupBox:
         box = QGroupBox("Events (trigger code -> label)  ·  modality-agnostic  →  events.tsv")
         v = QVBoxLayout(box)
+        v.setContentsMargins(8, 6, 8, 6)
+        v.setSpacing(4)
         self._events = QTableWidget(0, 2)
         self._events.setHorizontalHeaderLabels(["Code", "Label"])
         self._events.horizontalHeader().setStretchLastSection(True)
-        # Bound the table height so it does not greedily expand: the whole
-        # dialog then scrolls as one (rather than only this table scrolling).
-        self._events.setMinimumHeight(120)
-        self._events.setMaximumHeight(200)
+        # Bound the table to a natural, modest height. It keeps its own size
+        # (it does not stretch to fill); when the stacked sections together
+        # exceed the window, the OUTER scroll area moves the whole body.
+        self._events.setMinimumHeight(96)
+        self._events.setMaximumHeight(160)
         v.addWidget(self._events)
 
         row = QHBoxLayout()
@@ -213,11 +375,15 @@ class RecordingMetaDialog(QDialog):
     def _build_phenotype_group(self) -> QGroupBox:
         box = QGroupBox("Phenotype tables  ·  modality-agnostic  →  phenotype/")
         v = QVBoxLayout(box)
-        v.addWidget(QLabel(
-            "Participant-level measure tables (TSV/CSV/XLSX/ODS keyed by "
-            "participant_id). Each becomes phenotype/<measure>.tsv + .json."
-        ))
+        v.setContentsMargins(8, 6, 8, 6)
+        v.setSpacing(4)
+        hint = QLabel(
+            "Measure tables keyed by participant_id -> phenotype/<measure>.tsv + .json."
+        )
+        hint.setWordWrap(True)
+        v.addWidget(hint)
         self._phenotype = QListWidget()
+        self._phenotype.setMinimumHeight(70)
         self._phenotype.setMaximumHeight(110)
         v.addWidget(self._phenotype)
         row = QHBoxLayout()
@@ -262,7 +428,7 @@ class RecordingMetaDialog(QDialog):
         self._manufacturer.setCurrentText(acq.manufacturer or "")
         self._amplifier_model.setText(acq.amplifier_model or "")
         self._software_versions.setText(acq.software_versions or "")
-        self._cap_manufacturer.setText(acq.cap_manufacturer or "")
+        self._cap_manufacturer.setCurrentText(acq.cap_manufacturer or "")
         self._institution_name.setText(acq.institution_name or "")
         self._institution_dept.setText(acq.institution_dept or "")
         self._eeg_reference.setText(acq.eeg_reference or "")
@@ -273,6 +439,10 @@ class RecordingMetaDialog(QDialog):
             str(int(acq.power_line_freq)) if acq.power_line_freq else "",
             _BLANK,
         )
+        # MEG-specific manual fields.
+        self._dewar_position.setCurrentText(acq.dewar_position or "")
+        self._associated_empty_room.setText(acq.associated_empty_room or "")
+        self._subject_artefact_description.setText(acq.subject_artefact_description or "")
 
         event_map = self._spec.event_maps.get("*", {})
         self._events.setRowCount(0)
@@ -317,34 +487,45 @@ class RecordingMetaDialog(QDialog):
 
         prev = self._spec.defaults
 
-        # Device & institution block (generic sidecar; all EEG/MEG).
+        # Institution / site is agnostic - its group is always shown, so read it
+        # unconditionally.
+        institution_name = _opt(self._institution_name)
+        institution_dept = _opt(self._institution_dept)
+
+        # Device block (modality-specific; all EEG/MEG).
         if self._device_applies:
             manufacturer = self._manufacturer.currentText().strip() or None
             amplifier_model = _opt(self._amplifier_model)
             software_versions = _opt(self._software_versions)
-            institution_name = _opt(self._institution_name)
-            institution_dept = _opt(self._institution_dept)
             lf = self._combo_value(self._line_freq, _BLANK)
             power_line_freq = float(lf) if lf else None
         else:
             manufacturer = prev.manufacturer
             amplifier_model = prev.amplifier_model
             software_versions = prev.software_versions
-            institution_name = prev.institution_name
-            institution_dept = prev.institution_dept
             power_line_freq = prev.power_line_freq
 
         # EEG montage & references block (EEG/iEEG only).
         if self._eeg_applies:
             eeg_ref = _opt(self._eeg_reference)
             eeg_gnd = _opt(self._eeg_ground)
-            cap = _opt(self._cap_manufacturer)
+            cap = self._cap_manufacturer.currentText().strip() or None
             montage = self._combo_value(self._montage, _NONE)
         else:
             eeg_ref = prev.eeg_reference
             eeg_gnd = prev.eeg_ground
             cap = prev.cap_manufacturer
             montage = prev.montage
+
+        # MEG-specific block (MEG only) - manual fields mne-bids cannot derive.
+        if self._meg_applies:
+            dewar_position = self._dewar_position.currentText().strip() or None
+            associated_empty_room = _opt(self._associated_empty_room)
+            subject_artefact_description = _opt(self._subject_artefact_description)
+        else:
+            dewar_position = prev.dewar_position
+            associated_empty_room = prev.associated_empty_room
+            subject_artefact_description = prev.subject_artefact_description
 
         acq = AcquisitionSpec(
             manufacturer=manufacturer,
@@ -357,7 +538,13 @@ class RecordingMetaDialog(QDialog):
             eeg_ground=eeg_gnd,
             montage=montage,
             power_line_freq=power_line_freq,
-            # Preserve blocks this dialog does not edit (aux channels, etc.).
+            dewar_position=dewar_position,
+            associated_empty_room=associated_empty_room,
+            subject_artefact_description=subject_artefact_description,
+            # Preserve fields/blocks this dialog does not edit (legacy `software`,
+            # aux channels, filters, extras, cap_model).
+            software=self._spec.defaults.software,
+            cap_model=self._spec.defaults.cap_model,
             aux_channels=self._spec.defaults.aux_channels,
             filters=self._spec.defaults.filters,
             extras=self._spec.defaults.extras,

--- a/bidsmgr/gui/recording_meta_dialog.py
+++ b/bidsmgr/gui/recording_meta_dialog.py
@@ -147,6 +147,7 @@ class RecordingMetaDialog(QDialog):
         bl.addWidget(self._region_label("Modality-agnostic", agnostic=True))
         bl.addWidget(self._build_institution_group())
         bl.addWidget(self._build_event_group())
+        bl.addWidget(self._build_participants_group())
         bl.addWidget(self._build_phenotype_group())
         bl.addStretch(1)
         scroll = QScrollArea()
@@ -372,6 +373,42 @@ class RecordingMetaDialog(QDialog):
         for r in rows:
             self._events.removeRow(r)
 
+    def _build_participants_group(self) -> QGroupBox:
+        box = QGroupBox("Participants spreadsheet  ·  modality-agnostic  →  participants.tsv")
+        v = QVBoxLayout(box)
+        v.setContentsMargins(8, 6, 8, 6)
+        v.setSpacing(4)
+        hint = QLabel(
+            "Optional table keyed by participant_id. Its age / sex / handedness "
+            "override the inventory; any extra columns (group, IQ, ...) are added "
+            "to participants.tsv. A sibling <name>.json supplies column "
+            "descriptions / Levels / Units."
+        )
+        hint.setWordWrap(True)
+        v.addWidget(hint)
+        row = QHBoxLayout()
+        self._participants_file = QLineEdit()
+        self._participants_file.setObjectName("ent-input")
+        self._participants_file.setReadOnly(True)
+        self._participants_file.setPlaceholderText("(none)")
+        browse = QPushButton("Choose…")
+        browse.clicked.connect(self._choose_participants_file)
+        clear = QPushButton("Clear")
+        clear.clicked.connect(lambda: self._participants_file.clear())
+        row.addWidget(self._participants_file, 1)
+        row.addWidget(browse)
+        row.addWidget(clear)
+        v.addLayout(row)
+        return box
+
+    def _choose_participants_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select participants spreadsheet", "",
+            "Tables (*.tsv *.csv *.xlsx *.ods);;All files (*)",
+        )
+        if path:
+            self._participants_file.setText(path)
+
     def _build_phenotype_group(self) -> QGroupBox:
         box = QGroupBox("Phenotype tables  ·  modality-agnostic  →  phenotype/")
         v = QVBoxLayout(box)
@@ -455,6 +492,8 @@ class RecordingMetaDialog(QDialog):
         self._phenotype.clear()
         for p in self._spec.phenotype_files:
             self._phenotype.addItem(str(p))
+
+        self._participants_file.setText(self._spec.participants_file or "")
 
     @staticmethod
     def _set_combo(combo: QComboBox, value: Optional[str], blank: str) -> None:
@@ -573,6 +612,7 @@ class RecordingMetaDialog(QDialog):
             "defaults": acq,
             "event_maps": event_maps,
             "phenotype_files": phenotype_files,
+            "participants_file": self._participants_file.text().strip(),
         })
 
     def _on_save(self) -> None:

--- a/bidsmgr/gui/recording_meta_dialog.py
+++ b/bidsmgr/gui/recording_meta_dialog.py
@@ -1,0 +1,398 @@
+"""Dataset-level recording-metadata editor (the "global changes" surface).
+
+Opened from the inspection footer's "Recording metadata" button, this dialog
+edits the dataset-wide enrichment defaults plus the event-code labels, backed by
+the same ``<inventory>.tsv.recording_meta.json`` scaffold the scan writes and the
+convert verb auto-discovers. Per-row overrides (reference, ground, montage,
+line_freq, demographics) live in the inspection table; this is for the values
+shared across the dataset.
+
+``montage`` and ``line_freq`` are dropdown-only here too (never hand-typed).
+Auxiliary-channel / filter / extras tables are a later addition; this v1 covers
+the highest-value fields: device, institution, reference/ground, and the event
+map the scan seeded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QPushButton,
+    QScrollArea,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..recording_meta import AcquisitionSpec, RecordingMetaSpec, dump_spec, load_spec
+from .delegates import builtin_montages
+
+_NONE = "(none)"
+_BLANK = "(blank)"
+
+# Common EEG + MEG amplifier/system manufacturers, offered as an editable
+# dropdown (the user can still type any other value). MEG names follow the BIDS
+# Manufacturer convention; EEG names are the common vendors.
+_MANUFACTURERS: tuple[str, ...] = (
+    # EEG
+    "Brain Products", "BioSemi", "EGI / Philips Neuro", "ANT Neuro",
+    "Compumedics Neuroscan", "g.tec", "Cognionics", "mBrainTrain", "OpenBCI",
+    # MEG (BIDS convention)
+    "MEGIN / Elekta / Neuromag", "CTF", "4D Neuroimaging / BTi",
+    "KIT / Yokogawa", "ITAB", "KRISS", "FieldLine", "QuSpin",
+)
+
+
+class RecordingMetaDialog(QDialog):
+    """Edit the dataset-level recording-metadata scaffold."""
+
+    def __init__(
+        self,
+        scaffold_path: Path,
+        present_datatypes: Optional[set[str]] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Dataset metadata")
+        self.resize(560, 640)
+        self._scaffold_path = Path(scaffold_path)
+        # Datatypes the scanned dataset actually contains. Drives which sections
+        # / fields make sense: the recording-acquisition section is hidden for a
+        # dataset with no EEG/MEG, and within it the scalp-EEG fields
+        # (reference / ground / montage / cap) are hidden for MEG-only. The
+        # agnostic sections (events, phenotype) always show.
+        self._present = set(present_datatypes or {"eeg", "meg", "ieeg", "nirs"})
+        self._spec = self._load()
+
+        outer = QVBoxLayout(self)
+        intro = QLabel(
+            "Dataset-wide metadata, grouped by where it is written. "
+            "Modality-agnostic sections apply to any dataset; modality-specific "
+            "sections only affect their datatype's sidecars. Per-recording "
+            "overrides live in the inspection table."
+        )
+        intro.setWordWrap(True)
+        outer.addWidget(intro)
+
+        body = QWidget()
+        bl = QVBoxLayout(body)
+        bl.setContentsMargins(0, 0, 0, 0)
+        # Modality-specific (non-agnostic) -> the datatype sidecar, split into a
+        # generic device/site block (all EEG/MEG) and an EEG-only montage block.
+        self._device_box = self._build_device_group()
+        self._eeg_box = self._build_eeg_group()
+        bl.addWidget(self._device_box)
+        bl.addWidget(self._eeg_box)
+        # Modality-agnostic -> their own destination files.
+        bl.addWidget(self._build_event_group())
+        bl.addWidget(self._build_phenotype_group())
+        bl.addStretch(1)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(body)
+        outer.addWidget(scroll, 1)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self._on_save)
+        buttons.rejected.connect(self.reject)
+        outer.addWidget(buttons)
+
+        self._populate()
+        self._apply_modality_constraints()
+
+    def _apply_modality_constraints(self) -> None:
+        """Show/hide modality-specific sections by what was scanned.
+
+        Both non-agnostic sections are hidden when the dataset has no
+        EEG/MEG/iEEG/NIRS. The EEG montage/reference section is additionally
+        hidden for a dataset with no scalp-EEG (e.g. MEG-only).
+        """
+        has_eeg_meg = bool(self._present & {"eeg", "meg", "ieeg", "nirs"})
+        has_eeg = bool(self._present & {"eeg", "ieeg"})
+        # Flags consulted by build_spec so a hidden section's loaded values are
+        # preserved (not clobbered by the empty, never-shown widgets).
+        self._device_applies = has_eeg_meg
+        self._eeg_applies = has_eeg
+        self._device_box.setVisible(has_eeg_meg)
+        self._eeg_box.setVisible(has_eeg)
+
+    # ------------------------------------------------------------------
+    # build
+    # ------------------------------------------------------------------
+
+    def _build_device_group(self) -> QGroupBox:
+        # Generic recording sidecar fields - apply to every EEG/MEG datatype's
+        # sidecar (Manufacturer / InstitutionName etc. are not scalp-specific).
+        box = QGroupBox(
+            "Device & institution  ·  modality-specific  →  sub-..._<datatype>.json"
+        )
+        form = QFormLayout(box)
+
+        self._manufacturer = QComboBox()
+        self._manufacturer.setEditable(True)  # pick a default OR type another
+        self._manufacturer.addItem("")
+        self._manufacturer.addItems(_MANUFACTURERS)
+        self._amplifier_model = QLineEdit()
+        self._software_versions = QLineEdit()
+        self._institution_name = QLineEdit()
+        self._institution_dept = QLineEdit()
+        self._line_freq = QComboBox()
+        self._line_freq.addItems([_BLANK, "50", "60"])
+
+        form.addRow("Manufacturer:", self._manufacturer)
+        form.addRow("Amplifier / system model:", self._amplifier_model)
+        form.addRow("Software versions:", self._software_versions)
+        form.addRow("Institution name:", self._institution_name)
+        form.addRow("Institution department:", self._institution_dept)
+        form.addRow("Default line frequency (Hz):", self._line_freq)
+        return box
+
+    def _build_eeg_group(self) -> QGroupBox:
+        # Scalp-EEG / iEEG only sidecar fields.
+        box = QGroupBox(
+            "EEG montage & references  ·  EEG / iEEG only  →  sub-..._eeg.json + electrodes.tsv"
+        )
+        form = QFormLayout(box)
+
+        self._cap_manufacturer = QLineEdit()
+        self._eeg_reference = QLineEdit()
+        self._eeg_ground = QLineEdit()
+        self._montage = QComboBox()
+        self._montage.addItem(_NONE)
+        self._montage.addItems(builtin_montages())
+
+        form.addRow("Default EEG reference:", self._eeg_reference)
+        form.addRow("Default EEG ground:", self._eeg_ground)
+        form.addRow("Default montage:", self._montage)
+        form.addRow("Cap manufacturer:", self._cap_manufacturer)
+        return box
+
+    def _build_event_group(self) -> QGroupBox:
+        box = QGroupBox("Events (trigger code -> label)  ·  modality-agnostic  →  events.tsv")
+        v = QVBoxLayout(box)
+        self._events = QTableWidget(0, 2)
+        self._events.setHorizontalHeaderLabels(["Code", "Label"])
+        self._events.horizontalHeader().setStretchLastSection(True)
+        # Bound the table height so it does not greedily expand: the whole
+        # dialog then scrolls as one (rather than only this table scrolling).
+        self._events.setMinimumHeight(120)
+        self._events.setMaximumHeight(200)
+        v.addWidget(self._events)
+
+        row = QHBoxLayout()
+        add = QPushButton("Add row")
+        add.clicked.connect(lambda: self._events.insertRow(self._events.rowCount()))
+        rem = QPushButton("Remove selected")
+        rem.clicked.connect(self._remove_selected_event)
+        row.addWidget(add)
+        row.addWidget(rem)
+        row.addStretch(1)
+        v.addLayout(row)
+        return box
+
+    def _remove_selected_event(self) -> None:
+        rows = sorted({i.row() for i in self._events.selectedIndexes()}, reverse=True)
+        for r in rows:
+            self._events.removeRow(r)
+
+    def _build_phenotype_group(self) -> QGroupBox:
+        box = QGroupBox("Phenotype tables  ·  modality-agnostic  →  phenotype/")
+        v = QVBoxLayout(box)
+        v.addWidget(QLabel(
+            "Participant-level measure tables (TSV/CSV/XLSX/ODS keyed by "
+            "participant_id). Each becomes phenotype/<measure>.tsv + .json."
+        ))
+        self._phenotype = QListWidget()
+        self._phenotype.setMaximumHeight(110)
+        v.addWidget(self._phenotype)
+        row = QHBoxLayout()
+        add = QPushButton("Add file…")
+        add.clicked.connect(self._add_phenotype_file)
+        rem = QPushButton("Remove selected")
+        rem.clicked.connect(self._remove_phenotype)
+        row.addWidget(add)
+        row.addWidget(rem)
+        row.addStretch(1)
+        v.addLayout(row)
+        return box
+
+    def _add_phenotype_file(self) -> None:
+        paths, _ = QFileDialog.getOpenFileNames(
+            self, "Select phenotype table(s)", "",
+            "Tables (*.tsv *.csv *.xlsx *.ods);;All files (*)",
+        )
+        existing = {self._phenotype.item(i).text() for i in range(self._phenotype.count())}
+        for p in paths:
+            if p and p not in existing:
+                self._phenotype.addItem(p)
+
+    def _remove_phenotype(self) -> None:
+        for item in self._phenotype.selectedItems():
+            self._phenotype.takeItem(self._phenotype.row(item))
+
+    # ------------------------------------------------------------------
+    # load / populate / save
+    # ------------------------------------------------------------------
+
+    def _load(self) -> RecordingMetaSpec:
+        if self._scaffold_path.exists():
+            try:
+                return load_spec(self._scaffold_path)
+            except Exception:
+                pass
+        return RecordingMetaSpec()
+
+    def _populate(self) -> None:
+        acq = self._spec.defaults
+        self._manufacturer.setCurrentText(acq.manufacturer or "")
+        self._amplifier_model.setText(acq.amplifier_model or "")
+        self._software_versions.setText(acq.software_versions or "")
+        self._cap_manufacturer.setText(acq.cap_manufacturer or "")
+        self._institution_name.setText(acq.institution_name or "")
+        self._institution_dept.setText(acq.institution_dept or "")
+        self._eeg_reference.setText(acq.eeg_reference or "")
+        self._eeg_ground.setText(acq.eeg_ground or "")
+        self._set_combo(self._montage, acq.montage, _NONE)
+        self._set_combo(
+            self._line_freq,
+            str(int(acq.power_line_freq)) if acq.power_line_freq else "",
+            _BLANK,
+        )
+
+        event_map = self._spec.event_maps.get("*", {})
+        self._events.setRowCount(0)
+        for code, label in event_map.items():
+            r = self._events.rowCount()
+            self._events.insertRow(r)
+            self._events.setItem(r, 0, QTableWidgetItem(str(code)))
+            self._events.setItem(r, 1, QTableWidgetItem(str(label)))
+
+        self._phenotype.clear()
+        for p in self._spec.phenotype_files:
+            self._phenotype.addItem(str(p))
+
+    @staticmethod
+    def _set_combo(combo: QComboBox, value: Optional[str], blank: str) -> None:
+        value = (value or "").strip()
+        if not value:
+            combo.setCurrentText(blank)
+            return
+        pos = combo.findText(value)
+        if pos < 0:
+            combo.addItem(value)
+            pos = combo.findText(value)
+        combo.setCurrentIndex(pos)
+
+    @staticmethod
+    def _combo_value(combo: QComboBox, blank: str) -> Optional[str]:
+        text = combo.currentText()
+        return None if text == blank else text
+
+    def build_spec(self) -> RecordingMetaSpec:
+        """Assemble a :class:`RecordingMetaSpec` from the current form state.
+
+        Sections hidden for the scanned modality keep their loaded values
+        (read from ``self._spec``) rather than reading the empty, never-shown
+        widgets - so a MEG-only or MRI-only dataset never wipes EEG fields a
+        shared scaffold may carry.
+        """
+        def _opt(edit: QLineEdit) -> Optional[str]:
+            t = edit.text().strip()
+            return t or None
+
+        prev = self._spec.defaults
+
+        # Device & institution block (generic sidecar; all EEG/MEG).
+        if self._device_applies:
+            manufacturer = self._manufacturer.currentText().strip() or None
+            amplifier_model = _opt(self._amplifier_model)
+            software_versions = _opt(self._software_versions)
+            institution_name = _opt(self._institution_name)
+            institution_dept = _opt(self._institution_dept)
+            lf = self._combo_value(self._line_freq, _BLANK)
+            power_line_freq = float(lf) if lf else None
+        else:
+            manufacturer = prev.manufacturer
+            amplifier_model = prev.amplifier_model
+            software_versions = prev.software_versions
+            institution_name = prev.institution_name
+            institution_dept = prev.institution_dept
+            power_line_freq = prev.power_line_freq
+
+        # EEG montage & references block (EEG/iEEG only).
+        if self._eeg_applies:
+            eeg_ref = _opt(self._eeg_reference)
+            eeg_gnd = _opt(self._eeg_ground)
+            cap = _opt(self._cap_manufacturer)
+            montage = self._combo_value(self._montage, _NONE)
+        else:
+            eeg_ref = prev.eeg_reference
+            eeg_gnd = prev.eeg_ground
+            cap = prev.cap_manufacturer
+            montage = prev.montage
+
+        acq = AcquisitionSpec(
+            manufacturer=manufacturer,
+            amplifier_model=amplifier_model,
+            software_versions=software_versions,
+            cap_manufacturer=cap,
+            institution_name=institution_name,
+            institution_dept=institution_dept,
+            eeg_reference=eeg_ref,
+            eeg_ground=eeg_gnd,
+            montage=montage,
+            power_line_freq=power_line_freq,
+            # Preserve blocks this dialog does not edit (aux channels, etc.).
+            aux_channels=self._spec.defaults.aux_channels,
+            filters=self._spec.defaults.filters,
+            extras=self._spec.defaults.extras,
+        )
+
+        event_map: dict[str, str] = {}
+        for r in range(self._events.rowCount()):
+            code_item = self._events.item(r, 0)
+            label_item = self._events.item(r, 1)
+            code = code_item.text().strip() if code_item else ""
+            label = label_item.text().strip() if label_item else ""
+            if code:
+                event_map[code] = label
+
+        event_maps = dict(self._spec.event_maps)
+        if event_map:
+            event_maps["*"] = event_map
+        else:
+            event_maps.pop("*", None)
+
+        phenotype_files = [
+            self._phenotype.item(i).text() for i in range(self._phenotype.count())
+        ]
+
+        return self._spec.model_copy(update={
+            "defaults": acq,
+            "event_maps": event_maps,
+            "phenotype_files": phenotype_files,
+        })
+
+    def _on_save(self) -> None:
+        spec = self.build_spec()
+        self._scaffold_path.parent.mkdir(parents=True, exist_ok=True)
+        self._scaffold_path.write_text(dump_spec(spec), encoding="utf-8")
+        self.accept()
+
+
+__all__ = ["RecordingMetaDialog"]

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -542,6 +542,17 @@ class SettingsDialog(QDialog):
         )
         form.addRow("Residuals:", self._convert_skip_residuals)
 
+        self._convert_force_edf = QCheckBox(
+            "Force EDF for EEG / iEEG (re-encode recordings to EDF on convert)"
+        )
+        self._convert_force_edf.setToolTip(
+            "Re-encode EEG / iEEG recordings to EDF instead of keeping the "
+            "source format. Harmonises a study to one BIDS-native format, and "
+            "makes a non-BIDS-native but mne-readable source (GDF, EGI, ...) "
+            "convertible. MEG / NIRS are unaffected."
+        )
+        form.addRow("Force EDF:", self._convert_force_edf)
+
         v.addWidget(convert)
 
         # Post-convert chain laid out as an indented hierarchy: each step is
@@ -633,6 +644,7 @@ class SettingsDialog(QDialog):
         idx = self._convert_on_existing.findData(s.convert_on_existing)
         self._convert_on_existing.setCurrentIndex(idx if idx >= 0 else 0)
         self._convert_skip_residuals.setChecked(s.convert_skip_residuals)
+        self._convert_force_edf.setChecked(s.convert_force_edf)
 
         self._post_run_metadata.setChecked(s.post_run_metadata)
         self._post_metadata_fill_todos.setChecked(s.post_metadata_fill_todos)
@@ -697,6 +709,7 @@ class SettingsDialog(QDialog):
         # Keep the legacy flag in sync for any old reader.
         s.convert_overwrite = (s.convert_on_existing == "replace")
         s.convert_skip_residuals = self._convert_skip_residuals.isChecked()
+        s.convert_force_edf = self._convert_force_edf.isChecked()
 
         s.post_run_metadata = self._post_run_metadata.isChecked()
         s.post_metadata_fill_todos = self._post_metadata_fill_todos.isChecked()

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -511,11 +511,25 @@ class SettingsDialog(QDialog):
         )
         form.addRow("Parallel workers (-j):", self._convert_jobs)
 
-        self._convert_overwrite = QCheckBox(
-            "Overwrite existing subjects in the BIDS output (otherwise "
-            "the convert verb refuses to clobber)"
+        # Policy for a subject that already exists in the dataset (incremental
+        # conversion). New sessions/datatypes always merge in; this governs
+        # files that collide with existing ones. Replaces the old overwrite
+        # checkbox (which mapped only to "replace").
+        self._convert_on_existing = QComboBox()
+        for value, label in (
+            ("skip",    "Skip: keep existing files, add only new (safe default)"),
+            ("update",  "Update: replace only files whose content changed"),
+            ("replace", "Replace: back up and replace colliding files"),
+            ("error",   "Error: abort a subject if any file would be overwritten"),
+        ):
+            self._convert_on_existing.addItem(label, userData=value)
+        self._convert_on_existing.setToolTip(
+            "What to do when a subject already exists in the dataset. Adding a "
+            "new session or datatype always merges in; this only governs files "
+            "that collide with existing ones. Existing data is never lost on the "
+            "default (Skip)."
         )
-        form.addRow("Overwrite:", self._convert_overwrite)
+        form.addRow("Existing subjects:", self._convert_on_existing)
 
         self._convert_skip_residuals = QCheckBox(
             "Skip residual volumes (drop dcm2niix secondary duplicates such "
@@ -616,7 +630,8 @@ class SettingsDialog(QDialog):
         self._scan_skip_bids_guess.setChecked(s.scan_skip_bids_guess)
 
         self._convert_jobs.setValue(max(1, min(s.convert_n_jobs, cap)))
-        self._convert_overwrite.setChecked(s.convert_overwrite)
+        idx = self._convert_on_existing.findData(s.convert_on_existing)
+        self._convert_on_existing.setCurrentIndex(idx if idx >= 0 else 0)
         self._convert_skip_residuals.setChecked(s.convert_skip_residuals)
 
         self._post_run_metadata.setChecked(s.post_run_metadata)
@@ -678,7 +693,9 @@ class SettingsDialog(QDialog):
         s.scan_skip_bids_guess = self._scan_skip_bids_guess.isChecked()
 
         s.convert_n_jobs = self._convert_jobs.value()
-        s.convert_overwrite = self._convert_overwrite.isChecked()
+        s.convert_on_existing = self._convert_on_existing.currentData() or "skip"
+        # Keep the legacy flag in sync for any old reader.
+        s.convert_overwrite = (s.convert_on_existing == "replace")
         s.convert_skip_residuals = self._convert_skip_residuals.isChecked()
 
         s.post_run_metadata = self._post_run_metadata.isChecked()

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -218,15 +218,11 @@ class SettingsDialog(QDialog):
         self._scan_dataset.setPlaceholderText("(auto-derive from raw folder name)")
         form.addRow("Default dataset slug:", self._scan_dataset)
 
-        self._scan_line_freq = QDoubleSpinBox()
-        self._scan_line_freq.setRange(0.0, 100.0)
-        self._scan_line_freq.setDecimals(1)
-        self._scan_line_freq.setSingleStep(1.0)
-        form.addRow("EEG/MEG line frequency (Hz):", self._scan_line_freq)
-
-        self._scan_montage = QLineEdit()
-        self._scan_montage.setPlaceholderText("e.g. standard_1005, biosemi64")
-        form.addRow("EEG/MEG montage:", self._scan_montage)
+        # EEG/MEG line frequency + montage are no longer scan settings: they
+        # are recording metadata, edited as dropdowns per recording in the
+        # inspection table (montage / line_freq columns) and dataset-wide in
+        # the "Recording metadata" editor. Free-text fields here would have
+        # been a second, inconsistent way to set the same values.
 
         self._scan_probe = QCheckBox(
             "Enable --probe-convert (run dcm2niix per series to enrich "
@@ -616,8 +612,6 @@ class SettingsDialog(QDialog):
 
         self._scan_jobs.setValue(max(1, min(s.scan_n_jobs, cap)))
         self._scan_dataset.setText(s.dataset_slug)
-        self._scan_line_freq.setValue(s.scan_line_freq)
-        self._scan_montage.setText(s.scan_montage)
         self._scan_probe.setChecked(s.scan_probe_convert)
         self._scan_skip_bids_guess.setChecked(s.scan_skip_bids_guess)
 
@@ -680,8 +674,6 @@ class SettingsDialog(QDialog):
 
         s.scan_n_jobs = self._scan_jobs.value()
         s.dataset_slug = self._scan_dataset.text().strip()
-        s.scan_line_freq = self._scan_line_freq.value()
-        s.scan_montage = self._scan_montage.text().strip()
         s.scan_probe_convert = self._scan_probe.isChecked()
         s.scan_skip_bids_guess = self._scan_skip_bids_guess.isChecked()
 

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -3,13 +3,17 @@
 Reads / writes :class:`bidsmgr.gui.app_settings.AppSettings` via
 ``QSettings``. All changes are applied on **Save** (no live binding) so
 the user can experiment with values and cancel without commit.
+
+Tabs: Display / System / Scan / Convert + post-convert. The Convert tab
+lays the post-convert chain out as an indented hierarchy (parent step +
+its sub-options), and a "Restore defaults" button resets every widget to
+the :class:`AppSettings` field defaults.
 """
 
 from __future__ import annotations
 
 from typing import Optional
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -18,6 +22,7 @@ from PyQt6.QtWidgets import (
     QDoubleSpinBox,
     QFormLayout,
     QGroupBox,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QSpinBox,
@@ -26,11 +31,35 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ..util.system_info import SystemInfo, get_system_info
 from .app_settings import AppSettings
 
 
+def _indented(child: QWidget, *, indent: int = 22) -> QWidget:
+    """Wrap ``child`` in a left-indented container so it reads as a
+    sub-option nested under the checkbox above it (the post-convert
+    hierarchy tree)."""
+    box = QWidget()
+    lay = QHBoxLayout(box)
+    lay.setContentsMargins(indent, 0, 0, 0)
+    lay.setSpacing(6)
+    lay.addWidget(child)
+    lay.addStretch(1)
+    return box
+
+
+def _bind_children(parent_cb: QCheckBox, *children: QWidget) -> None:
+    """Enable ``children`` only while ``parent_cb`` is checked, and sync
+    immediately so the initial state is correct."""
+    def _sync(checked: bool) -> None:
+        for c in children:
+            c.setEnabled(checked)
+    parent_cb.toggled.connect(_sync)
+    _sync(parent_cb.isChecked())
+
+
 class SettingsDialog(QDialog):
-    """Three-tab settings dialog: Display / Scan / Convert.
+    """Settings dialog: Display / System / Scan / Convert + post-convert.
 
     Theme + post-convert chain live under their natural homes. The
     inspector column visibility is NOT here — it's controlled via the
@@ -41,25 +70,37 @@ class SettingsDialog(QDialog):
     def __init__(self, settings: AppSettings, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("BIDS-Manager — Settings")
-        self.resize(540, 560)
+        self.resize(560, 600)
         self._settings = settings
+        # Detected once: the worker-count spinboxes are capped at the host's
+        # logical thread count so the user can never ask for more workers
+        # than the machine has threads.
+        self._sys: SystemInfo = get_system_info()
 
         v = QVBoxLayout(self)
 
         tabs = QTabWidget()
         tabs.addTab(self._build_display_tab(), "Display")
+        tabs.addTab(self._build_system_tab(), "System")
         tabs.addTab(self._build_scan_tab(), "Scan")
         tabs.addTab(self._build_convert_tab(), "Convert + post-convert")
         v.addWidget(tabs, 1)
 
-        # Save / Cancel.
+        # Save / Cancel / Restore defaults.
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Save
-            | QDialogButtonBox.StandardButton.Cancel,
+            | QDialogButtonBox.StandardButton.Cancel
+            | QDialogButtonBox.StandardButton.RestoreDefaults,
         )
         buttons.accepted.connect(self._on_save)
         buttons.rejected.connect(self.reject)
+        buttons.button(
+            QDialogButtonBox.StandardButton.RestoreDefaults
+        ).clicked.connect(self._on_restore_defaults)
         v.addWidget(buttons)
+
+        # Populate every widget from the current settings.
+        self._load_into_widgets(self._settings)
 
     # ------------------------------------------------------------------
     # Tabs
@@ -75,35 +116,32 @@ class SettingsDialog(QDialog):
         ("Extra large (1.50x)",    1.50),
     ]
 
+    # Combo presets for the header brand mark.
+    _HEADER_LOGO_PRESETS: list[tuple[str, str]] = [
+        ("Default (monochrome mark)", "default"),
+        ("App icon (full color)",     "app_icon"),
+    ]
+
     def _build_display_tab(self) -> QWidget:
         w = QWidget()
         form = QFormLayout(w)
 
         self._theme_combo = QComboBox()
         self._theme_combo.addItems(["dark", "light"])
-        self._theme_combo.setCurrentText(self._settings.theme)
         form.addRow("Theme:", self._theme_combo)
 
         # Font scale: multiplies every font-size (QSS + delegate paints +
         # inline stylesheets + icon sizes) so the user can comfortably
-        # nudge the whole UI up or down without touching individual
-        # widgets. The user's choice is persisted in QSettings under
-        # ``ui/font_scale``.
+        # nudge the whole UI up or down. Persisted under ``ui/font_scale``.
         self._font_scale_combo = QComboBox()
         for label, _value in self._FONT_SCALE_PRESETS:
             self._font_scale_combo.addItem(label)
-        current_idx = self._closest_font_scale_index(self._settings.font_scale)
-        self._font_scale_combo.setCurrentIndex(current_idx)
         form.addRow("Font scale:", self._font_scale_combo)
 
-        # Header brand artwork. "Default" = minimalist mark inverted on
-        # dark; "App icon" = full-color BIDS-Manager application icon.
+        # Header brand artwork.
         self._header_logo_combo = QComboBox()
         for label, _value in self._HEADER_LOGO_PRESETS:
             self._header_logo_combo.addItem(label)
-        self._header_logo_combo.setCurrentIndex(
-            self._header_logo_index(self._settings.header_logo)
-        )
         form.addRow("Header logo:", self._header_logo_combo)
 
         hint = QLabel(
@@ -116,50 +154,55 @@ class SettingsDialog(QDialog):
 
         return w
 
-    # Combo presets for the header brand mark.
-    _HEADER_LOGO_PRESETS: list[tuple[str, str]] = [
-        ("Default (monochrome mark)", "default"),
-        ("App icon (full color)",     "app_icon"),
-    ]
+    def _build_system_tab(self) -> QWidget:
+        w = QWidget()
+        v = QVBoxLayout(w)
 
-    @classmethod
-    def _header_logo_index(cls, value: str) -> int:
-        for i, (_label, key) in enumerate(cls._HEADER_LOGO_PRESETS):
-            if key == value:
-                return i
-        return 0
+        info = QGroupBox("System info (detected)")
+        form = QFormLayout(info)
 
-    @classmethod
-    def _closest_font_scale_index(cls, value: float) -> int:
-        """Return the preset index whose multiplier is nearest *value*.
+        threads = self._sys.logical_threads
+        cores = self._sys.physical_cores
+        cpu_txt = f"{threads} logical threads"
+        if cores:
+            cpu_txt += f"  /  {cores} physical cores"
+        form.addRow("CPU:", QLabel(cpu_txt))
 
-        Lets us round-trip an arbitrary persisted float (e.g. a hand-
-        edited QSettings value) back to the nearest combo entry without
-        rejecting it.
-        """
-        try:
-            return min(
-                range(len(cls._FONT_SCALE_PRESETS)),
-                key=lambda i: abs(cls._FONT_SCALE_PRESETS[i][1] - value),
-            )
-        except Exception:
-            return 1  # "Normal"
+        ram_gib = self._sys.total_ram_gib
+        form.addRow(
+            "Memory:",
+            QLabel(f"{ram_gib:.1f} GiB total" if ram_gib is not None else "unknown"),
+        )
+
+        v.addWidget(info)
+
+        note = QLabel(
+            "Parallel-worker counts (Scan and Convert) are capped at the "
+            f"detected thread count ({threads}). Asking for more workers than "
+            "the machine has threads only adds scheduling overhead, so the "
+            "spinboxes will not go higher."
+        )
+        note.setStyleSheet("color: #8b949e;")
+        note.setWordWrap(True)
+        v.addWidget(note)
+        v.addStretch(1)
+        return w
 
     def _build_scan_tab(self) -> QWidget:
         w = QWidget()
         v = QVBoxLayout(w)
 
-        # Defaults group.
         defaults = QGroupBox("Scan defaults")
         form = QFormLayout(defaults)
 
         self._scan_jobs = QSpinBox()
-        self._scan_jobs.setRange(1, 64)
-        self._scan_jobs.setValue(self._settings.scan_n_jobs)
+        self._scan_jobs.setRange(1, self._sys.logical_threads)
+        self._scan_jobs.setToolTip(
+            f"Capped at the detected thread count ({self._sys.logical_threads})."
+        )
         form.addRow("Parallel workers (-j):", self._scan_jobs)
 
         self._scan_dataset = QLineEdit()
-        self._scan_dataset.setText(self._settings.dataset_slug)
         self._scan_dataset.setPlaceholderText("(auto-derive from raw folder name)")
         form.addRow("Default dataset slug:", self._scan_dataset)
 
@@ -167,11 +210,9 @@ class SettingsDialog(QDialog):
         self._scan_line_freq.setRange(0.0, 100.0)
         self._scan_line_freq.setDecimals(1)
         self._scan_line_freq.setSingleStep(1.0)
-        self._scan_line_freq.setValue(self._settings.scan_line_freq)
         form.addRow("EEG/MEG line frequency (Hz):", self._scan_line_freq)
 
         self._scan_montage = QLineEdit()
-        self._scan_montage.setText(self._settings.scan_montage)
         self._scan_montage.setPlaceholderText("e.g. standard_1005, biosemi64")
         form.addRow("EEG/MEG montage:", self._scan_montage)
 
@@ -179,14 +220,12 @@ class SettingsDialog(QDialog):
             "Enable --probe-convert (run dcm2niix per series to enrich "
             "naming with the actual file count + extensions)"
         )
-        self._scan_probe.setChecked(self._settings.scan_probe_convert)
         form.addRow("Probe:", self._scan_probe)
 
         self._scan_skip_bids_guess = QCheckBox(
             "Skip dcm2niix BidsGuess classifier (use only the legacy "
             "regex fallback layer)"
         )
-        self._scan_skip_bids_guess.setChecked(self._settings.scan_skip_bids_guess)
         form.addRow("Classifier:", self._scan_skip_bids_guess)
 
         v.addWidget(defaults)
@@ -199,60 +238,135 @@ class SettingsDialog(QDialog):
 
         convert = QGroupBox("Convert defaults")
         form = QFormLayout(convert)
+
         self._convert_jobs = QSpinBox()
-        self._convert_jobs.setRange(1, 64)
-        self._convert_jobs.setValue(self._settings.convert_n_jobs)
+        self._convert_jobs.setRange(1, self._sys.logical_threads)
+        self._convert_jobs.setToolTip(
+            f"Capped at the detected thread count ({self._sys.logical_threads})."
+        )
         form.addRow("Parallel workers (-j):", self._convert_jobs)
 
         self._convert_overwrite = QCheckBox(
             "Overwrite existing subjects in the BIDS output (otherwise "
             "the convert verb refuses to clobber)"
         )
-        self._convert_overwrite.setChecked(self._settings.convert_overwrite)
         form.addRow("Overwrite:", self._convert_overwrite)
+
+        self._convert_skip_residuals = QCheckBox(
+            "Skip residual volumes (drop dcm2niix secondary duplicates such "
+            "as ..._bolda / _Eq_ / _ROI that are not real images)"
+        )
+        self._convert_skip_residuals.setToolTip(
+            "dcm2niix splits a single input series into the real image plus "
+            "derived single-volume duplicates it names ..._bolda, ..._Eq_1, "
+            "etc. These have no valid BIDS suffix. Recommended: on."
+        )
+        form.addRow("Residuals:", self._convert_skip_residuals)
 
         v.addWidget(convert)
 
-        # Post-convert chain.
+        # Post-convert chain laid out as an indented hierarchy: each step is
+        # a parent checkbox; its sub-options sit indented beneath and are
+        # enabled only while the parent is on.
         post = QGroupBox("Post-convert chain (run after every conversion)")
-        pform = QFormLayout(post)
+        pv = QVBoxLayout(post)
+        pv.setSpacing(4)
 
         self._post_run_metadata = QCheckBox(
-            "Run bidsmgr-metadata (writes dataset_description, "
-            "participants.tsv, *_scans.tsv, sidecar audit)"
+            "Generate metadata (dataset_description, participants.tsv, "
+            "*_scans.tsv, sidecar audit)"
         )
-        self._post_run_metadata.setChecked(self._settings.post_run_metadata)
-        pform.addRow(self._post_run_metadata)
-
+        pv.addWidget(self._post_run_metadata)
         self._post_metadata_fill_todos = QCheckBox(
-            "  └ insert 'TODO' placeholders for missing recommended fields"
+            "Insert 'TODO' placeholders for missing recommended fields"
         )
-        self._post_metadata_fill_todos.setChecked(self._settings.post_metadata_fill_todos)
-        pform.addRow(self._post_metadata_fill_todos)
+        pv.addWidget(_indented(self._post_metadata_fill_todos))
 
         self._post_run_validate = QCheckBox(
-            "Run bidsmgr-validate (schema + bidsschematools structural)"
+            "Validate dataset (schema + bidsschematools structural)"
         )
-        self._post_run_validate.setChecked(self._settings.post_run_validate)
-        pform.addRow(self._post_run_validate)
-
+        pv.addWidget(self._post_run_validate)
         self._post_validate_strict = QCheckBox(
-            "  └ --strict (warnings → errors)"
+            "Strict: treat warnings as errors (--strict)"
         )
-        self._post_validate_strict.setChecked(self._settings.post_validate_strict)
-        pform.addRow(self._post_validate_strict)
-
         self._post_validate_html = QCheckBox(
-            "  └ --html (write self-contained validation_report.html)"
+            "Write a self-contained validation_report.html (--html)"
         )
-        self._post_validate_html.setChecked(self._settings.post_validate_html)
-        pform.addRow(self._post_validate_html)
+        pv.addWidget(_indented(self._post_validate_strict))
+        pv.addWidget(_indented(self._post_validate_html))
+
+        _bind_children(self._post_run_metadata, self._post_metadata_fill_todos)
+        _bind_children(
+            self._post_run_validate,
+            self._post_validate_strict,
+            self._post_validate_html,
+        )
 
         v.addWidget(post)
         v.addStretch(1)
         return w
 
     # ------------------------------------------------------------------
+    # Widget <-> settings
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _header_logo_index(cls, value: str) -> int:
+        for i, (_label, key) in enumerate(cls._HEADER_LOGO_PRESETS):
+            if key == value:
+                return i
+        return 0
+
+    @classmethod
+    def _closest_font_scale_index(cls, value: float) -> int:
+        """Return the preset index whose multiplier is nearest *value*."""
+        try:
+            return min(
+                range(len(cls._FONT_SCALE_PRESETS)),
+                key=lambda i: abs(cls._FONT_SCALE_PRESETS[i][1] - value),
+            )
+        except Exception:
+            return 1  # "Normal"
+
+    def _load_into_widgets(self, s: AppSettings) -> None:
+        """Push every value from ``s`` into the dialog's widgets.
+
+        Used both on open (with the live settings) and by "Restore
+        defaults" (with a fresh ``AppSettings()``), so the two paths can
+        never drift. Worker counts are clamped to the detected thread cap.
+        """
+        cap = self._sys.logical_threads
+
+        self._theme_combo.setCurrentText(s.theme)
+        self._font_scale_combo.setCurrentIndex(
+            self._closest_font_scale_index(s.font_scale)
+        )
+        self._header_logo_combo.setCurrentIndex(
+            self._header_logo_index(s.header_logo)
+        )
+
+        self._scan_jobs.setValue(max(1, min(s.scan_n_jobs, cap)))
+        self._scan_dataset.setText(s.dataset_slug)
+        self._scan_line_freq.setValue(s.scan_line_freq)
+        self._scan_montage.setText(s.scan_montage)
+        self._scan_probe.setChecked(s.scan_probe_convert)
+        self._scan_skip_bids_guess.setChecked(s.scan_skip_bids_guess)
+
+        self._convert_jobs.setValue(max(1, min(s.convert_n_jobs, cap)))
+        self._convert_overwrite.setChecked(s.convert_overwrite)
+        self._convert_skip_residuals.setChecked(s.convert_skip_residuals)
+
+        self._post_run_metadata.setChecked(s.post_run_metadata)
+        self._post_metadata_fill_todos.setChecked(s.post_metadata_fill_todos)
+        self._post_run_validate.setChecked(s.post_run_validate)
+        self._post_validate_strict.setChecked(s.post_validate_strict)
+        self._post_validate_html.setChecked(s.post_validate_html)
+
+    def _on_restore_defaults(self) -> None:
+        """Reset all widgets to the AppSettings field defaults (not saved
+        until the user clicks Save)."""
+        self._load_into_widgets(AppSettings())
+
     def _on_save(self) -> None:
         s = self._settings
         s.theme = self._theme_combo.currentText()
@@ -272,6 +386,7 @@ class SettingsDialog(QDialog):
 
         s.convert_n_jobs = self._convert_jobs.value()
         s.convert_overwrite = self._convert_overwrite.isChecked()
+        s.convert_skip_residuals = self._convert_skip_residuals.isChecked()
 
         s.post_run_metadata = self._post_run_metadata.isChecked()
         s.post_metadata_fill_todos = self._post_metadata_fill_todos.isChecked()

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 from typing import Optional
 
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
+    QAbstractItemView,
     QCheckBox,
     QComboBox,
     QDialog,
@@ -23,14 +25,23 @@ from PyQt6.QtWidgets import (
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
     QSpinBox,
+    QTableWidget,
+    QTableWidgetItem,
     QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from .. import schema
+from ..classifier import sequence_dict
+from ..classifier import user_rules
 from ..util.system_info import SystemInfo, get_system_info
 from .app_settings import AppSettings
 
@@ -83,6 +94,7 @@ class SettingsDialog(QDialog):
         tabs.addTab(self._build_display_tab(), "Display")
         tabs.addTab(self._build_system_tab(), "System")
         tabs.addTab(self._build_scan_tab(), "Scan")
+        tabs.addTab(self._build_scan_rules_tab(), "Scan rules")
         tabs.addTab(self._build_convert_tab(), "Convert + post-convert")
         v.addWidget(tabs, 1)
 
@@ -232,6 +244,263 @@ class SettingsDialog(QDialog):
         v.addStretch(1)
         return w
 
+    # ------------------------------------------------------------------
+    # Scan rules tab (exclusions + user hints + read-only built-ins)
+    # ------------------------------------------------------------------
+
+    def _build_scan_rules_tab(self) -> QWidget:
+        # Valid BIDS datatypes for the hint dropdowns (derivatives excluded -
+        # user hints route to raw datatypes only).
+        self._valid_datatypes = sorted(
+            d for d in schema.list_datatypes() if d != "derivatives"
+        )
+
+        content = QWidget()
+        v = QVBoxLayout(content)
+
+        intro = QLabel(
+            "These rules apply to MRI / DICOM series, which are classified "
+            "from their SeriesDescription. EEG / MEG recordings are classified "
+            "by a different built-in method (mne channel types) and are NOT "
+            "affected by custom sequence hints. Path-based exclusions can still "
+            "skip any modality."
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: #8b949e;")
+        v.addWidget(intro)
+
+        # Exclusions.
+        excl_box = QGroupBox("Scan exclusions (skip matching series)")
+        ebl = QVBoxLayout(excl_box)
+        self._excl_table = QTableWidget(0, 3)
+        self._excl_table.setHorizontalHeaderLabels(["Pattern", "Match against", "Mode"])
+        self._excl_table.verticalHeader().setVisible(False)
+        self._excl_table.setMinimumHeight(130)
+        self._excl_table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        ebl.addWidget(self._excl_table)
+        ebl.addLayout(self._rule_row_buttons(self._add_exclusion_row, self._excl_table))
+        v.addWidget(excl_box)
+
+        # User hints (MRI / DICOM only).
+        hint_box = QGroupBox("Custom sequence hints (MRI / DICOM only)")
+        hbl = QVBoxLayout(hint_box)
+        self._hint_table = QTableWidget(0, 6)
+        self._hint_table.setHorizontalHeaderLabels(
+            ["Patterns (comma-separated)", "Datatype", "Suffix", "Task", "Mode", "Force"]
+        )
+        self._hint_table.verticalHeader().setVisible(False)
+        self._hint_table.setMinimumHeight(150)
+        self._hint_table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        hbl.addWidget(self._hint_table)
+        force_hint = QLabel(
+            "Datatype + suffix are chosen from the BIDS schema (no free text). "
+            "'Force' overrides even the dcm2niix classifier; otherwise a hint "
+            "only beats the built-in regex layer. 'Task' is the optional "
+            "task-<label> for func rows."
+        )
+        force_hint.setWordWrap(True)
+        force_hint.setStyleSheet("color: #8b949e;")
+        hbl.addWidget(force_hint)
+        hbl.addLayout(self._rule_row_buttons(self._add_hint_row, self._hint_table))
+        v.addWidget(hint_box)
+
+        # Read-only built-in criteria.
+        builtin_box = QGroupBox("Built-in MRI classifier criteria (read-only)")
+        bbl = QVBoxLayout(builtin_box)
+        builtin_note = QLabel(
+            "What the MRI classifier already matches. EEG / MEG do not use this "
+            "table - their datatype comes from mne channel types."
+        )
+        builtin_note.setWordWrap(True)
+        builtin_note.setStyleSheet("color: #8b949e;")
+        bbl.addWidget(builtin_note)
+        builtin = QTableWidget(0, 4)
+        builtin.setHorizontalHeaderLabels(
+            ["Label / group", "Datatype", "Suffix", "Match patterns"]
+        )
+        builtin.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        builtin.verticalHeader().setVisible(False)
+        builtin.setMinimumHeight(240)
+        builtin.horizontalHeader().setSectionResizeMode(
+            3, QHeaderView.ResizeMode.Stretch
+        )
+        self._populate_builtin_criteria(builtin)
+        bbl.addWidget(builtin)
+        v.addWidget(builtin_box)
+        v.addStretch(1)
+
+        # Whole tab scrolls (not just the built-in table).
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        scroll.setWidget(content)
+        return scroll
+
+    def _rule_row_buttons(self, add_cb, table: QTableWidget) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        add = QPushButton("Add row")
+        add.clicked.connect(lambda: add_cb())
+        rem = QPushButton("Delete selected")
+        rem.clicked.connect(lambda: self._delete_selected_rows(table))
+        bar.addStretch(1)
+        bar.addWidget(add)
+        bar.addWidget(rem)
+        return bar
+
+    @staticmethod
+    def _delete_selected_rows(table: QTableWidget) -> None:
+        for r in sorted({i.row() for i in table.selectedIndexes()}, reverse=True):
+            table.removeRow(r)
+
+    def _add_exclusion_row(self, pattern: str = "", target: str = "sequence",
+                           mode: str = "substring") -> None:
+        t = self._excl_table
+        r = t.rowCount()
+        t.insertRow(r)
+        t.setItem(r, 0, QTableWidgetItem(pattern))
+        target_cb = QComboBox()
+        target_cb.addItems(list(user_rules.EXCLUSION_TARGETS))
+        target_cb.setCurrentText(target if target in user_rules.EXCLUSION_TARGETS else "sequence")
+        t.setCellWidget(r, 1, target_cb)
+        mode_cb = QComboBox()
+        mode_cb.addItems(list(user_rules.MATCH_MODES))
+        mode_cb.setCurrentText(mode if mode in user_rules.MATCH_MODES else "substring")
+        t.setCellWidget(r, 2, mode_cb)
+
+    def _add_hint_row(self, patterns: str = "", datatype: str = "", suffix: str = "",
+                      task: str = "", mode: str = "substring", force: bool = False) -> None:
+        t = self._hint_table
+        r = t.rowCount()
+        t.insertRow(r)
+        t.setItem(r, 0, QTableWidgetItem(patterns))
+
+        # Datatype + suffix are constrained dropdowns (no hand-typed labels).
+        # The suffix list depends on the chosen datatype, so it re-fills
+        # whenever the datatype changes.
+        dt_cb = QComboBox()
+        dt_cb.addItems(self._valid_datatypes)
+        suffix_cb = QComboBox()
+
+        def _refill_suffixes(dt: str) -> None:
+            suffix_cb.blockSignals(True)
+            suffix_cb.clear()
+            try:
+                suffix_cb.addItems(sorted(schema.list_suffixes(dt)))
+            except Exception:
+                pass
+            suffix_cb.blockSignals(False)
+
+        dt_cb.currentTextChanged.connect(_refill_suffixes)
+        if datatype in self._valid_datatypes:
+            dt_cb.setCurrentText(datatype)
+        _refill_suffixes(dt_cb.currentText())   # seed for the initial datatype
+        if suffix:
+            idx = suffix_cb.findText(suffix)
+            if idx >= 0:
+                suffix_cb.setCurrentIndex(idx)
+        t.setCellWidget(r, 1, dt_cb)
+        t.setCellWidget(r, 2, suffix_cb)
+
+        t.setItem(r, 3, QTableWidgetItem(task))
+        mode_cb = QComboBox()
+        mode_cb.addItems(list(user_rules.MATCH_MODES))
+        mode_cb.setCurrentText(mode if mode in user_rules.MATCH_MODES else "substring")
+        t.setCellWidget(r, 4, mode_cb)
+        force_item = QTableWidgetItem()
+        force_item.setFlags(
+            Qt.ItemFlag.ItemIsUserCheckable
+            | Qt.ItemFlag.ItemIsEnabled
+            | Qt.ItemFlag.ItemIsSelectable
+        )
+        force_item.setCheckState(Qt.CheckState.Checked if force else Qt.CheckState.Unchecked)
+        t.setItem(r, 5, force_item)
+
+    @staticmethod
+    def _populate_builtin_criteria(table: QTableWidget) -> None:
+        rows: list[tuple[str, str, str, str]] = []
+        for label, hint in sequence_dict.SEQUENCE_HINTS.items():
+            dt = hint.container_override or (hint.datatype or "")
+            rows.append((label, dt, hint.suffix or "", ", ".join(hint.patterns)))
+        for rgx, suffix, dt in sequence_dict._DWI_DERIVATIVE_PATTERNS:
+            rows.append(("dwi-derivative", dt, suffix, rgx))
+        for task_label, pats in sequence_dict.TASK_HINT_PATTERNS.items():
+            rows.append((f"task:{task_label}", "func", "(task entity)", ", ".join(pats)))
+        table.setRowCount(len(rows))
+        for r, cells in enumerate(rows):
+            for col, val in enumerate(cells):
+                it = QTableWidgetItem(val)
+                it.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+                table.setItem(r, col, it)
+
+    def _read_scan_rules(self) -> tuple[list[dict], list[dict], Optional[str]]:
+        """Read both editable tables into list[dict]. Returns
+        ``(hints, exclusions, error)`` - ``error`` non-None means a hint /
+        regex was invalid and the dialog must not save."""
+        # Exclusions.
+        exclusions: list[dict] = []
+        for r in range(self._excl_table.rowCount()):
+            item = self._excl_table.item(r, 0)
+            pattern = item.text().strip() if item else ""
+            if not pattern:
+                continue
+            mode = self._excl_table.cellWidget(r, 2).currentText()
+            if mode == "regex":
+                err = user_rules.validate_regex(pattern)
+                if err:
+                    return [], [], f"Exclusion regex {pattern!r} is invalid: {err}"
+            exclusions.append({
+                "pattern": pattern,
+                "target": self._excl_table.cellWidget(r, 1).currentText(),
+                "match_mode": mode,
+            })
+
+        # Hints.
+        hints: list[dict] = []
+        valid_datatypes = schema.list_datatypes()
+        for r in range(self._hint_table.rowCount()):
+            pat_item = self._hint_table.item(r, 0)
+            patterns = [p.strip() for p in (pat_item.text() if pat_item else "").split(",") if p.strip()]
+            if not patterns:
+                continue
+            # Datatype + suffix come from constrained dropdowns.
+            datatype = self._hint_table.cellWidget(r, 1).currentText().strip()
+            suffix = self._hint_table.cellWidget(r, 2).currentText().strip()
+            task = (self._hint_table.item(r, 3).text().strip() if self._hint_table.item(r, 3) else "")
+            mode = self._hint_table.cellWidget(r, 4).currentText()
+            force_item = self._hint_table.item(r, 5)
+            force = bool(force_item and force_item.checkState() == Qt.CheckState.Checked)
+
+            if not datatype or not suffix:
+                return [], [], f"Hint for {patterns!r} needs both a datatype and a suffix."
+            if datatype == "derivatives" or datatype not in valid_datatypes:
+                return [], [], (
+                    f"Hint datatype {datatype!r} is not a valid BIDS datatype. "
+                    f"Choose one of: {', '.join(sorted(valid_datatypes))}."
+                )
+            if suffix not in schema.list_suffixes(datatype):
+                return [], [], (
+                    f"Suffix {suffix!r} is not valid for datatype {datatype!r}."
+                )
+            if mode == "regex":
+                for p in patterns:
+                    err = user_rules.validate_regex(p)
+                    if err:
+                        return [], [], f"Hint regex {p!r} is invalid: {err}"
+            hints.append({
+                "patterns": patterns,
+                "datatype": datatype,
+                "suffix": suffix,
+                "task": task,
+                "entities": {},
+                "match_mode": mode,
+                "force": force,
+            })
+        return hints, exclusions, None
+
     def _build_convert_tab(self) -> QWidget:
         w = QWidget()
         v = QVBoxLayout(w)
@@ -362,13 +631,45 @@ class SettingsDialog(QDialog):
         self._post_validate_strict.setChecked(s.post_validate_strict)
         self._post_validate_html.setChecked(s.post_validate_html)
 
+        # Scan rules: rebuild both editable tables from the persisted lists
+        # (clear first so Restore-defaults empties them).
+        self._excl_table.setRowCount(0)
+        for e in s.scan_exclusions:
+            self._add_exclusion_row(
+                pattern=str(e.get("pattern", "")),
+                target=str(e.get("target", "sequence")),
+                mode=str(e.get("match_mode", "substring")),
+            )
+        self._hint_table.setRowCount(0)
+        for h in s.user_hints:
+            pats = h.get("patterns", [])
+            if isinstance(pats, str):
+                pats = [pats]
+            self._add_hint_row(
+                patterns=", ".join(str(p) for p in pats),
+                datatype=str(h.get("datatype", "")),
+                suffix=str(h.get("suffix", "")),
+                task=str(h.get("task", "") or ""),
+                mode=str(h.get("match_mode", "substring")),
+                force=bool(h.get("force", False)),
+            )
+
     def _on_restore_defaults(self) -> None:
         """Reset all widgets to the AppSettings field defaults (not saved
         until the user clicks Save)."""
         self._load_into_widgets(AppSettings())
 
     def _on_save(self) -> None:
+        # Validate the scan rules first so an invalid hint blocks the save
+        # without losing the user's other edits.
+        hints, exclusions, error = self._read_scan_rules()
+        if error:
+            QMessageBox.warning(self, "Invalid scan rule", error)
+            return
+
         s = self._settings
+        s.user_hints = hints
+        s.scan_exclusions = exclusions
         s.theme = self._theme_combo.currentText()
         s.font_scale = self._FONT_SCALE_PRESETS[
             self._font_scale_combo.currentIndex()

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -27,7 +27,6 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
-    QLineEdit,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -213,10 +212,6 @@ class SettingsDialog(QDialog):
             f"Capped at the detected thread count ({self._sys.logical_threads})."
         )
         form.addRow("Parallel workers (-j):", self._scan_jobs)
-
-        self._scan_dataset = QLineEdit()
-        self._scan_dataset.setPlaceholderText("(auto-derive from raw folder name)")
-        form.addRow("Default dataset slug:", self._scan_dataset)
 
         # EEG/MEG line frequency + montage are no longer scan settings: they
         # are recording metadata, edited as dropdowns per recording in the
@@ -636,7 +631,6 @@ class SettingsDialog(QDialog):
         )
 
         self._scan_jobs.setValue(max(1, min(s.scan_n_jobs, cap)))
-        self._scan_dataset.setText(s.dataset_slug)
         self._scan_probe.setChecked(s.scan_probe_convert)
         self._scan_skip_bids_guess.setChecked(s.scan_skip_bids_guess)
 
@@ -700,7 +694,6 @@ class SettingsDialog(QDialog):
         ][1]
 
         s.scan_n_jobs = self._scan_jobs.value()
-        s.dataset_slug = self._scan_dataset.text().strip()
         s.scan_probe_convert = self._scan_probe.isChecked()
         s.scan_skip_bids_guess = self._scan_skip_bids_guess.isChecked()
 

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -72,6 +72,59 @@ QToolTip {
     font-size: 11px;
 }
 
+/* ---------- Dropdowns (global, rounded + stylish) ----------
+ * Every plain QComboBox gets a rounded, themed box + a rounded popup list
+ * with rounded item selection (mirroring the project dropdown look).
+ * Object-name'd combos (#ent-input, #project-switcher) keep their own
+ * more-specific rules on top of this. */
+QComboBox {
+    background: $surface2;
+    color: $text;
+    border: 1px solid $border;
+    border-radius: 6px;
+    padding: 3px 8px;
+    min-height: 20px;
+    /* Force Qt's own list popup instead of the native macOS NSMenu, which
+     * ignores every QSS rule below (square corners, native selection). With
+     * this the popup is a styleable QAbstractItemView. */
+    combobox-popup: 0;
+}
+QComboBox:hover { border-color: $accent_border; }
+QComboBox:focus, QComboBox:on { border-color: $accent; }
+QComboBox::drop-down {
+    subcontrol-origin: padding;
+    subcontrol-position: right center;
+    border: none;
+    width: 16px;
+}
+QComboBox::down-arrow {
+    image: none;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid $dim;
+    width: 0; height: 0;
+    margin-right: 6px;
+}
+QComboBox QAbstractItemView {
+    background: $surface2;
+    color: $text;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 4px;
+    outline: 0;
+    selection-background-color: $accent_bg;
+    selection-color: $accent;
+}
+QComboBox QAbstractItemView::item {
+    padding: 5px 10px;
+    border-radius: 5px;
+    min-height: 18px;
+}
+QComboBox QAbstractItemView::item:selected { background: $accent_bg; color: $accent; }
+/* The popup container window (made frameless + translucent by
+ * gui/combo_popup.py) - transparent so only the rounded view above shows. */
+#combo-popup { background: transparent; border: none; }
+
 /* ---------- Top header (above toolbar) ---------- */
 QFrame#top-header {
     background: $surface;
@@ -167,6 +220,23 @@ QWidget#proj-menu-row-current { background: $surface3; border-radius: 5px; }
 QWidget#proj-menu-row-current:hover { background: $accent_bg; }
 QLabel#proj-menu-name, QLabel#proj-menu-path { background: transparent; }
 
+/* Generic rounded context / popup menu (combo_popup.round_menu), e.g. the
+ * Welcome recents right-click menu. Same look as the project dropdown. */
+QMenu#rounded-menu {
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 6px;
+}
+QMenu#rounded-menu::separator { height: 1px; background: $border; margin: 4px 8px; }
+QMenu#rounded-menu::item {
+    padding: 7px 12px;
+    border-radius: 5px;
+    color: $text;
+}
+QMenu#rounded-menu::item:selected { background: $accent_bg; color: $accent; }
+QMenu#rounded-menu::item:disabled { color: $muted; }
+
 /* ---------- Toolbar ---------- */
 QFrame#toolbar {
     background: $surface2;
@@ -252,9 +322,12 @@ QFrame#vsep {
 }
 
 /* ---------- Status chips ---------- */
+/* border-radius is large so Qt clamps it to half the height -> a perfect
+ * pill at ANY font scale (a fixed 9px looked square once the font/height
+ * changed). A border is required so the background clips to the radius. */
 QLabel[chipKind] {
-    padding: 1px 8px;
-    border-radius: 9px;
+    padding: 1px 9px;
+    border-radius: 100px;
     font-size: 11px;
     font-weight: 500;
     background: $surface3;
@@ -841,6 +914,73 @@ QLabel#sidecar-footer-summary {
     font-size: 10px;
 }
 
+/* ---------- Editor: EEG/MEG recording viewer ---------- */
+/* Metadata card: a scrollable list of label/value rows shown before the
+ * user loads the signal. All colours come from palette tokens so the
+ * card follows the dark/light theme. */
+QScrollArea#viewer-meta-scroll { background: $bg; border: none; }
+QLabel#viewer-meta-title {
+    color: $text;
+    font-size: 16px;
+    font-weight: 700;
+    padding-bottom: 4px;
+}
+QLabel#viewer-meta-section {
+    color: $accent;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding-top: 10px;
+}
+QWidget#viewer-meta-row { background: transparent; }
+QLabel#viewer-meta-key {
+    color: $dim;
+    font-size: 12px;
+}
+QLabel#viewer-meta-val {
+    color: $text;
+    font-size: 12px;
+}
+QLabel#viewer-meta-note {
+    color: $teal;
+    font-size: 11px;
+    padding-top: 4px;
+}
+/* Collapsible section header inside the time-series viewer (Display
+ * controls / Events). Flat, full-width, with a hover wash. */
+QPushButton#viewer-section-toggle {
+    background: $surface2;
+    color: $dim;
+    border: none;
+    border-bottom: 1px solid $subtle;
+    padding: 5px 12px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    text-align: left;
+}
+QPushButton#viewer-section-toggle:hover { color: $text; background: $surface3; }
+QPushButton#viewer-section-toggle:checked { color: $text; }
+/* The fixed-width channel-label strip beside the plot + the horizontal
+ * toolbar scroll (lets the viewer shrink without the toolbar forcing width). */
+QScrollArea#viewer-label-strip { background: $bg; border: none; }
+QScrollArea#viewer-toolbar-scroll { background: transparent; border: none; }
+
+/* "Load signal" button on the metadata card - styled like the header project
+ * switcher (accent pill, rounded, centered), not a green action button. */
+QPushButton#load-signal-btn {
+    background: $accent_bg;
+    color: $accent;
+    border: 1px solid $accent_border;
+    border-radius: 5px;
+    padding: 7px 30px;
+    font-size: 12px;
+    font-weight: 600;
+}
+QPushButton#load-signal-btn:hover { background: $accent_border; color: $text; }
+QPushButton#load-signal-btn:pressed { background: $accent_bg; }
+
 /* ---------- Editor: validation panel ---------- */
 QWidget#val-panel { background: $surface; }
 QLabel#val-section-title {
@@ -861,9 +1001,8 @@ QLabel#val-audit-missing {
     font-family: "SF Mono","Menlo","Monaco",monospace;
 }
 
-QLabel#val-count-ok   { background: $surface3; color: $dim; padding: 1px 6px; border-radius: 8px; font-size: 9px; }
-QLabel#val-count-warn { background: $warning_bg; color: $warning; padding: 1px 6px; border-radius: 8px; font-size: 9px; }
-QLabel#val-count-err  { background: $error_bg; color: $error; padding: 1px 6px; border-radius: 8px; font-size: 9px; }
+/* Validation-pane section count chips are now painted Chip widgets
+ * (widgets/primitives.Chip) - always-pill, theme-aware - so no QSS here. */
 
 QFrame#val-msg {
     background: $surface2;

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -908,3 +908,71 @@ QLabel#busy-spinner-message {
     color: $dim;
     font-size: 11px;
 }
+
+/* ------------------------------------------------------------------
+ * Welcome (Home) tab - the project-first landing.
+ * Every surface keys off a theme token so a dark<->light swap repaints
+ * cleanly (combined with WelcomePanel.repaint_for_palette).
+ * ------------------------------------------------------------------ */
+QWidget#welcome-panel,
+QScrollArea#welcome-scroll,
+QWidget#welcome-body,
+QWidget#welcome-col,
+QWidget#welcome-hero { background: $bg; }
+QScrollArea#welcome-scroll { border: none; }
+
+QLabel#welcome-title {
+    color: $text;
+    font-size: 23px;
+    font-weight: 700;
+}
+QLabel#welcome-subtitle {
+    color: $dim;
+    font-size: 12px;
+}
+
+QFrame#welcome-card {
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 10px;
+}
+QLabel#welcome-section {
+    color: $text;
+    font-size: 14px;
+    font-weight: 600;
+}
+QLabel#welcome-section-desc {
+    color: $dim;
+    font-size: 11px;
+}
+
+QLineEdit#welcome-input {
+    background: $surface3;
+    color: $text;
+    border: 1px solid $border;
+    border-radius: 6px;
+    padding: 6px 9px;
+    font-size: 12px;
+    selection-background-color: $accent;
+    selection-color: $primary_btn_text;
+}
+QLineEdit#welcome-input:focus { border-color: $accent; }
+QLineEdit#welcome-input:read-only { color: $dim; }
+
+QListWidget#welcome-recent {
+    background: $surface2;
+    color: $text;
+    border: 1px solid $border;
+    border-radius: 6px;
+    padding: 4px;
+    font-size: 12px;
+}
+QListWidget#welcome-recent::item {
+    padding: 6px 8px;
+    border-radius: 4px;
+}
+QListWidget#welcome-recent::item:hover { background: $surface3; }
+QListWidget#welcome-recent::item:selected {
+    background: $accent_bg;
+    color: $accent;
+}

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -959,6 +959,36 @@ QLineEdit#welcome-input {
 QLineEdit#welcome-input:focus { border-color: $accent; }
 QLineEdit#welcome-input:read-only { color: $dim; }
 
+/* Open-dataset button: ghost styling but blue (accent) text. */
+QPushButton#welcome-open-btn {
+    color: $accent;
+    background: transparent;
+    border: 1px solid $accent_border;
+    border-radius: 6px;
+    padding: 7px 14px;
+    font-size: 12px;
+    font-weight: 600;
+}
+QPushButton#welcome-open-btn:hover {
+    background: $accent_bg;
+    border-color: $accent;
+}
+
+/* "Sample datasets" sub-heading inside the Getting-started card. */
+QLabel#welcome-subsection {
+    color: $text;
+    font-size: 12px;
+    font-weight: 600;
+    margin-top: 4px;
+}
+
+/* Resource / sample-data links. Colour comes from QPalette.Link (accent),
+ * set by the theme manager, so it follows dark/light automatically. */
+QLabel#welcome-link {
+    font-size: 12px;
+    padding: 1px 0;
+}
+
 QListWidget#welcome-recent {
     background: $surface2;
     color: $text;

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -119,6 +119,54 @@ QPushButton#theme-toggle {
 }
 QPushButton#theme-toggle:hover { background: $border; }
 
+/* ---------- Project switcher (header, PyCharm-style) ---------- */
+/* Blue (accent) "current project" anchor; same size + shape as the view
+ * pills (matches the checked-pill look), works in both themes. Content is
+ * centred with symmetric padding; the right side leaves room for the caret. */
+QPushButton#project-switcher {
+    background: $accent_bg;
+    color: $accent;
+    border: 1px solid $accent_border;
+    border-radius: 5px;
+    padding: 5px 22px;
+    font-size: 12px;
+    font-weight: 600;
+    text-align: center;
+}
+QPushButton#project-switcher:hover { background: $accent_border; color: $text; }
+QPushButton#project-switcher::menu-indicator {
+    subcontrol-position: right center;
+    subcontrol-origin: padding;
+    right: 7px;
+    width: 10px;
+}
+/* Rounded dropdown (combined with the frameless + translucent window the
+ * header sets on this menu so the corners render cleanly). */
+QMenu#project-menu {
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+    padding: 6px;
+}
+QMenu#project-menu::separator { height: 1px; background: $border; margin: 4px 8px; }
+QMenu#project-menu::item {
+    padding: 7px 12px;
+    border-radius: 5px;
+    color: $text;
+}
+QMenu#project-menu::item:selected { background: $accent_bg; color: $accent; }
+QLabel#proj-menu-name { color: $accent; font-size: 12px; font-weight: 600; }
+QLabel#proj-menu-path { color: $dim; font-size: 10px; }
+QLabel#proj-menu-section {
+    color: $dim; font-size: 10px; font-weight: 700;
+    padding: 6px 12px 2px 12px;
+}
+QWidget#proj-menu-row { background: transparent; border-radius: 5px; }
+QWidget#proj-menu-row:hover { background: $accent_bg; }
+QWidget#proj-menu-row-current { background: $surface3; border-radius: 5px; }
+QWidget#proj-menu-row-current:hover { background: $accent_bg; }
+QLabel#proj-menu-name, QLabel#proj-menu-path { background: transparent; }
+
 /* ---------- Toolbar ---------- */
 QFrame#toolbar {
     background: $surface2;

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -284,6 +284,38 @@ QLabel#pane-hint {
     font-size: 11px;
 }
 
+/* Collapsible / detachable panel-frame header bar. Mirrors the pane-h5
+ * look (surface background + bottom rule) but carries a collapse caret on
+ * the left and a detach button on the right. The title label inside drops
+ * its own background / border so the bar reads as one strip. */
+QFrame#panel-frame-header {
+    background: $surface;
+    border-bottom: 1px solid $subtle;
+}
+QFrame#panel-frame-header QLabel#pane-h5 {
+    background: transparent;
+    border-bottom: none;
+    padding: 0px 2px;
+}
+/* Vertical collapse strip for left / right panels: a thin bar carrying a
+ * vertically-centred caret (+ detach button) on the panel's outer edge. */
+QFrame#panel-frame-strip {
+    background: $surface;
+    border-right: 1px solid $subtle;
+    border-left: 1px solid $subtle;
+}
+QToolButton#panel-frame-caret,
+QToolButton#panel-frame-detach {
+    background: transparent;
+    border: none;
+    padding: 2px;
+}
+QToolButton#panel-frame-caret:hover,
+QToolButton#panel-frame-detach:hover {
+    background: $border;
+    border-radius: 3px;
+}
+
 /* Bottom-dock log view. Uses a slightly tinted background so the
  * worker output reads clearly against both palettes. Selection inherits
  * the accent token (already covered by ``QPalette.Highlight``). */

--- a/bidsmgr/gui/theme_manager.py
+++ b/bidsmgr/gui/theme_manager.py
@@ -300,6 +300,9 @@ class ThemeManager:
         p.setColor(QPalette.ColorRole.ButtonText,      QColor(pal['text']))
         p.setColor(QPalette.ColorRole.Highlight,       QColor(pal['accent']))
         p.setColor(QPalette.ColorRole.HighlightedText, QColor(pal['primary_btn_text']))
+        # Rich-text ``<a href>`` links (welcome-panel resources) read this role,
+        # so theme swaps recolour them automatically.
+        p.setColor(QPalette.ColorRole.Link,            QColor(pal['accent']))
         p.setColor(QPalette.ColorRole.ToolTipBase,     QColor(pal['surface2']))
         p.setColor(QPalette.ColorRole.ToolTipText,     QColor(pal['text']))
         self._app.setPalette(p)

--- a/bidsmgr/gui/welcome_panel.py
+++ b/bidsmgr/gui/welcome_panel.py
@@ -16,14 +16,15 @@ recomputes every card's colours (no stale white/black patches).
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Optional
 
 import shutil
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QPixmap
+from PyQt6.QtCore import QRect, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QFont, QPixmap
 from PyQt6.QtWidgets import (
     QFileDialog,
     QFrame,
@@ -36,6 +37,8 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QPushButton,
     QScrollArea,
+    QStyle,
+    QStyledItemDelegate,
     QVBoxLayout,
     QWidget,
 )
@@ -43,8 +46,130 @@ from PyQt6.QtWidgets import (
 from ..cli._scaffold import slugify_name
 from ..cli.create import open_or_create_workspace
 from .app_settings import AppSettings
+from .theme_manager import CUR
 
 log = logging.getLogger(__name__)
+
+# Recent-list item roles: the path lives at ``UserRole`` (handlers read it);
+# the dataset display name + a missing flag ride alongside for the delegate.
+_RECENT_PATH_ROLE = Qt.ItemDataRole.UserRole
+_RECENT_NAME_ROLE = Qt.ItemDataRole.UserRole + 1
+_RECENT_MISSING_ROLE = Qt.ItemDataRole.UserRole + 2
+
+# Static resource links surfaced in the "Getting started" card. Texts are
+# friendly labels; the raw URLs never show. Theme-aware: rendered as rich-text
+# anchors that read ``QPalette.Link`` (set by the theme manager).
+_RESOURCE_LINKS: tuple[tuple[str, str], ...] = (
+    ("Documentation website", "https://ancplaboldenburg.github.io/bids_manager_documentation/"),
+    ("Tutorial walkthrough", "https://ancplaboldenburg.github.io/bids_manager_documentation/tutorial.html"),
+    ("Source code on GitHub", "https://github.com/ANCPLabOldenburg/BIDS-Manager"),
+)
+# Sample datasets (hosted on the UOL cloud) the docs offer for trying the tool.
+_SAMPLE_DATASETS: tuple[tuple[str, str], ...] = (
+    ("MRI walkthrough dataset", "https://cloud.uol.de/s/g9gMPpwL7Xg49y9/download"),
+    ("EEG motor-imagery dataset", "https://cloud.uol.de/s/T66zc5mN4eeZPGK/download"),
+    ("MEG Elekta sample dataset", "https://cloud.uol.de/s/btGeke5NNkDcs6G/download"),
+    ("Advanced MRI (Siemens) dataset", "https://cloud.uol.de/s/ZxaZCtHJPLjtDbR/download"),
+)
+
+
+def _parse_qcolor(value: str) -> QColor:
+    """Build a QColor from a palette token, including CSS ``rgba()`` strings.
+
+    The palette carries translucent tints as ``rgba(r,g,b,a)`` strings, which
+    ``QColor(str)`` cannot parse (it returns an invalid/black colour). This
+    parses both ``rgba()`` / ``rgb()`` and plain hex so theme-driven tints
+    render correctly (the recent-list selection was painting black otherwise).
+    """
+    s = str(value).strip()
+    if s.startswith("rgba(") or s.startswith("rgb("):
+        inner = s[s.index("(") + 1: s.rindex(")")]
+        parts = [p.strip() for p in inner.split(",")]
+        try:
+            r, g, b = (int(float(parts[0])), int(float(parts[1])), int(float(parts[2])))
+            a = int(round(float(parts[3]) * 255)) if len(parts) > 3 else 255
+            return QColor(r, g, b, a)
+        except (ValueError, IndexError):
+            return QColor(0, 0, 0, 0)
+    return QColor(s)
+
+
+def _dataset_display_name(bids_root: Path) -> str:
+    """Dataset Name from ``dataset_description.json``, else the folder name."""
+    dd = Path(bids_root) / "dataset_description.json"
+    if dd.exists():
+        try:
+            data = json.loads(dd.read_text(encoding="utf-8"))
+            name = str(data.get("Name", "")).strip()
+            if name:
+                return name
+        except (OSError, ValueError):
+            pass
+    return Path(bids_root).name
+
+
+class _RecentItemDelegate(QStyledItemDelegate):
+    """Paint a recent-project row as a coloured dataset name above its path.
+
+    Palette tokens are read fresh on every paint (via :func:`CUR`), so a theme
+    swap recolours the rows once the list viewport repaints.
+    """
+
+    def paint(self, painter, option, index) -> None:  # noqa: N802
+        pal = CUR()
+        name = str(index.data(_RECENT_NAME_ROLE) or "")
+        path = str(index.data(_RECENT_PATH_ROLE) or "")
+        missing = bool(index.data(_RECENT_MISSING_ROLE))
+
+        painter.save()
+        # Theme-aware selection / hover backgrounds. The palette stores these
+        # as ``rgba()`` strings, so parse them properly (a bare QColor(str)
+        # would render black and the selection looked black in every theme).
+        if option.state & QStyle.StateFlag.State_Selected:
+            painter.fillRect(option.rect, _parse_qcolor(pal["accent_bg"]))
+        elif option.state & QStyle.StateFlag.State_MouseOver:
+            painter.fillRect(option.rect, _parse_qcolor(pal["surface3"]))
+
+        rect = option.rect.adjusted(10, 5, -10, -5)
+        half = rect.height() // 2
+
+        # Dataset name (accent, bold) — muted when the folder is gone.
+        name_font = QFont(option.font)
+        name_font.setBold(True)
+        painter.setFont(name_font)
+        painter.setPen(QColor(pal["dim"] if missing else pal["accent"]))
+        label = f"{name}   (missing)" if missing else name
+        painter.drawText(
+            QRect(rect.x(), rect.y(), rect.width(), half),
+            int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter),
+            label,
+        )
+
+        # Path (dim, just one step smaller than the name and middle-elided).
+        # The app font is sized in PIXELS, so ``pointSizeF()`` is -1; derive the
+        # smaller size from pixelSize instead or it collapses to a tiny 7pt.
+        path_font = QFont(option.font)
+        px = option.font.pixelSize()
+        if px > 0:
+            path_font.setPixelSize(max(11, px - 1))
+        else:
+            path_font.setPointSizeF(max(10.0, option.font.pointSizeF() - 0.5))
+        painter.setFont(path_font)
+        painter.setPen(QColor(pal["dim"]))
+        path_rect = QRect(rect.x(), rect.y() + half, rect.width(), rect.height() - half)
+        elided = painter.fontMetrics().elidedText(
+            path, Qt.TextElideMode.ElideMiddle, path_rect.width(),
+        )
+        painter.drawText(
+            path_rect,
+            int(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter),
+            elided,
+        )
+        painter.restore()
+
+    def sizeHint(self, option, index) -> QSize:  # noqa: N802
+        s = super().sizeHint(option, index)
+        return QSize(s.width(), 50)
 
 
 def _section_card(title: str, description: str) -> tuple[QFrame, QVBoxLayout]:
@@ -118,6 +243,7 @@ class WelcomePanel(QWidget):
         left = QVBoxLayout()
         left.setSpacing(16)
         left.addWidget(self._build_create_card())
+        left.addWidget(self._build_resources_card())
         left.addStretch(1)
         right = QVBoxLayout()
         right.setSpacing(16)
@@ -210,13 +336,45 @@ class WelcomePanel(QWidget):
         )
         btn_row = QHBoxLayout()
         self._open_btn = QPushButton("Open dataset folder…")
-        self._open_btn.setObjectName("tb-btn-ghost")
+        # Blue (accent) text — see ``QPushButton#welcome-open-btn`` in theme.qss.
+        self._open_btn.setObjectName("welcome-open-btn")
         self._open_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self._open_btn.clicked.connect(self._on_open_clicked)
         btn_row.addWidget(self._open_btn)
         btn_row.addStretch(1)
         lay.addLayout(btn_row)
         return card
+
+    def _build_resources_card(self) -> QFrame:
+        card, lay = _section_card(
+            "Getting started",
+            "Documentation, tutorial, source code, and sample datasets to "
+            "try the full scan to validate workflow.",
+        )
+        for text, url in _RESOURCE_LINKS:
+            lay.addWidget(self._link_label(text, url))
+
+        sample = QLabel("Sample datasets")
+        sample.setObjectName("welcome-subsection")
+        lay.addWidget(sample)
+        for text, url in _SAMPLE_DATASETS:
+            lay.addWidget(self._link_label(text, url))
+        return card
+
+    @staticmethod
+    def _link_label(text: str, url: str) -> QLabel:
+        """A clickable rich-text link (opens in the system browser).
+
+        No explicit anchor colour, so it inherits ``QPalette.Link`` (accent)
+        and recolours on a theme swap. ``text-decoration:none`` keeps it tidy.
+        """
+        lbl = QLabel(f'<a style="text-decoration:none" href="{url}">{text}</a>')
+        lbl.setObjectName("welcome-link")
+        lbl.setOpenExternalLinks(True)
+        lbl.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
+        lbl.setCursor(Qt.CursorShape.PointingHandCursor)
+        lbl.setToolTip(url)
+        return lbl
 
     def _build_recent_card(self) -> QFrame:
         card, lay = _section_card(
@@ -226,6 +384,8 @@ class WelcomePanel(QWidget):
         self._recent = QListWidget()
         self._recent.setObjectName("welcome-recent")
         self._recent.setMinimumHeight(160)
+        self._recent.setMouseTracking(True)  # hover state for the delegate
+        self._recent.setItemDelegate(_RecentItemDelegate(self._recent))
         self._recent.itemActivated.connect(self._on_recent_activated)
         self._recent.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self._recent.customContextMenuRequested.connect(self._on_recent_menu)
@@ -243,14 +403,21 @@ class WelcomePanel(QWidget):
     # ------------------------------------------------------------------
 
     def refresh_recent(self) -> None:
-        """Repopulate the recent-projects list from AppSettings."""
+        """Repopulate the recent-projects list from AppSettings.
+
+        Each row carries the dataset name (painted in accent by the delegate)
+        and its full path (dim, beneath). Missing folders are kept but muted
+        and disabled.
+        """
         self._recent.clear()
         recents = AppSettings.load().recent_projects
         for p in recents:
-            item = QListWidgetItem(p)
-            item.setData(Qt.ItemDataRole.UserRole, p)
-            if not Path(p).exists():
-                item.setText(f"{p}   (missing)")
+            exists = Path(p).exists()
+            item = QListWidgetItem()
+            item.setData(_RECENT_PATH_ROLE, p)
+            item.setData(_RECENT_NAME_ROLE, _dataset_display_name(Path(p)) if exists else Path(p).name)
+            item.setData(_RECENT_MISSING_ROLE, not exists)
+            if not exists:
                 item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
             self._recent.addItem(item)
         has = bool(recents)
@@ -298,6 +465,21 @@ class WelcomePanel(QWidget):
     def _on_inline_create(self) -> None:
         name = self._name_edit.text().strip()
         if not name:
+            self._name_edit.setFocus()
+            return
+        # No spaces in dataset names (cleaner BIDS paths + cross-platform
+        # safety). Make the user aware and offer the underscore form instead
+        # of silently rewriting it.
+        if " " in name:
+            suggested = "_".join(name.split())
+            QMessageBox.information(
+                self,
+                "Spaces are not allowed",
+                "Dataset names cannot contain spaces, for cleaner BIDS paths "
+                "and cross-platform safety. Please use underscores instead.\n\n"
+                f"Suggested name: {suggested}",
+            )
+            self._name_edit.setText(suggested)
             self._name_edit.setFocus()
             return
         parent = self._location_edit.text().strip() or str(Path.home())
@@ -399,6 +581,16 @@ class WelcomePanel(QWidget):
             style.unpolish(w)
             style.polish(w)
             w.update()
+        # Rich-text anchors bake the link colour into their layout at parse
+        # time, so a bare update() keeps the old colour. Re-set the text to
+        # force a re-parse against the new ``QPalette.Link``.
+        for lbl in self.findChildren(QLabel):
+            if lbl.objectName() == "welcome-link":
+                lbl.setText(lbl.text())
+        # The recent-list delegate reads palette tokens at paint time; nudge
+        # the viewport so the rows recolour immediately.
+        if hasattr(self, "_recent"):
+            self._recent.viewport().update()
 
 
 __all__ = ["WelcomePanel"]

--- a/bidsmgr/gui/welcome_panel.py
+++ b/bidsmgr/gui/welcome_panel.py
@@ -534,6 +534,8 @@ class WelcomePanel(QWidget):
             return
         bids_root = Path(path)
         menu = QMenu(self)
+        from .combo_popup import round_menu
+        round_menu(menu)
         act_open = menu.addAction("Open")
         act_open.setEnabled(bids_root.exists())
         act_forget = menu.addAction("Remove from list")

--- a/bidsmgr/gui/welcome_panel.py
+++ b/bidsmgr/gui/welcome_panel.py
@@ -1,0 +1,404 @@
+"""Welcome panel - the project-first landing (VS Code-style home tab).
+
+Shown when no project is open. A hero header plus three self-contained section
+cards: Create a new dataset, Open an existing one, and Recent projects. Emits
+:pyattr:`project_opened` with the opened ``Project`` and its dataset root so
+:class:`MainWindow` can bind it to the Converter.
+
+The create/open *logic* lives in small testable methods (``create_project`` /
+``open_project``); the controls gather input then call those, so the flow can be
+exercised offscreen without driving modal dialogs.
+
+Styling is fully QSS-driven (object names keyed in ``theme.qss``);
+``repaint_for_palette`` runs the unpolish/polish dance so a dark<->light swap
+recomputes every card's colours (no stale white/black patches).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import shutil
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMenu,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..cli._scaffold import slugify_name
+from ..cli.create import open_or_create_workspace
+from .app_settings import AppSettings
+
+log = logging.getLogger(__name__)
+
+
+def _section_card(title: str, description: str) -> tuple[QFrame, QVBoxLayout]:
+    """Build a titled, self-contained section card; return (frame, body layout)."""
+    card = QFrame()
+    card.setObjectName("welcome-card")
+    lay = QVBoxLayout(card)
+    lay.setContentsMargins(22, 18, 22, 18)
+    lay.setSpacing(10)
+    head = QLabel(title)
+    head.setObjectName("welcome-section")
+    desc = QLabel(description)
+    desc.setObjectName("welcome-section-desc")
+    desc.setWordWrap(True)
+    lay.addWidget(head)
+    lay.addWidget(desc)
+    return card, lay
+
+
+class WelcomePanel(QWidget):
+    """Create / open / recent for BIDS dataset projects.
+
+    Emits ``project_opened(project, bids_root)`` (a
+    :class:`~bidsmgr.project.Project` and a :class:`pathlib.Path`).
+    """
+
+    project_opened = pyqtSignal(object, object)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("welcome-panel")
+
+        # Default the create-location to the last BIDS-output parent (or home).
+        last_parent = AppSettings.load().bids_parent
+        self._create_location = Path(last_parent) if last_parent else Path.home()
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setObjectName("welcome-scroll")
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        outer.addWidget(scroll)
+
+        body = QWidget()
+        body.setObjectName("welcome-body")
+        scroll.setWidget(body)
+
+        # Centred, capped-width container that uses the horizontal space: a
+        # full-width hero on top, then a two-column row (Create on the left,
+        # Open + Recent stacked on the right) so the page reads as a desktop
+        # layout rather than a tall single phone-width column.
+        body_row = QHBoxLayout(body)
+        body_row.setContentsMargins(28, 28, 28, 28)
+        body_row.addStretch(1)
+        col_host = QWidget()
+        col_host.setObjectName("welcome-col")
+        col_host.setMaximumWidth(1080)
+        host_v = QVBoxLayout(col_host)
+        host_v.setContentsMargins(0, 0, 0, 0)
+        host_v.setSpacing(18)
+        body_row.addWidget(col_host, 6)
+        body_row.addStretch(1)
+
+        host_v.addWidget(self._build_hero())
+
+        content = QHBoxLayout()
+        content.setSpacing(18)
+        left = QVBoxLayout()
+        left.setSpacing(16)
+        left.addWidget(self._build_create_card())
+        left.addStretch(1)
+        right = QVBoxLayout()
+        right.setSpacing(16)
+        right.addWidget(self._build_open_card())
+        right.addWidget(self._build_recent_card(), 1)
+        content.addLayout(left, 1)
+        content.addLayout(right, 1)
+        host_v.addLayout(content, 1)
+
+        self.refresh_recent()
+
+    # ------------------------------------------------------------------
+    # Sections
+    # ------------------------------------------------------------------
+
+    def _build_hero(self) -> QWidget:
+        hero = QWidget()
+        hero.setObjectName("welcome-hero")
+        h = QHBoxLayout(hero)
+        h.setContentsMargins(2, 0, 2, 4)
+        h.setSpacing(14)
+
+        icon = QLabel()
+        icon.setObjectName("welcome-logo")
+        png = Path(__file__).parent / "assets" / "macos" / "AppIcon128.png"
+        if png.exists():
+            pix = QPixmap(str(png))
+            if not pix.isNull():
+                icon.setPixmap(pix.scaledToHeight(
+                    56, Qt.TransformationMode.SmoothTransformation,
+                ))
+                h.addWidget(icon, 0, Qt.AlignmentFlag.AlignVCenter)
+
+        text = QVBoxLayout()
+        text.setSpacing(2)
+        title = QLabel("Welcome to BIDS-Manager")
+        title.setObjectName("welcome-title")
+        subtitle = QLabel(
+            "Schema-driven BIDS conversion, curation, and editing. "
+            "Create a dataset to start, or reopen one to pick up where you left off."
+        )
+        subtitle.setObjectName("welcome-subtitle")
+        subtitle.setWordWrap(True)
+        text.addWidget(title)
+        text.addWidget(subtitle)
+        h.addLayout(text, 1)
+        return hero
+
+    def _build_create_card(self) -> QFrame:
+        card, lay = _section_card(
+            "Create a new dataset",
+            "Scaffold a fresh BIDS dataset (dataset_description.json, README, "
+            ".bidsignore) and start scanning raw data into it.",
+        )
+
+        self._name_edit = QLineEdit()
+        self._name_edit.setObjectName("welcome-input")
+        self._name_edit.setPlaceholderText("Dataset name, e.g. My Study")
+        self._name_edit.returnPressed.connect(self._on_inline_create)
+        lay.addWidget(self._name_edit)
+
+        loc_row = QHBoxLayout()
+        loc_row.setSpacing(8)
+        self._location_edit = QLineEdit(str(self._create_location))
+        self._location_edit.setObjectName("welcome-input")
+        self._location_edit.setReadOnly(True)
+        browse = QPushButton("Browse…")
+        browse.setObjectName("tb-btn-ghost")
+        browse.setCursor(Qt.CursorShape.PointingHandCursor)
+        browse.clicked.connect(self._on_browse_location)
+        loc_row.addWidget(self._location_edit, 1)
+        loc_row.addWidget(browse)
+        lay.addLayout(loc_row)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch(1)
+        self._create_btn = QPushButton("Create dataset")
+        self._create_btn.setObjectName("tb-btn-primary")
+        self._create_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._create_btn.clicked.connect(self._on_inline_create)
+        btn_row.addWidget(self._create_btn)
+        lay.addLayout(btn_row)
+        return card
+
+    def _build_open_card(self) -> QFrame:
+        card, lay = _section_card(
+            "Open an existing dataset",
+            "Continue curating a BIDS-Manager project, or adopt a dataset "
+            "created elsewhere (it is opened read-only, never overwritten).",
+        )
+        btn_row = QHBoxLayout()
+        self._open_btn = QPushButton("Open dataset folder…")
+        self._open_btn.setObjectName("tb-btn-ghost")
+        self._open_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._open_btn.clicked.connect(self._on_open_clicked)
+        btn_row.addWidget(self._open_btn)
+        btn_row.addStretch(1)
+        lay.addLayout(btn_row)
+        return card
+
+    def _build_recent_card(self) -> QFrame:
+        card, lay = _section_card(
+            "Recent projects",
+            "Datasets you recently created or opened. Double-click to reopen.",
+        )
+        self._recent = QListWidget()
+        self._recent.setObjectName("welcome-recent")
+        self._recent.setMinimumHeight(160)
+        self._recent.itemActivated.connect(self._on_recent_activated)
+        self._recent.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self._recent.customContextMenuRequested.connect(self._on_recent_menu)
+        lay.addWidget(self._recent, 1)
+        hint = QLabel("Right-click a project to remove or delete it.")
+        hint.setObjectName("welcome-section-desc")
+        lay.addWidget(hint)
+        self._recent_empty = QLabel("No recent projects yet.")
+        self._recent_empty.setObjectName("welcome-section-desc")
+        lay.addWidget(self._recent_empty)
+        return card
+
+    # ------------------------------------------------------------------
+    # Recent list
+    # ------------------------------------------------------------------
+
+    def refresh_recent(self) -> None:
+        """Repopulate the recent-projects list from AppSettings."""
+        self._recent.clear()
+        recents = AppSettings.load().recent_projects
+        for p in recents:
+            item = QListWidgetItem(p)
+            item.setData(Qt.ItemDataRole.UserRole, p)
+            if not Path(p).exists():
+                item.setText(f"{p}   (missing)")
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEnabled)
+            self._recent.addItem(item)
+        has = bool(recents)
+        self._recent.setVisible(has)
+        self._recent_empty.setVisible(not has)
+
+    # ------------------------------------------------------------------
+    # Core (testable) actions
+    # ------------------------------------------------------------------
+
+    def create_project(self, parent_dir: Path, name: str) -> Optional[Path]:
+        """Create ``<parent_dir>/<slug(name)>`` and open it. Returns the root."""
+        name = (name or "").strip()
+        if not name:
+            return None
+        bids_root = Path(parent_dir) / slugify_name(name)
+        proj = open_or_create_workspace(bids_root, name=name)
+        AppSettings.remember_recent_project(bids_root)
+        self.refresh_recent()
+        self.project_opened.emit(proj, bids_root)
+        return bids_root
+
+    def open_project(self, bids_root: Path) -> Optional[Path]:
+        """Open (or adopt) the dataset at ``bids_root``. Returns the root."""
+        bids_root = Path(bids_root)
+        proj = open_or_create_workspace(bids_root)
+        AppSettings.remember_recent_project(bids_root)
+        self.refresh_recent()
+        self.project_opened.emit(proj, bids_root)
+        return bids_root
+
+    # ------------------------------------------------------------------
+    # Control handlers
+    # ------------------------------------------------------------------
+
+    def _on_browse_location(self) -> None:
+        d = QFileDialog.getExistingDirectory(
+            self, "Choose where to create the dataset",
+            str(self._create_location),
+        )
+        if d:
+            self._create_location = Path(d)
+            self._location_edit.setText(d)
+
+    def _on_inline_create(self) -> None:
+        name = self._name_edit.text().strip()
+        if not name:
+            self._name_edit.setFocus()
+            return
+        parent = self._location_edit.text().strip() or str(Path.home())
+        self.create_project(Path(parent), name)
+        self._name_edit.clear()
+
+    def _on_open_clicked(self) -> None:
+        d = QFileDialog.getExistingDirectory(
+            self, "Open BIDS dataset folder", str(self._create_location),
+        )
+        if not d:
+            return
+        self.open_project(Path(d))
+
+    def _on_recent_activated(self, item: QListWidgetItem) -> None:
+        p = item.data(Qt.ItemDataRole.UserRole)
+        if p and Path(p).exists():
+            self.open_project(Path(p))
+
+    # ------------------------------------------------------------------
+    # Remove / delete projects
+    # ------------------------------------------------------------------
+
+    def delete_project(self, bids_root: Path, *, from_disk: bool) -> bool:
+        """Forget a project (and optionally delete its folder from disk).
+
+        With ``from_disk=False`` the dataset is only dropped from the recent
+        list. With ``from_disk=True`` the folder is permanently removed, but only
+        when it actually looks like a BIDS dataset / BM project (has
+        ``.bidsmgr/`` or ``dataset_description.json``) so an arbitrary path can
+        never be nuked. Returns ``True`` if anything was removed.
+        """
+        bids_root = Path(bids_root)
+        if from_disk and bids_root.exists():
+            looks_bids = (
+                (bids_root / ".bidsmgr").exists()
+                or (bids_root / "dataset_description.json").exists()
+            )
+            if not looks_bids:
+                return False  # refuse to delete a non-dataset folder
+            shutil.rmtree(bids_root, ignore_errors=True)
+        AppSettings.forget_recent_project(bids_root)
+        self.refresh_recent()
+        return True
+
+    def _on_recent_menu(self, pos) -> None:
+        item = self._recent.itemAt(pos)
+        if item is None:
+            return
+        path = item.data(Qt.ItemDataRole.UserRole)
+        if not path:
+            return
+        bids_root = Path(path)
+        menu = QMenu(self)
+        act_open = menu.addAction("Open")
+        act_open.setEnabled(bids_root.exists())
+        act_forget = menu.addAction("Remove from list")
+        act_delete = menu.addAction("Delete project from disk…")
+        chosen = menu.exec(self._recent.mapToGlobal(pos))
+        if chosen is None:
+            return
+        if chosen is act_open:
+            if bids_root.exists():
+                self.open_project(bids_root)
+        elif chosen is act_forget:
+            self.delete_project(bids_root, from_disk=False)
+        elif chosen is act_delete:
+            confirm = QMessageBox.warning(
+                self,
+                "Delete project",
+                f"Permanently delete this dataset and everything in it?\n\n{bids_root}\n\n"
+                "This cannot be undone.",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+                QMessageBox.StandardButton.Cancel,
+            )
+            if confirm == QMessageBox.StandardButton.Yes:
+                if not self.delete_project(bids_root, from_disk=True):
+                    QMessageBox.information(
+                        self, "Delete project",
+                        "Not deleted: that folder does not look like a BIDS "
+                        "dataset, so it was left untouched (removed from the "
+                        "list only).",
+                    )
+
+    # ------------------------------------------------------------------
+    # Theme
+    # ------------------------------------------------------------------
+
+    def repaint_for_palette(self, pal: dict) -> None:
+        """Force QSS recomputation on a dark<->light swap.
+
+        The same unpolish/polish dance the other panels use, so the cards /
+        inputs / recent list pick up the re-applied stylesheet instead of
+        keeping stale background colours.
+        """
+        del pal
+        style = self.style()
+        for w in [self, *self.findChildren(QWidget)]:
+            style.unpolish(w)
+            style.polish(w)
+            w.update()
+
+
+__all__ = ["WelcomePanel"]

--- a/bidsmgr/gui/widgets/__init__.py
+++ b/bidsmgr/gui/widgets/__init__.py
@@ -17,6 +17,7 @@ from .bids_tree_pane import BidsTreePane
 from .image_label import ImageLabel
 from .json_tree_view import JsonTreeView
 from .nifti_viewer_pane import NiftiViewerPane
+from .panel_frame import PanelFrame
 from .primitives import Chip, PaneHeader, PathBar, VSep
 from .sidecar_form_pane import SidecarFormPane, find_peer_files
 from .sidecar_row import SidecarRow
@@ -43,6 +44,7 @@ __all__ = [
     "KIND_FG_TOKEN",
     "NiftiViewerPane",
     "PaneHeader",
+    "PanelFrame",
     "PathBar",
     "SidecarFormPane",
     "SidecarRow",

--- a/bidsmgr/gui/widgets/__init__.py
+++ b/bidsmgr/gui/widgets/__init__.py
@@ -19,6 +19,7 @@ from .json_tree_view import JsonTreeView
 from .nifti_viewer_pane import NiftiViewerPane
 from .panel_frame import PanelFrame
 from .primitives import Chip, PaneHeader, PathBar, VSep
+from .recording_viewer_pane import RecordingViewerPane, is_recording_path
 from .sidecar_form_pane import SidecarFormPane, find_peer_files
 from .sidecar_row import SidecarRow
 from .tsv_viewer_pane import TsvViewerPane
@@ -46,11 +47,13 @@ __all__ = [
     "PaneHeader",
     "PanelFrame",
     "PathBar",
+    "RecordingViewerPane",
     "SidecarFormPane",
     "SidecarRow",
     "TsvViewerPane",
     "ValidationPane",
     "find_peer_files",
+    "is_recording_path",
     "StatusBadge",
     "ValMessage",
     "VSep",

--- a/bidsmgr/gui/widgets/bids_tree_pane.py
+++ b/bidsmgr/gui/widgets/bids_tree_pane.py
@@ -28,7 +28,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import QSize, Qt, pyqtSignal
+from PyQt6.QtCore import QFileSystemWatcher, QSize, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor
 from PyQt6.QtWidgets import (
     QLabel,
@@ -97,8 +97,32 @@ def _is_folder_recording(name: str) -> bool:
     return name.lower().endswith(_FOLDER_RECORDING_SUFFIXES)
 
 
-def _walk(folder: Path, parent_item: QTreeWidgetItem, *, depth: int) -> None:
-    """Populate ``parent_item`` with the contents of ``folder``."""
+def _norm_path(p) -> str:
+    """Resolve a path to a comparable string.
+
+    Resolving both sides means macOS ``/private/var/...`` vs ``/var/...``
+    symlink differences between the tree paths and the validation report paths
+    don't cause spurious badge misses.
+    """
+    try:
+        return str(Path(p).resolve())
+    except OSError:
+        return str(Path(p))
+
+
+def _walk(
+    folder: Path,
+    parent_item: QTreeWidgetItem,
+    *,
+    depth: int,
+    dirs: Optional[list[str]] = None,
+) -> None:
+    """Populate ``parent_item`` with the contents of ``folder``.
+
+    When ``dirs`` is supplied, every directory recursed into is appended to it
+    so the caller can register them with a ``QFileSystemWatcher`` for live
+    refresh (mirrors the Converter's output tree).
+    """
     if depth >= _MAX_DEPTH:
         return
     try:
@@ -127,7 +151,9 @@ def _walk(folder: Path, parent_item: QTreeWidgetItem, *, depth: int) -> None:
         parent_item.addChild(item)
         # Recurse only into real directories that are not folder-recordings.
         if is_dir and not _is_folder_recording(entry.name):
-            _walk(Path(entry.path), item, depth=depth + 1)
+            if dirs is not None:
+                dirs.append(entry.path)
+            _walk(Path(entry.path), item, depth=depth + 1, dirs=dirs)
 
 
 class BidsTreePane(QWidget):
@@ -144,6 +170,22 @@ class BidsTreePane(QWidget):
         super().__init__(parent)
         self.setObjectName("pane")
         self._root: Optional[Path] = None
+        # Remember the last severity badges so a live (watcher-driven) refresh
+        # re-applies them onto the freshly-walked items instead of dropping
+        # them. Keyed by normalised absolute path string.
+        self._last_badges: dict[str, str] = {}
+
+        # Live refresh: every visible directory is registered with a
+        # ``QFileSystemWatcher`` so files created / deleted / renamed under the
+        # BIDS root update the tree without a manual reopen (parity with the
+        # Converter's output tree). Bursts of events (e.g. a conversion writing
+        # into the open dataset) are coalesced through a 500 ms debounce.
+        self._watcher = QFileSystemWatcher(self)
+        self._watcher.directoryChanged.connect(self._on_fs_changed)
+        self._refresh_timer = QTimer(self)
+        self._refresh_timer.setSingleShot(True)
+        self._refresh_timer.setInterval(500)
+        self._refresh_timer.timeout.connect(self.refresh)
 
         v = QVBoxLayout(self)
         v.setContentsMargins(0, 0, 0, 0)
@@ -189,36 +231,153 @@ class BidsTreePane(QWidget):
     def set_root(self, path: Optional[Path]) -> None:
         """Switch the tree to a new BIDS root (or clear it with ``None``).
 
-        Repopulates synchronously. Datasets are small enough that the
-        walk completes well under a frame on any modern disk; if that
-        ever stops being true we can swap to the threadpool pattern
-        ``OutputFsPane`` uses.
+        Re-setting the SAME root (e.g. the editor re-opening the dataset it is
+        already showing) preserves the user's expansion / selection by routing
+        through :meth:`refresh`, exactly like the Converter's output tree. Only
+        a genuinely new root forgets badges + expansion and opens to depth 2.
+
+        Repopulates synchronously. Datasets are small enough that the walk
+        completes well under a frame on any modern disk; if that ever stops
+        being true we can swap to the threadpool pattern ``OutputFsPane`` uses.
         """
+        if (
+            path is not None
+            and self._root is not None
+            and Path(path) == self._root
+            and self._tree.topLevelItemCount() > 0
+        ):
+            # Same root, already rendered -> in-place refresh (keep the view).
+            self.refresh()
+            return
+
+        self._clear_watcher()
         self._tree.clear()
         if path is None or not path.exists() or not path.is_dir():
             self._root = None
+            self._last_badges = {}
             self._stack.setCurrentIndex(0)
             return
 
         self._root = path
+        self._last_badges = {}  # new root -> stale badges no longer apply
+        dirs = self._populate(path)
+        self._watch(dirs)
+        self._tree.expandToDepth(2)
+        self._stack.setCurrentIndex(1)
+
+    def refresh(self) -> None:
+        """Re-walk the current root, preserving the user's view.
+
+        Unlike :meth:`set_root`, this keeps whatever the user had expanded /
+        selected (and the scroll position) and re-applies the last severity
+        badges, so a live filesystem change does not collapse the tree or wipe
+        validation markers. No-op if no root is set.
+        """
+        if self._root is None:
+            return
+        snap = self._snapshot_state()
+        self._clear_watcher()
+        # Block selection signals so re-selecting the same row after the rebuild
+        # does not spuriously reload the center viewer on every disk tick.
+        self._tree.blockSignals(True)
+        try:
+            self._tree.clear()
+            if not self._root.exists() or not self._root.is_dir():
+                self._root = None
+                self._stack.setCurrentIndex(0)
+                return
+            dirs = self._populate(self._root)
+            self._watch(dirs)
+            self._restore_state(snap)
+        finally:
+            self._tree.blockSignals(False)
+        # Re-apply badges from the cache (validation has not re-run, but the
+        # markers are still valid for files that survived the change).
+        if self._last_badges:
+            self._apply_badge_map(self._last_badges)
+
+    def _populate(self, path: Path) -> list[str]:
+        """Build the tree under ``path`` and return the dirs to watch."""
+        pal = CUR()
         # Top-level item carries the dataset name. We do NOT colour it
         # as a directory — the dataset root is the user's anchor, so
         # we paint it in the default text token.
-        pal = CUR()
         top = QTreeWidgetItem([path.name or str(path)])
         top.setData(0, PATH_ROLE, str(path))
         top.setData(0, COLOR_TOKEN_ROLE, "text")
         top.setForeground(0, QColor(pal["text"]))
         top.setIcon(0, icons.icon_for_path(path.name or str(path), is_dir=True))
         self._tree.addTopLevelItem(top)
-        _walk(path, top, depth=0)
-        self._tree.expandToDepth(2)
+        dirs: list[str] = [str(path)]
+        _walk(path, top, depth=0, dirs=dirs)
         self._stack.setCurrentIndex(1)
+        return dirs
 
-    def refresh(self) -> None:
-        """Re-walk the current root from disk. No-op if no root is set."""
-        if self._root is not None:
-            self.set_root(self._root)
+    # ------------------------------------------------------------------
+    # Live refresh (QFileSystemWatcher)
+    # ------------------------------------------------------------------
+
+    def _watch(self, dirs: list[str]) -> None:
+        if dirs:
+            self._watcher.addPaths(dirs)
+
+    def _clear_watcher(self) -> None:
+        existing = self._watcher.directories()
+        if existing:
+            self._watcher.removePaths(existing)
+
+    def _on_fs_changed(self, _path: str) -> None:
+        """A watched directory changed — schedule one debounced refresh."""
+        if not self._refresh_timer.isActive():
+            self._refresh_timer.start()
+
+    # ------------------------------------------------------------------
+    # View-state preservation across an in-place refresh
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _item_key(item: QTreeWidgetItem) -> str:
+        """Stable identity for a row across rebuilds (its absolute path)."""
+        return str(item.data(0, PATH_ROLE) or "")
+
+    def _snapshot_state(self) -> dict:
+        """Capture expanded paths + current selection + scroll position."""
+        snap: dict = {
+            "expanded": set(),
+            "selected": None,
+            "scroll": self._tree.verticalScrollBar().value(),
+        }
+        cur = self._tree.currentItem()
+        if cur is not None:
+            snap["selected"] = self._item_key(cur)
+
+        def _walk_items(item: QTreeWidgetItem) -> None:
+            if item.isExpanded():
+                snap["expanded"].add(self._item_key(item))
+            for i in range(item.childCount()):
+                _walk_items(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            _walk_items(self._tree.topLevelItem(i))
+        return snap
+
+    def _restore_state(self, snap: dict) -> None:
+        """Re-apply expansion / selection / scroll captured by a snapshot."""
+        expanded: set = snap["expanded"]
+        selected = snap["selected"]
+
+        def _walk_items(item: QTreeWidgetItem) -> None:
+            key = self._item_key(item)
+            if key in expanded:
+                item.setExpanded(True)
+            if selected is not None and key == selected:
+                self._tree.setCurrentItem(item)
+            for i in range(item.childCount()):
+                _walk_items(item.child(i))
+
+        for i in range(self._tree.topLevelItemCount()):
+            _walk_items(self._tree.topLevelItem(i))
+        self._tree.verticalScrollBar().setValue(snap["scroll"])
 
     def set_badges(self, severities: dict[Path, str]) -> None:
         """Stamp per-row severity badges from a path → severity map.
@@ -229,17 +388,15 @@ class BidsTreePane(QWidget):
         their visible descendants.
         """
         # Build a normalised lookup (string form) so we don't have to
-        # construct ``Path`` for every tree item. We resolve every key
-        # so macOS ``/private/var/...`` vs ``/var/...`` symlink
-        # differences between the tree paths and the report paths
-        # don't cause spurious misses.
-        def _norm(p) -> str:
-            try:
-                return str(Path(p).resolve())
-            except OSError:
-                return str(Path(p))
+        # construct ``Path`` for every tree item.
+        leaf_map = {_norm_path(p): s for p, s in severities.items()}
+        # Remember so a live (watcher-driven) refresh can re-stamp the rebuilt
+        # tree without re-running validation.
+        self._last_badges = dict(leaf_map)
+        self._apply_badge_map(leaf_map)
 
-        leaf_map = {_norm(p): s for p, s in severities.items()}
+    def _apply_badge_map(self, leaf_map: dict[str, str]) -> None:
+        """Stamp a normalised path -> severity map onto the current tree."""
 
         def visit(item: QTreeWidgetItem) -> str | None:
             """Set this item's badge; return the rolled-up severity for
@@ -259,7 +416,7 @@ class BidsTreePane(QWidget):
             else:
                 # Leaf: look up by absolute path (normalised).
                 path_str = item.data(0, PATH_ROLE)
-                badge = leaf_map.get(_norm(path_str)) if path_str else None
+                badge = leaf_map.get(_norm_path(path_str)) if path_str else None
             if badge:
                 item.setData(0, BADGE_ROLE, badge)
             else:
@@ -272,7 +429,8 @@ class BidsTreePane(QWidget):
         self._tree.viewport().update()
 
     def clear_badges(self) -> None:
-        """Remove every badge from the tree."""
+        """Remove every badge from the tree (and forget the cached map)."""
+        self._last_badges = {}
         def visit(item: QTreeWidgetItem) -> None:
             item.setData(0, BADGE_ROLE, None)
             for i in range(item.childCount()):

--- a/bidsmgr/gui/widgets/edit_history.py
+++ b/bidsmgr/gui/widgets/edit_history.py
@@ -1,0 +1,64 @@
+"""Tiny snapshot-based undo/redo stack for the Editor panes.
+
+Qt-free and content-agnostic: a *snapshot* is whatever opaque value a pane
+captures for its editable state (a ``(header, rows)`` tuple for the TSV table,
+a deep-copied dict for the JSON sidecar). The pane records the pre-edit
+snapshot after each edit; ``undo`` / ``redo`` swap snapshots, pushing the
+current state onto the opposite stack so the chain is reversible.
+
+The pane owns the snapshot/restore semantics; this class only sequences them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class SnapshotHistory:
+    """Undo/redo stacks of opaque snapshots for one editable document."""
+
+    def __init__(self) -> None:
+        self._undo: list[Any] = []
+        self._redo: list[Any] = []
+
+    def clear(self) -> None:
+        """Drop all history (e.g. when a new file is bound)."""
+        self._undo.clear()
+        self._redo.clear()
+
+    def record(self, pre_edit_snapshot: Any) -> None:
+        """Record the state as it was *before* the edit that just happened.
+
+        A fresh edit diverges the timeline, so the redo stack is cleared.
+        """
+        self._undo.append(pre_edit_snapshot)
+        self._redo.clear()
+
+    def undo(self, current_snapshot: Any) -> Any:
+        """Return the snapshot to restore, or ``None`` if nothing to undo.
+
+        ``current_snapshot`` is pushed onto the redo stack so a later redo
+        returns here.
+        """
+        if not self._undo:
+            return None
+        self._redo.append(current_snapshot)
+        return self._undo.pop()
+
+    def redo(self, current_snapshot: Any) -> Any:
+        """Return the snapshot to re-apply, or ``None`` if nothing to redo."""
+        if not self._redo:
+            return None
+        self._undo.append(current_snapshot)
+        return self._redo.pop()
+
+    @property
+    def can_undo(self) -> bool:
+        return bool(self._undo)
+
+    @property
+    def can_redo(self) -> bool:
+        return bool(self._redo)
+
+
+__all__ = ["SnapshotHistory"]

--- a/bidsmgr/gui/widgets/panel_frame.py
+++ b/bidsmgr/gui/widgets/panel_frame.py
@@ -268,6 +268,17 @@ class PanelFrame(QFrame):
         win = QDialog(self.window())
         win.setWindowTitle(f"BIDS-Manager - {self._title}" if self._title else "BIDS-Manager")
         win.setObjectName("panel-frame-float")
+        # A bare QDialog gets only a close button on Linux / Windows. Promote
+        # it to a normal top-level window so it carries minimize + maximize
+        # buttons and can be maximised / tiled like any other window.
+        win.setWindowFlags(
+            Qt.WindowType.Window
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowSystemMenuHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
         lay = QVBoxLayout(win)
         lay.setContentsMargins(0, 0, 0, 0)
         self._inner.setParent(win)

--- a/bidsmgr/gui/widgets/panel_frame.py
+++ b/bidsmgr/gui/widgets/panel_frame.py
@@ -1,0 +1,334 @@
+"""A collapsible / detachable wrapper around a pane (or a sub-splitter).
+
+Each side region in the Converter / Editor is wrapped in a ``PanelFrame``
+to get two affordances:
+
+* a **collapse caret** that folds the body toward an ``edge``:
+    - ``"top"`` / ``"bottom"``  fold by height; caret + title + detach share
+      one thin horizontal bar on that edge.
+    - ``"left"`` / ``"right"``  fold by width; the title + detach stay in a
+      horizontal bar across the top, while the collapse caret sits centred in
+      a thin VERTICAL strip on the panel's outer edge.
+  When collapsed inside a splitter the freed space is handed to a designated
+  ``grow_target`` (the inspection table / the editor viewer) so the work
+  surface expands automatically, no manual drag needed.
+* a **detach button** (always in the horizontal bar) that pops the body out
+  into a floating window; closing it docks it back. ``inner`` may be a whole
+  ``QSplitter``, so two panes (inspection + properties) detach as one unit.
+
+The frame hides the pane's own ``PaneHeader`` so there is a single header.
+State is not persisted across restarts.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QSplitter,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .. import icons
+from .primitives import PaneHeader
+
+_QWIDGETSIZE_MAX = (1 << 24) - 1
+_STRIP_PX = 24  # collapsed vertical-strip thickness
+_BAR_PX = 26    # horizontal title-bar height
+
+
+class PanelFrame(QFrame):
+    """Collapsible + detachable container for one pane (or sub-splitter)."""
+
+    state_changed = pyqtSignal()
+
+    def __init__(
+        self,
+        inner: QWidget,
+        title: str = "",
+        *,
+        edge: str = "top",            # "top" | "bottom" | "left" | "right"
+        collapsible: bool = True,
+        detachable: bool = True,
+        hide_inner_header: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("panel-frame")
+        self._inner = inner
+        self._title = title
+        self._edge = edge
+        self._vertical_fold = edge in ("left", "right")
+        self._collapsible = collapsible
+        self._detachable = detachable
+        self._collapsed = False
+        self._detached: Optional[QDialog] = None
+        self._splitter: Optional[QSplitter] = None
+        self._grow_target: Optional[QWidget] = None
+        self._saved_extent: Optional[int] = None
+
+        if hide_inner_header:
+            hdr = inner.findChild(PaneHeader)
+            if hdr is not None:
+                hdr.setVisible(False)
+
+        # Placeholder shown in place of the body while detached.
+        self._placeholder = QLabel("Detached - close the window to dock it back.")
+        self._placeholder.setObjectName("pane-hint")
+        self._placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._placeholder.setWordWrap(True)
+        self._placeholder.setVisible(False)
+
+        self._build_controls()
+        self._assemble()
+        self._refresh_icons()
+
+    # ------------------------------------------------------------------
+    def _build_controls(self) -> None:
+        self._caret = QToolButton()
+        self._caret.setObjectName("panel-frame-caret")
+        self._caret.setAutoRaise(True)
+        self._caret.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._caret.setToolTip("Collapse / expand")
+        self._caret.clicked.connect(self.toggle_collapsed)
+
+        self._detach_btn = QToolButton()
+        self._detach_btn.setObjectName("panel-frame-detach")
+        self._detach_btn.setAutoRaise(True)
+        self._detach_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._detach_btn.setToolTip("Detach into a floating window")
+        self._detach_btn.clicked.connect(self.toggle_detached)
+
+        self._title_lbl = QLabel(self._title.upper())
+        self._title_lbl.setObjectName("pane-h5")
+
+        # Horizontal title bar. For top/bottom panels it also carries the
+        # caret; for left/right panels the caret lives in the side strip and
+        # the bar holds just the title + detach.
+        self._bar = QFrame()
+        self._bar.setObjectName("panel-frame-header")
+        self._bar.setFixedHeight(_BAR_PX)
+        bl = QHBoxLayout(self._bar)
+        bl.setContentsMargins(6, 0, 4, 0)
+        bl.setSpacing(4)
+        if not self._vertical_fold:
+            bl.addWidget(self._caret)
+        bl.addWidget(self._title_lbl, 1)
+        bl.addWidget(self._detach_btn)
+
+        # Side strip (left/right only): a thin vertical bar with the caret
+        # centred vertically.
+        self._strip: Optional[QFrame] = None
+        if self._vertical_fold:
+            self._strip = QFrame()
+            self._strip.setObjectName("panel-frame-strip")
+            self._strip.setFixedWidth(_STRIP_PX)
+            self._strip.setToolTip(self._title)
+            sl = QVBoxLayout(self._strip)
+            sl.setContentsMargins(0, 4, 0, 4)
+            sl.setSpacing(4)
+            sl.addStretch(1)
+            sl.addWidget(self._caret, 0, Qt.AlignmentFlag.AlignHCenter)
+            sl.addStretch(1)
+
+        self._caret.setVisible(self._collapsible)
+        self._detach_btn.setVisible(self._detachable)
+
+    def _assemble(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        if self._vertical_fold:
+            # [ title bar              ]
+            # [ strip | content ]   (strip on the panel's outer edge)
+            outer.addWidget(self._bar)
+            self._body_row = QWidget()
+            brow = QHBoxLayout(self._body_row)
+            brow.setContentsMargins(0, 0, 0, 0)
+            brow.setSpacing(0)
+            if self._edge == "left":
+                brow.addWidget(self._strip)
+                brow.addWidget(self._inner, 1)
+                brow.addWidget(self._placeholder, 1)
+                self._content_index = 1
+            else:  # right
+                brow.addWidget(self._inner, 1)
+                brow.addWidget(self._placeholder, 1)
+                brow.addWidget(self._strip)
+                self._content_index = 0
+            outer.addWidget(self._body_row, 1)
+        else:
+            self._body_row = None
+            if self._edge == "bottom":
+                outer.addWidget(self._inner, 1)
+                outer.addWidget(self._placeholder, 1)
+                outer.addWidget(self._bar)
+                self._content_index = 0
+            else:  # top
+                outer.addWidget(self._bar)
+                outer.addWidget(self._inner, 1)
+                outer.addWidget(self._placeholder, 1)
+                self._content_index = 1
+
+    # ------------------------------------------------------------------
+    # Splitter wiring
+    # ------------------------------------------------------------------
+
+    def attach_splitter(self, splitter: QSplitter, grow_target: Optional[QWidget] = None) -> None:
+        self._splitter = splitter
+        self._grow_target = grow_target
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def inner(self) -> QWidget:
+        return self._inner
+
+    def is_collapsed(self) -> bool:
+        return self._collapsed
+
+    def is_detached(self) -> bool:
+        return self._detached is not None
+
+    def toggle_collapsed(self) -> None:
+        self.set_collapsed(not self._collapsed)
+
+    def set_collapsed(self, collapsed: bool) -> None:
+        if not self._collapsible or collapsed == self._collapsed or self.is_detached():
+            return
+        self._collapsed = collapsed
+        self._inner.setVisible(not collapsed)
+        if self._vertical_fold:
+            # Fold to just the side strip: hide the top title bar too.
+            self._bar.setVisible(not collapsed)
+        self._apply_fold(collapsed)
+        self._refresh_icons()
+        self.state_changed.emit()
+
+    def _grow_index(self, sizes_len: int, idx: int) -> Optional[int]:
+        if self._grow_target is not None and self._splitter is not None:
+            gi = self._splitter.indexOf(self._grow_target)
+            if gi != -1 and gi != idx:
+                return gi
+        others = [i for i in range(sizes_len) if i != idx]
+        return max(others, key=lambda i: self._splitter.sizes()[i]) if others else None
+
+    def _apply_fold(self, collapsed: bool) -> None:
+        sp = self._splitter
+        if self._vertical_fold:
+            if collapsed:
+                self.setFixedWidth(_STRIP_PX)
+            else:
+                self.setMinimumWidth(0)
+                self.setMaximumWidth(_QWIDGETSIZE_MAX)
+        else:
+            self.setMaximumHeight(_BAR_PX + 4 if collapsed else _QWIDGETSIZE_MAX)
+
+        if sp is None or sp.indexOf(self) == -1:
+            return
+        sizes = sp.sizes()
+        idx = sp.indexOf(self)
+        grow = self._grow_index(len(sizes), idx)
+        if grow is None:
+            return
+        strip = _STRIP_PX if self._vertical_fold else _BAR_PX + 4
+        if collapsed:
+            self._saved_extent = sizes[idx]
+            delta = sizes[idx] - strip
+            sizes[idx] = strip
+            sizes[grow] += delta
+        else:
+            restore = self._saved_extent or 280
+            delta = restore - sizes[idx]
+            sizes[idx] = restore
+            sizes[grow] = max(strip, sizes[grow] - delta)
+        sp.setSizes(sizes)
+
+    def toggle_detached(self) -> None:
+        if self.is_detached():
+            self.reattach()
+        else:
+            self.detach()
+
+    def detach(self) -> None:
+        if self.is_detached():
+            return
+        if self._collapsed:
+            self.set_collapsed(False)
+
+        win = QDialog(self.window())
+        win.setWindowTitle(f"BIDS-Manager - {self._title}" if self._title else "BIDS-Manager")
+        win.setObjectName("panel-frame-float")
+        lay = QVBoxLayout(win)
+        lay.setContentsMargins(0, 0, 0, 0)
+        self._inner.setParent(win)
+        lay.addWidget(self._inner)
+        self._inner.setVisible(True)
+        win.resize(max(self._inner.width(), 520), max(self._inner.height(), 380))
+        win.finished.connect(lambda _=0: self.reattach())
+        self._detached = win
+
+        self._placeholder.setVisible(True)
+        self._caret.setVisible(False)
+        self._detach_btn.setToolTip("Re-dock the floating window")
+        self._refresh_icons()
+        win.show()
+        self.state_changed.emit()
+
+    def reattach(self) -> None:
+        if not self.is_detached():
+            return
+        win = self._detached
+        self._detached = None
+        # Move the body back next to its control, at its original position.
+        parent_layout = self._body_row.layout() if self._vertical_fold else self.layout()
+        self._inner.setParent(self._body_row if self._vertical_fold else self)
+        parent_layout.insertWidget(self._content_index, self._inner, 1)
+        self._inner.setVisible(True)
+        self._placeholder.setVisible(False)
+        self._caret.setVisible(self._collapsible)
+        self._detach_btn.setVisible(self._detachable)
+        self._detach_btn.setToolTip("Detach into a floating window")
+        self._refresh_icons()
+        try:
+            win.finished.disconnect()
+        except TypeError:
+            pass
+        win.close()
+        win.deleteLater()
+        self.state_changed.emit()
+
+    # ------------------------------------------------------------------
+    # Theming
+    # ------------------------------------------------------------------
+
+    def repaint_for_palette(self, pal: dict) -> None:
+        self._refresh_icons()
+        inner_repaint = getattr(self._inner, "repaint_for_palette", None)
+        if callable(inner_repaint):
+            inner_repaint(pal)
+
+    def _refresh_icons(self) -> None:
+        if self._vertical_fold:
+            if self._edge == "left":
+                glyph = "panel_expand" if self._collapsed else "chevron_left"
+            else:  # right
+                glyph = "chevron_left" if self._collapsed else "panel_expand"
+        else:
+            glyph = "panel_expand" if self._collapsed else "panel_collapse"
+        self._caret.setIcon(icons.icon(glyph))
+        self._detach_btn.setIcon(
+            icons.icon("reattach" if self.is_detached() else "detach")
+        )
+
+
+__all__ = ["PanelFrame"]

--- a/bidsmgr/gui/widgets/primitives.py
+++ b/bidsmgr/gui/widgets/primitives.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import QRectF, Qt, pyqtSignal
+from PyQt6.QtGui import QBrush, QColor, QPainter, QPen
 from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
@@ -33,33 +34,76 @@ from PyQt6.QtWidgets import (
 )
 
 
-class Chip(QLabel):
-    """A small pill label. ``kind`` selects color via QSS property selector.
+def _chip_qcolor(token: str) -> QColor:
+    """Parse a palette token (hex or ``rgba(r,g,b,a)``) into a QColor.
 
-    Known kinds (from ``theme.qss``): ``default``, ``success``, ``warn``,
-    ``err``, ``purple``, ``teal``. Unknown kinds fall back to ``default``.
+    ``QColor`` cannot parse the CSS ``rgba(...)`` strings the palette uses
+    for translucent tints, so handle those explicitly.
+    """
+    s = (token or "").strip()
+    if s.startswith(("rgba(", "rgb(")):
+        nums = s[s.index("(") + 1: s.rindex(")")].split(",")
+        try:
+            r, g, b = (int(float(nums[i])) for i in range(3))
+            a = int(float(nums[3]) * 255) if len(nums) > 3 else 255
+            return QColor(r, g, b, a)
+        except (ValueError, IndexError):
+            return QColor("#000000")
+    return QColor(s or "#000000")
+
+
+class Chip(QLabel):
+    """A small pill label that **paints its own rounded background**.
+
+    ``kind`` selects the colour set: ``default``, ``success``, ``warn``,
+    ``err``, ``accent``, ``purple``, ``teal``.
+
+    The pill is drawn in :meth:`paintEvent` with a corner radius of
+    ``height / 2``, so it is ALWAYS a perfect pill at any font size /
+    DPI / platform - QSS ``border-radius`` proved unreliable across
+    macOS/Linux/Windows + font scales. Colours are read live from the
+    active palette (:func:`bidsmgr.gui.theme_manager.CUR`) at paint time,
+    so a theme swap (which triggers ``update()``) recolours automatically.
 
     Emits :pyattr:`clicked` on a left-mouse release **only if**
-    :meth:`set_clickable` is called with ``True``. The default chip is
-    a passive label (no signal, no cursor change) so existing callers
-    don't accidentally pick up click semantics.
+    :meth:`set_clickable` is called with ``True``.
     """
 
     clicked = pyqtSignal()
 
+    # kind -> (background token, foreground token, border token).
+    _KIND_TOKENS = {
+        "default": ("surface3", "dim", "border"),
+        "success": ("success_bg", "success", "success_border"),
+        "warn":    ("warning_bg", "warning", "warning_border"),
+        "err":     ("error_bg", "error", "error_border"),
+        "accent":  ("accent_bg", "accent", "accent_border"),
+        "purple":  ("purple_bg", "purple", "purple_border"),
+        "teal":    ("teal_bg", "teal", "teal_border"),
+    }
+
     def __init__(self, text: str, kind: str = "", parent=None) -> None:
         super().__init__(text, parent)
-        self.setProperty("chipKind", kind or "default")
+        self._kind = kind or "default"
+        # Keep the property so any QSS targeting chipKind still matches.
+        self.setProperty("chipKind", self._kind)
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Maximum)
+        # Transparent widget background so ONLY the painted pill shows - the
+        # parent (toolbar / panel) shows through the rounded corners. Without
+        # this Qt fills the widget rect first, leaving a square behind the pill.
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        # Horizontal breathing room + a hair of vertical so the pill reads.
+        self.setContentsMargins(9, 1, 9, 1)
         self._clickable = False
 
-    def set_clickable(self, clickable: bool) -> None:
-        """Toggle whether mouse presses on the chip emit ``clicked``.
+    def setText(self, text: str) -> None:  # noqa: N802 — Qt naming
+        super().setText(text)
+        self.updateGeometry()
+        self.update()
 
-        Also flips the cursor to a hand pointer so users can tell the
-        chip is an actionable element.
-        """
+    def set_clickable(self, clickable: bool) -> None:
+        """Toggle whether mouse presses on the chip emit ``clicked``."""
         self._clickable = clickable
         self.setCursor(
             Qt.CursorShape.PointingHandCursor if clickable else
@@ -71,6 +115,28 @@ class Chip(QLabel):
                 and self.rect().contains(event.position().toPoint()):
             self.clicked.emit()
         super().mouseReleaseEvent(event)
+
+    def paintEvent(self, event):  # noqa: N802 — Qt naming
+        from ..theme_manager import CUR
+
+        pal = CUR()
+        bg_t, fg_t, br_t = self._KIND_TOKENS.get(
+            self._kind, self._KIND_TOKENS["default"]
+        )
+        bg = _chip_qcolor(pal.get(bg_t, "#1c2128"))
+        fg = _chip_qcolor(pal.get(fg_t, "#8b949e"))
+        border = _chip_qcolor(pal.get(br_t, "#21262d"))
+
+        p = QPainter(self)
+        p.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        rect = QRectF(self.rect()).adjusted(0.5, 0.5, -0.5, -0.5)
+        radius = rect.height() / 2.0
+        p.setBrush(QBrush(bg))
+        p.setPen(QPen(border, 1))
+        p.drawRoundedRect(rect, radius, radius)
+        p.setPen(QPen(fg))
+        p.setFont(self.font())
+        p.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, self.text())
 
 
 class VSep(QFrame):

--- a/bidsmgr/gui/widgets/recording_viewer_pane.py
+++ b/bidsmgr/gui/widgets/recording_viewer_pane.py
@@ -1,0 +1,2025 @@
+"""EEG / MEG / iEEG recording viewer (Editor center pane, recording kind).
+
+Sister widget to :class:`NiftiViewerPane` / :class:`TsvViewerPane` /
+:class:`SidecarFormPane`. When the user clicks a recording file in the
+BIDS tree (``.fif``, ``.edf``, ``.set``, ``.vhdr``, ``.cnt``, CTF ``.ds``,
+...), :class:`bidsmgr.gui.editor_panel.EditorPanel` swaps its center pane
+to this viewer.
+
+Flow
+----
+1. **Metadata first.** Selecting a recording shows a themed metadata card
+   (channels, sampling rate, duration, per-type counts, filters, bad
+   channels, measurement date), read on a background thread
+   (:class:`bidsmgr.workers.RecordingMetaWorker`, ``preload=False``).
+2. **Load signal.** A "Load signal" button reads the full recording on a
+   background thread (:class:`bidsmgr.workers.RecordingSignalWorker`,
+   ``preload=True``) and switches to the interactive time-series viewer.
+   Its **Close** button returns to the metadata card.
+
+The time-series viewer is a restyled, annotation-free port of the MEEGqc
+``qc_viewer`` time-series widget (pyqtgraph): channel-type filtering with
+CTF axial-gradiometer handling, an individual-channel picker, visible
+count / amplitude scale / time-window controls, navigation + channel
+scroll + hover tooltips, raw-vs-normalise rendering, HP/LP/notch
+filtering, resample (threaded), an interactive in-app PSD view
+(pyqtgraph, MNE-like: per-channel + per-type-average tabs), and a
+BIDS-native event overlay (sibling ``*_events.tsv`` plus stim-channel
+``find_events``).
+
+Theme handling: toolbar / metadata controls are QSS-driven; the
+pyqtgraph plot reads the palette explicitly (it does not honour QSS),
+following the :class:`NiftiViewerPane` pattern. Everything (reads, PSD,
+resample) runs on ``QThread`` workers so the GUI never blocks; stale
+results are dropped via a path guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Set
+
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QCursor, QPalette
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QColorDialog,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QDoubleSpinBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QScrollBar,
+    QSizePolicy,
+    QSlider,
+    QSpinBox,
+    QSplitter,
+    QStackedWidget,
+    QTabWidget,
+    QToolTip,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .. import icons
+from ..theme_manager import CUR
+from .primitives import PaneHeader
+from .spinner import BusySpinner
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Recognised recording extensions (the Editor dispatch set).
+#
+# Deliberately excludes BrainVision sidecars (``.eeg`` / ``.vmrk``) and the
+# raw partners opened via their header file: the user opens ``.vhdr``, not the
+# binary ``.eeg``. ``mne.io.read_raw`` auto-dispatches every entry below (with
+# the format-specific fallbacks in ``_read_raw``).
+# ---------------------------------------------------------------------------
+_VIEWER_FILE_EXTS: frozenset[str] = frozenset({
+    ".fif", ".fif.gz", ".con", ".sqd", ".kdf",
+    ".vhdr", ".edf", ".bdf", ".gdf", ".set", ".cnt", ".egi", ".mef", ".nwb",
+})
+_VIEWER_DIR_EXTS: frozenset[str] = frozenset({".ds", ".mff"})
+
+# channel-type -> palette token, so trace colours follow the theme.
+_TYPE_TOKENS: dict[str, str] = {
+    "mag": "accent", "grad": "success", "eeg": "purple", "seeg": "purple",
+    "ecog": "purple", "eog": "teal", "ecg": "error", "emg": "warning",
+    "stim": "warning", "ref_meg": "dim", "misc": "dim", "bio": "teal",
+    "resp": "teal", "dbs": "purple",
+}
+
+# Distinct colours (palette tokens) for event IDs / PSD curves.
+_SERIES_TOKENS: tuple[str, ...] = (
+    "accent", "success", "purple", "teal", "warning", "error", "dim",
+)
+
+
+def _full_ext(path) -> str:
+    """Lower-case extension, preserving the ``.fif.gz`` double suffix."""
+    p = Path(path)
+    name = p.name.lower()
+    if name.endswith(".fif.gz"):
+        return ".fif.gz"
+    return p.suffix.lower()
+
+
+def is_recording_path(path) -> bool:
+    """True when *path* is an EEG/MEG/iEEG recording the viewer can open."""
+    p = Path(path)
+    ext = _full_ext(p)
+    if p.is_dir():
+        return ext in _VIEWER_DIR_EXTS
+    return ext in _VIEWER_FILE_EXTS
+
+
+# ---------------------------------------------------------------------------
+# Qt-free read helpers (imported by the loader workers).
+# ---------------------------------------------------------------------------
+# Extensions ``mne.io.read_raw`` refuses to auto-dispatch (ambiguous between
+# vendors). Try the generic reader first, then these in order. ``read_raw_ant``
+# needs the optional ``antio`` package; absent it the error is surfaced cleanly.
+_SPECIFIC_READERS: dict[str, tuple[str, ...]] = {
+    ".cnt": ("read_raw_cnt", "read_raw_ant"),
+    ".egi": ("read_raw_egi",),
+    ".mff": ("read_raw_egi",),
+}
+
+
+def _read_raw(path, *, preload: bool):
+    """Read a recording with MNE. ``preload`` controls full vs lazy load."""
+    import mne
+
+    p = str(path)
+    try:
+        return mne.io.read_raw(p, preload=preload, verbose=False)
+    except Exception as primary:
+        readers = _SPECIFIC_READERS.get(_full_ext(path))
+        if not readers:
+            raise
+        last = primary
+        for name in readers:
+            fn = getattr(mne.io, name, None)
+            if fn is None:
+                continue
+            try:
+                return fn(p, preload=preload, verbose=False)
+            except Exception as exc:  # noqa: BLE001 - try the next reader
+                last = exc
+        raise last
+
+
+def _summarize_raw(raw, path) -> dict:
+    """Build a plain display summary from an ``mne.io.Raw`` (no Qt)."""
+    import mne
+
+    info = raw.info
+    ch_names = list(info["ch_names"])
+    ch_types = [mne.channel_type(info, i) for i in range(len(ch_names))]
+    counts: dict[str, int] = {}
+    for t in ch_types:
+        counts[t] = counts.get(t, 0) + 1
+    available = sorted(set(ch_types))
+    is_ctf = (
+        "mag" in available
+        and "grad" not in available
+        and (
+            "ref_meg" in available
+            or getattr(raw, "compensation_grade", None) is not None
+            or _full_ext(path) == ".ds"
+        )
+    )
+    try:
+        duration = float(raw.times[-1]) if raw.n_times else 0.0
+    except Exception:
+        duration = 0.0
+    meas = info.get("meas_date")
+    return {
+        "filename": str(path),
+        "name": Path(path).name,
+        "n_channels": len(ch_names),
+        "sfreq": float(info["sfreq"]),
+        "duration": duration,
+        "n_times": int(raw.n_times),
+        "highpass": info.get("highpass"),
+        "lowpass": info.get("lowpass"),
+        "line_freq": info.get("line_freq"),
+        "meas_date": str(meas) if meas else None,
+        "ch_type_counts": counts,
+        "available_ch_types": available,
+        "is_ctf": is_ctf,
+        "bads": list(info.get("bads") or []),
+    }
+
+
+def _events_sibling(path) -> Optional[Path]:
+    """Return the sibling BIDS ``*_events.tsv`` for *path*, if present."""
+    p = Path(path)
+    name = p.name
+    ext = _full_ext(p)
+    if ext and name.lower().endswith(ext):
+        stem = name[: -len(ext)]
+    else:
+        stem = p.stem
+    base = stem.rsplit("_", 1)[0] if "_" in stem else stem
+    for suffix in ("_events.tsv", "_events.tsv.gz"):
+        cand = p.parent / f"{base}{suffix}"
+        if cand.exists():
+            return cand
+    return None
+
+
+def _read_events_tsv(path) -> List[tuple]:
+    """Parse a BIDS ``events.tsv`` into ``[(onset_s, label), ...]``."""
+    import csv
+    import gzip
+
+    out: List[tuple] = []
+    is_gz = str(path).lower().endswith(".gz")
+    try:
+        opener = (
+            gzip.open(path, "rt", encoding="utf-8", newline="")
+            if is_gz
+            else open(path, "r", encoding="utf-8", newline="")
+        )
+        with opener as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for row in reader:
+                onset = row.get("onset")
+                if onset is None:
+                    continue
+                try:
+                    t = float(onset)
+                except (TypeError, ValueError):
+                    continue
+                label = (
+                    row.get("trial_type")
+                    or row.get("value")
+                    or row.get("event_type")
+                    or ""
+                )
+                out.append((t, str(label)))
+    except Exception as exc:  # noqa: BLE001
+        log.debug("could not read events.tsv %s: %s", path, exc)
+        return []
+    return out
+
+
+def _series_color(index: int) -> str:
+    pal = CUR()
+    token = _SERIES_TOKENS[index % len(_SERIES_TOKENS)]
+    return pal.get(token, pal.get("text", "#888888"))
+
+
+def _type_color(ch_type: str) -> str:
+    pal = CUR()
+    return pal.get(_TYPE_TOKENS.get(ch_type, "dim"), pal.get("text", "#888888"))
+
+
+# ===========================================================================
+# In-app PSD dialog (pyqtgraph, MNE-like, interactive, two tabs)
+# ===========================================================================
+class _PsdDialog(QDialog):
+    """Power Spectral Density viewer.
+
+    Two tabs:
+    * **Per channel** - every channel of the selected type overlaid (thin),
+      plus the type mean (bold); a "Highlight" picker isolates one channel.
+    * **Average** - the per-type mean with a +/-1 std shaded band + legend.
+
+    Both plots are fully interactive (pyqtgraph: drag-pan, wheel/right-drag
+    zoom, auto-range button) and carry a crosshair with a frequency / power
+    readout, mirroring the useful parts of MNE's spectrum plot.
+    """
+
+    def __init__(self, result: dict, *, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Power spectral density")
+        self.setObjectName("pane-dark")
+        self.resize(900, 560)
+        import pyqtgraph as pg
+
+        self._pg = pg
+        self._freqs = np.asarray(result["freqs"])
+        self._data = np.asarray(result["data"])          # (n_ch, n_freqs)
+        self._ch_names: List[str] = list(result["ch_names"])
+        self._ch_types: List[str] = list(result["ch_types"])
+        # Defensive clamp: only index rows that actually exist in ``data``
+        # (compute_psd returns a channel subset, so a caller passing the full
+        # name/type lists must never drive an out-of-range index).
+        n = min(self._data.shape[0], len(self._ch_names), len(self._ch_types))
+        self._by_type: dict[str, List[int]] = {}
+        for i in range(n):
+            self._by_type.setdefault(self._ch_types[i], []).append(i)
+        self._db = True
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(8, 8, 8, 8)
+        outer.setSpacing(6)
+
+        # Shared top bar.
+        top = QHBoxLayout()
+        self._db_chk = QCheckBox("dB (10·log10)")
+        self._db_chk.setChecked(True)
+        self._db_chk.toggled.connect(self._on_db_toggled)
+        top.addWidget(self._db_chk)
+        top.addStretch(1)
+        hint = QLabel("Drag to pan · wheel / right-drag to zoom · click ⟲ to reset")
+        hint.setObjectName("sidecar-footer-summary")
+        top.addWidget(hint)
+        outer.addLayout(top)
+
+        self._tabs = QTabWidget()
+        outer.addWidget(self._tabs, 1)
+        self._build_channel_tab()
+        self._build_average_tab()
+
+        self._redraw_channel()
+        self._redraw_average()
+
+    # ---- tab construction -------------------------------------------------
+    def _build_channel_tab(self) -> None:
+        pg = self._pg
+        page = QWidget()
+        page.setObjectName("pane-dark")
+        v = QVBoxLayout(page)
+        v.setContentsMargins(4, 4, 4, 4)
+        v.setSpacing(4)
+
+        ctrl = QHBoxLayout()
+        ctrl.addWidget(QLabel("Type:"))
+        self._type_combo = QComboBox()
+        for t in sorted(self._by_type):
+            self._type_combo.addItem(f"{t}  ({len(self._by_type[t])})", userData=t)
+        self._type_combo.currentIndexChanged.connect(self._on_type_changed)
+        ctrl.addWidget(self._type_combo)
+        ctrl.addWidget(QLabel("Highlight:"))
+        self._hi_combo = QComboBox()
+        self._hi_combo.currentIndexChanged.connect(self._redraw_channel)
+        ctrl.addWidget(self._hi_combo, 1)
+        v.addLayout(ctrl)
+
+        self._ch_plot = pg.PlotWidget()
+        self._ch_plot.showGrid(x=True, y=True, alpha=0.15)
+        self._ch_plot.setLabel("bottom", "Frequency", units="Hz")
+        v.addWidget(self._ch_plot, 1)
+        self._ch_readout = QLabel("")
+        self._ch_readout.setObjectName("sidecar-footer-summary")
+        v.addWidget(self._ch_readout)
+        self._theme_plot(self._ch_plot)
+        self._ch_cross = self._wire_crosshair(self._ch_plot, self._ch_readout)
+        self._tabs.addTab(page, "Per channel")
+        self._refresh_highlight_combo()
+
+    def _build_average_tab(self) -> None:
+        pg = self._pg
+        page = QWidget()
+        page.setObjectName("pane-dark")
+        v = QVBoxLayout(page)
+        v.setContentsMargins(4, 4, 4, 4)
+        v.setSpacing(4)
+        self._avg_plot = pg.PlotWidget()
+        self._avg_plot.showGrid(x=True, y=True, alpha=0.15)
+        self._avg_plot.setLabel("bottom", "Frequency", units="Hz")
+        self._avg_plot.addLegend(offset=(-10, 10))
+        v.addWidget(self._avg_plot, 1)
+        self._avg_readout = QLabel("")
+        self._avg_readout.setObjectName("sidecar-footer-summary")
+        v.addWidget(self._avg_readout)
+        self._theme_plot(self._avg_plot)
+        self._avg_cross = self._wire_crosshair(self._avg_plot, self._avg_readout)
+        self._tabs.addTab(page, "Average (per type)")
+
+    # ---- helpers ----------------------------------------------------------
+    def _scale(self, arr):
+        if self._db:
+            return 10.0 * np.log10(np.maximum(arr, 1e-30))
+        return arr
+
+    def _ylabel(self) -> str:
+        return "Power (dB)" if self._db else "Power"
+
+    def _theme_plot(self, plot) -> None:
+        pg = self._pg
+        bg = self.palette().color(QPalette.ColorRole.Base)
+        fg = self.palette().color(QPalette.ColorRole.Text)
+        plot.setBackground(bg)
+        for axis in ("left", "bottom"):
+            ax = plot.getPlotItem().getAxis(axis)
+            ax.setPen(pg.mkPen(color=fg))
+            ax.setTextPen(pg.mkPen(color=fg))
+
+    def _wire_crosshair(self, plot, readout: QLabel):
+        pg = self._pg
+        pen = pg.mkPen(color=self.palette().color(QPalette.ColorRole.Text), width=1,
+                       style=Qt.PenStyle.DashLine)
+        vline = pg.InfiniteLine(angle=90, movable=False, pen=pen)
+        hline = pg.InfiniteLine(angle=0, movable=False, pen=pen)
+        vline.setZValue(10)
+        hline.setZValue(10)
+        plot.addItem(vline, ignoreBounds=True)
+        plot.addItem(hline, ignoreBounds=True)
+
+        def _moved(evt):
+            pos = evt[0]
+            vb = plot.getPlotItem().vb
+            if not plot.sceneBoundingRect().contains(pos):
+                return
+            pt = vb.mapSceneToView(pos)
+            vline.setPos(pt.x())
+            hline.setPos(pt.y())
+            readout.setText(
+                f"{pt.x():.2f} Hz   ·   {pt.y():.2f} {self._ylabel()}"
+            )
+
+        proxy = pg.SignalProxy(plot.scene().sigMouseMoved, rateLimit=30, slot=_moved)
+        return {"vline": vline, "hline": hline, "proxy": proxy}
+
+    def _refresh_highlight_combo(self) -> None:
+        t = self._type_combo.currentData()
+        self._hi_combo.blockSignals(True)
+        self._hi_combo.clear()
+        self._hi_combo.addItem("(none)", userData=-1)
+        for idx in self._by_type.get(t, []):
+            self._hi_combo.addItem(self._ch_names[idx], userData=idx)
+        self._hi_combo.blockSignals(False)
+
+    # ---- draw -------------------------------------------------------------
+    def _on_db_toggled(self, checked: bool) -> None:
+        self._db = checked
+        self._redraw_channel()
+        self._redraw_average()
+
+    def _on_type_changed(self) -> None:
+        self._refresh_highlight_combo()
+        self._redraw_channel()
+
+    def _redraw_channel(self) -> None:
+        pg = self._pg
+        plot = self._ch_plot
+        plot.clear()
+        plot.addItem(self._ch_cross["vline"], ignoreBounds=True)
+        plot.addItem(self._ch_cross["hline"], ignoreBounds=True)
+        t = self._type_combo.currentData()
+        idxs = self._by_type.get(t, [])
+        if not idxs:
+            return
+        base = QColor(_type_color(t))
+        thin = QColor(base)
+        thin.setAlpha(60)
+        thin_pen = pg.mkPen(color=thin, width=1)
+        for i in idxs:
+            plot.plot(self._freqs, self._scale(self._data[i]), pen=thin_pen)
+        # Mean (bold).
+        mean = np.mean(self._data[idxs], axis=0)
+        plot.plot(self._freqs, self._scale(mean),
+                  pen=pg.mkPen(color=base, width=2), name="mean")
+        # Highlighted channel.
+        hi = self._hi_combo.currentData()
+        if hi is not None and hi >= 0:
+            hi_color = self.palette().color(QPalette.ColorRole.Text)
+            plot.plot(self._freqs, self._scale(self._data[hi]),
+                      pen=pg.mkPen(color=hi_color, width=2))
+        plot.setLabel("left", self._ylabel())
+
+    def _redraw_average(self) -> None:
+        pg = self._pg
+        plot = self._avg_plot
+        plot.clear()
+        legend = plot.getPlotItem().legend
+        if legend is not None:
+            legend.clear()
+        plot.addItem(self._avg_cross["vline"], ignoreBounds=True)
+        plot.addItem(self._avg_cross["hline"], ignoreBounds=True)
+        for t in sorted(self._by_type):
+            idxs = self._by_type[t]
+            arr = self._data[idxs]
+            mean = self._scale(np.mean(arr, axis=0))
+            color = QColor(_type_color(t))
+            if arr.shape[0] > 1:
+                std = np.std(self._scale(arr), axis=0)
+                band = QColor(color)
+                band.setAlpha(40)
+                top = plot.plot(self._freqs, mean + std,
+                                pen=pg.mkPen(color=band, width=1))
+                bot = plot.plot(self._freqs, mean - std,
+                                pen=pg.mkPen(color=band, width=1))
+                fill = pg.FillBetweenItem(top, bot, brush=pg.mkBrush(band))
+                plot.addItem(fill)
+            plot.plot(self._freqs, mean, pen=pg.mkPen(color=color, width=2), name=t)
+        plot.setLabel("left", self._ylabel())
+
+
+# ===========================================================================
+# Time-series view (the interactive viewer)
+# ===========================================================================
+class _TimeSeriesView(QWidget):
+    """Interactive multi-channel EEG/MEG trace viewer (pyqtgraph)."""
+
+    status_message = pyqtSignal(str)
+    loading_changed = pyqtSignal(bool, str)
+    close_requested = pyqtSignal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("pane-dark")
+
+        self._raw = None
+        self._sfreq = 1000.0
+        self._ch_names: List[str] = []
+        self._ch_types: List[str] = []
+        self._available_ch_types: List[str] = []
+        self._is_ctf = False
+        self._duration = 0.0
+        self._n_samples = 0
+
+        self._visible_channels = 20
+        self._channel_offset = 0
+        self._time_start = 0.0
+        self._time_window = 10.0
+        self._scale_factor = 1.0
+        self._active_ch_type = "all"
+        self._selected_channels: Optional[Set[str]] = None
+        self._normalize = False
+        self._dark_plot = False
+
+        self._display_indices: List[int] = []
+        self._shown_ch_info: list = []
+        self._overlay_items: list = []
+
+        self._current_filter = None
+        self._notch_freq = None
+        self._current_filepath: Optional[str] = None
+        self._current_root: Optional[Path] = None
+
+        # Events (BIDS-native).
+        self._show_events = False
+        self._event_source = "auto"
+        self._event_line_width = 2
+        self._event_color_override: Optional[QColor] = None
+        self._tsv_events: List[tuple] = []
+        self._stim_events: List[tuple] = []
+        self._stim_channels: List[str] = []
+
+        self._resample_worker = None
+        self._psd_worker = None
+
+        import pyqtgraph as pg
+
+        self._pg = pg
+        self._build_ui()
+
+    # ------------------------------------------------------------------ UI
+    def _build_ui(self) -> None:
+        main = QVBoxLayout(self)
+        main.setContentsMargins(0, 0, 0, 0)
+        main.setSpacing(2)
+
+        self._toolbar_widget = self._build_toolbar()
+        self._toolbar_toggle = self._make_section_toggle(
+            "Display controls", self._toolbar_widget, expanded=True
+        )
+        main.addWidget(self._toolbar_toggle)
+        main.addWidget(self._toolbar_widget)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.setChildrenCollapsible(False)
+
+        self._label_area = QWidget()
+        self._label_layout = QVBoxLayout(self._label_area)
+        self._label_layout.setContentsMargins(2, 0, 2, 0)
+        self._label_layout.setSpacing(0)
+        label_scroll = QScrollArea()
+        label_scroll.setWidget(self._label_area)
+        label_scroll.setWidgetResizable(True)
+        label_scroll.setFixedWidth(68)
+        label_scroll.setObjectName("viewer-label-strip")
+        label_scroll.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+
+        self._plot_widget = self._pg.PlotWidget()
+        self._plot_widget.setMinimumWidth(60)
+        self._plot_widget.showGrid(x=True, y=False, alpha=0.15)
+        self._plot_widget.setLabel("bottom", "Time", units="s")
+        self._plot_widget.setMouseEnabled(x=True, y=False)
+        self._plot_widget.getPlotItem().getAxis("left").setWidth(0)
+        self._plot_widget.getPlotItem().getAxis("left").setStyle(
+            showValues=False
+        )
+        self._plot_widget.wheelEvent = self._on_plot_wheel
+        self._hover_proxy = self._pg.SignalProxy(
+            self._plot_widget.scene().sigMouseMoved,
+            rateLimit=30,
+            slot=self._on_mouse_moved,
+        )
+
+        splitter.addWidget(label_scroll)
+        splitter.addWidget(self._plot_widget)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+
+        self._chan_scroll = QScrollBar(Qt.Orientation.Vertical)
+        self._chan_scroll.setToolTip("Scroll channels")
+        self._chan_scroll.valueChanged.connect(self._on_channel_scroll)
+
+        plot_row = QHBoxLayout()
+        plot_row.setContentsMargins(0, 0, 0, 0)
+        plot_row.setSpacing(0)
+        plot_row.addWidget(splitter, 1)
+        plot_row.addWidget(self._chan_scroll)
+        plot_container = QWidget()
+        plot_container.setLayout(plot_row)
+        main.addWidget(plot_container, 1)
+
+        main.addWidget(self._build_navigation())
+
+        self._events_widget = self._build_events_row()
+        self._events_toggle = self._make_section_toggle(
+            "Events", self._events_widget, expanded=False
+        )
+        main.addWidget(self._events_toggle)
+        main.addWidget(self._events_widget)
+
+        self._apply_plot_theme()
+
+    def _make_section_toggle(
+        self, title: str, widget: QWidget, *, expanded: bool
+    ) -> QPushButton:
+        btn = QPushButton(("▼ " if expanded else "▶ ") + title)
+        btn.setCheckable(True)
+        btn.setChecked(expanded)
+        btn.setObjectName("viewer-section-toggle")
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        widget.setVisible(expanded)
+
+        def _toggle(checked: bool, w=widget, b=btn, t=title) -> None:
+            w.setVisible(checked)
+            b.setText(("▼ " if checked else "▶ ") + t)
+
+        btn.clicked.connect(_toggle)
+        return btn
+
+    def _build_toolbar(self) -> QWidget:
+        """Two rows of controls inside a horizontal scroll area.
+
+        The scroll area means the toolbar never forces a wide minimum on the
+        pane: when the Editor splitter narrows it, the toolbar scrolls
+        horizontally instead of refusing to shrink.
+        """
+        container = QWidget()
+        cl = QVBoxLayout(container)
+        cl.setContentsMargins(0, 0, 0, 0)
+        cl.setSpacing(0)
+
+        # Row 1 - display
+        row1 = QFrame()
+        row1.setObjectName("toolbar")
+        l1 = QHBoxLayout(row1)
+        l1.setContentsMargins(10, 4, 10, 4)
+        l1.setSpacing(6)
+
+        l1.addWidget(QLabel("Type:"))
+        self.cmb_ch_type = QComboBox()
+        self.cmb_ch_type.addItem("all")
+        self.cmb_ch_type.currentTextChanged.connect(self._on_ch_type_changed)
+        l1.addWidget(self.cmb_ch_type)
+
+        self.btn_select = QPushButton("  Channels")
+        self.btn_select.setObjectName("tb-btn")
+        icons.apply_button(self.btn_select, "channels")
+        self.btn_select.setToolTip("Pick specific channels to display")
+        self.btn_select.clicked.connect(self._open_channel_selector)
+        l1.addWidget(self.btn_select)
+
+        l1.addWidget(QLabel("Count:"))
+        self.spn_n = QSpinBox()
+        self.spn_n.setRange(1, 500)
+        self.spn_n.setValue(self._visible_channels)
+        self.spn_n.valueChanged.connect(self._on_n_changed)
+        l1.addWidget(self.spn_n)
+
+        l1.addWidget(QLabel("Scale:"))
+        self.spn_scale = QDoubleSpinBox()
+        self.spn_scale.setRange(0.01, 1000.0)
+        self.spn_scale.setValue(1.0)
+        self.spn_scale.setSingleStep(0.1)
+        self.spn_scale.setDecimals(2)
+        self.spn_scale.valueChanged.connect(self._on_scale_changed)
+        l1.addWidget(self.spn_scale)
+
+        l1.addWidget(QLabel("Window (s):"))
+        self.spn_window = QDoubleSpinBox()
+        self.spn_window.setRange(0.1, 3600.0)
+        self.spn_window.setValue(self._time_window)
+        self.spn_window.setSingleStep(1.0)
+        self.spn_window.valueChanged.connect(self._on_window_changed)
+        l1.addWidget(self.spn_window)
+
+        self.chk_dark = QCheckBox("Dark plot")
+        self.chk_dark.toggled.connect(self._on_dark_toggled)
+        l1.addWidget(self.chk_dark)
+
+        self.chk_norm = QCheckBox("Normalize")
+        self.chk_norm.setToolTip(
+            "Normalise each channel independently to prevent overlap.\n"
+            "When off, raw signals share a per-type scale (may overlap)."
+        )
+        self.chk_norm.toggled.connect(self._on_norm_toggled)
+        l1.addWidget(self.chk_norm)
+
+        self.btn_reset = QPushButton("  Reset view")
+        self.btn_reset.setObjectName("tb-btn")
+        icons.apply_button(self.btn_reset, "reset_view")
+        self.btn_reset.clicked.connect(self._reset_view)
+        l1.addWidget(self.btn_reset)
+
+        self.btn_close = QPushButton("  Close")
+        self.btn_close.setObjectName("tb-btn")
+        icons.apply_button(self.btn_close, "close_data")
+        self.btn_close.setToolTip("Close the signal and return to the metadata view")
+        self.btn_close.clicked.connect(self.close_requested.emit)
+        l1.addWidget(self.btn_close)
+
+        l1.addStretch(1)
+        cl.addWidget(row1)
+
+        # Row 2 - processing
+        row2 = QFrame()
+        row2.setObjectName("toolbar")
+        l2 = QHBoxLayout(row2)
+        l2.setContentsMargins(10, 4, 10, 4)
+        l2.setSpacing(6)
+
+        l2.addWidget(QLabel("HP (Hz):"))
+        self.spn_hp = QDoubleSpinBox()
+        self.spn_hp.setRange(0.0, 500.0)
+        self.spn_hp.setDecimals(1)
+        self.spn_hp.setSpecialValueText("Off")
+        l2.addWidget(self.spn_hp)
+
+        l2.addWidget(QLabel("LP (Hz):"))
+        self.spn_lp = QDoubleSpinBox()
+        self.spn_lp.setRange(0.0, 5000.0)
+        self.spn_lp.setDecimals(1)
+        self.spn_lp.setSpecialValueText("Off")
+        l2.addWidget(self.spn_lp)
+
+        l2.addWidget(QLabel("Notch (Hz):"))
+        self.spn_notch = QDoubleSpinBox()
+        self.spn_notch.setRange(0.0, 1000.0)
+        self.spn_notch.setDecimals(1)
+        self.spn_notch.setSpecialValueText("Off")
+        l2.addWidget(self.spn_notch)
+
+        self.btn_filter = QPushButton("  Apply filter")
+        self.btn_filter.setObjectName("tb-btn")
+        icons.apply_button(self.btn_filter, "filter")
+        self.btn_filter.clicked.connect(self._apply_filters)
+        l2.addWidget(self.btn_filter)
+
+        self.btn_filter_reset = QPushButton("Reset filters")
+        self.btn_filter_reset.setObjectName("tb-btn")
+        self.btn_filter_reset.clicked.connect(self._reset_filters)
+        l2.addWidget(self.btn_filter_reset)
+
+        l2.addWidget(QLabel("Resample (Hz):"))
+        self.spn_resample = QDoubleSpinBox()
+        self.spn_resample.setRange(0.0, 10000.0)
+        self.spn_resample.setDecimals(0)
+        self.spn_resample.setSpecialValueText("Off")
+        l2.addWidget(self.spn_resample)
+
+        self.btn_resample = QPushButton("  Resample")
+        self.btn_resample.setObjectName("tb-btn")
+        icons.apply_button(self.btn_resample, "resample")
+        self.btn_resample.clicked.connect(self._apply_resample)
+        l2.addWidget(self.btn_resample)
+
+        self.btn_psd = QPushButton("  PSD")
+        self.btn_psd.setObjectName("tb-btn")
+        icons.apply_button(self.btn_psd, "psd")
+        self.btn_psd.setToolTip("Power spectral density (interactive, in-app)")
+        self.btn_psd.clicked.connect(self._show_psd)
+        l2.addWidget(self.btn_psd)
+
+        l2.addStretch(1)
+        cl.addWidget(row2)
+
+        scroll = QScrollArea()
+        scroll.setWidget(container)
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setObjectName("viewer-toolbar-scroll")
+        scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        scroll.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Maximum)
+        scroll.setMaximumHeight(container.sizeHint().height() + 16)
+        return scroll
+
+    def _build_navigation(self) -> QWidget:
+        nav = QFrame()
+        nav.setObjectName("toolbar")
+        lay = QHBoxLayout(nav)
+        lay.setContentsMargins(10, 2, 10, 2)
+        lay.setSpacing(4)
+
+        self.btn_start = QPushButton("|<")
+        self.btn_start.setObjectName("tb-btn")
+        self.btn_start.setFixedWidth(40)
+        self.btn_start.clicked.connect(lambda: self._navigate("start"))
+        self.btn_prev = QPushButton("<")
+        self.btn_prev.setObjectName("tb-btn")
+        self.btn_prev.setFixedWidth(34)
+        self.btn_prev.clicked.connect(lambda: self._navigate("prev"))
+        self.btn_next = QPushButton(">")
+        self.btn_next.setObjectName("tb-btn")
+        self.btn_next.setFixedWidth(34)
+        self.btn_next.clicked.connect(lambda: self._navigate("next"))
+        self.btn_end = QPushButton(">|")
+        self.btn_end.setObjectName("tb-btn")
+        self.btn_end.setFixedWidth(40)
+        self.btn_end.clicked.connect(lambda: self._navigate("end"))
+
+        self.sld_time = QSlider(Qt.Orientation.Horizontal)
+        self.sld_time.setRange(0, 1000)
+        self.sld_time.valueChanged.connect(self._on_time_slider)
+        self.lbl_time = QLabel("0.0 / 0.0 s")
+        self.lbl_time.setObjectName("sidecar-footer-summary")
+
+        lay.addWidget(self.btn_start)
+        lay.addWidget(self.btn_prev)
+        lay.addWidget(self.sld_time, 1)
+        lay.addWidget(self.btn_next)
+        lay.addWidget(self.btn_end)
+        lay.addWidget(self.lbl_time)
+        return nav
+
+    def _build_events_row(self) -> QWidget:
+        box = QFrame()
+        box.setObjectName("toolbar")
+        lay = QHBoxLayout(box)
+        lay.setContentsMargins(10, 4, 10, 4)
+        lay.setSpacing(6)
+
+        self.chk_events = QCheckBox("Show events")
+        self.chk_events.setEnabled(False)
+        self.chk_events.toggled.connect(self._on_events_toggled)
+        lay.addWidget(self.chk_events)
+
+        lay.addWidget(QLabel("Source:"))
+        self.cmb_event_src = QComboBox()
+        self.cmb_event_src.addItem("auto")
+        self.cmb_event_src.setEnabled(False)
+        self.cmb_event_src.currentTextChanged.connect(self._on_event_src_changed)
+        lay.addWidget(self.cmb_event_src)
+
+        lay.addWidget(QLabel("Width:"))
+        self.spn_event_w = QSpinBox()
+        self.spn_event_w.setRange(1, 10)
+        self.spn_event_w.setValue(self._event_line_width)
+        self.spn_event_w.setFixedWidth(54)
+        self.spn_event_w.valueChanged.connect(self._on_event_width_changed)
+        lay.addWidget(self.spn_event_w)
+
+        self.btn_event_color = QPushButton("Color…")
+        self.btn_event_color.setObjectName("tb-btn")
+        self.btn_event_color.clicked.connect(self._pick_event_color)
+        lay.addWidget(self.btn_event_color)
+        self.btn_event_color_reset = QPushButton("Reset")
+        self.btn_event_color_reset.setObjectName("tb-btn")
+        self.btn_event_color_reset.clicked.connect(self._reset_event_color)
+        lay.addWidget(self.btn_event_color_reset)
+
+        lay.addStretch(1)
+        return box
+
+    # -------------------------------------------------------------- loading
+    def set_current_filepath(self, path, root) -> None:
+        self._current_filepath = str(path) if path else None
+        self._current_root = root
+
+    def load_raw(self, raw) -> None:
+        """Accept a preloaded ``mne.io.Raw`` and render it."""
+        import mne
+
+        self._raw = raw
+        info = raw.info
+        self._sfreq = float(info["sfreq"])
+        self._ch_names = list(raw.ch_names)
+        self._n_samples = int(raw.n_times)
+        self._duration = float(raw.times[-1]) if raw.n_times else 0.0
+        self._ch_types = [
+            mne.channel_type(info, i) for i in range(len(self._ch_names))
+        ]
+        self._time_start = 0.0
+        self._channel_offset = 0
+        self._current_filter = None
+        self._notch_freq = None
+        self._selected_channels = None
+        self._available_ch_types = sorted(set(self._ch_types))
+        self._is_ctf = (
+            "mag" in self._available_ch_types
+            and "grad" not in self._available_ch_types
+            and (
+                "ref_meg" in self._available_ch_types
+                or getattr(raw, "compensation_grade", None) is not None
+                or (
+                    self._current_filepath
+                    and _full_ext(self._current_filepath) == ".ds"
+                )
+            )
+        )
+
+        self.spn_window.blockSignals(True)
+        self.spn_window.setMaximum(max(0.1, self._duration))
+        self.spn_window.setValue(min(self._time_window, max(0.1, self._duration)))
+        self._time_window = self.spn_window.value()
+        self.spn_window.blockSignals(False)
+
+        self._rebuild_ch_type_combo()
+        self._update_display_indices()
+        self._update_channel_scrollbar()
+        self._extract_events(raw)
+        self._refresh_event_controls()
+        self._apply_plot_theme()
+        self._redraw()
+
+        display = []
+        for ct in self._available_ch_types:
+            display.append("mag (axial grad)" if self._is_ctf and ct == "mag" else ct)
+        self.status_message.emit(
+            f"Loaded {len(self._ch_names)} channels, "
+            f"{self._duration:.1f}s @ {self._sfreq:.0f} Hz | "
+            f"Types: {', '.join(display)}"
+        )
+
+    def _rebuild_ch_type_combo(self) -> None:
+        self.cmb_ch_type.blockSignals(True)
+        self.cmb_ch_type.clear()
+        self.cmb_ch_type.addItem("all")
+        has_mag = "mag" in self._available_ch_types
+        has_grad = "grad" in self._available_ch_types
+        if has_mag and has_grad:
+            self.cmb_ch_type.addItem("mag+grad")
+        for ct in self._available_ch_types:
+            label = "mag (axial grad)" if self._is_ctf and ct == "mag" else ct
+            self.cmb_ch_type.addItem(label, userData=ct)
+        self.cmb_ch_type.setCurrentText("all")
+        self._active_ch_type = "all"
+        self.cmb_ch_type.blockSignals(False)
+
+    # --------------------------------------------------------------- events
+    def _extract_events(self, raw) -> None:
+        import mne
+
+        self._stim_events = []
+        self._stim_channels = []
+        try:
+            stim = [
+                ch
+                for ch, t in zip(raw.ch_names, self._ch_types)
+                if t == "stim"
+            ]
+            self._stim_channels = stim
+            if stim:
+                try:
+                    events = mne.find_events(
+                        raw, stim_channel=stim, shortest_event=1, verbose=False
+                    )
+                except Exception:
+                    events = np.empty((0, 3), dtype=int)
+                for ev in events:
+                    eid = int(ev[2])
+                    if eid != 0:
+                        self._stim_events.append((float(ev[0]) / self._sfreq, eid))
+        except Exception:
+            pass
+
+        self._tsv_events = []
+        if self._current_filepath:
+            sib = _events_sibling(self._current_filepath)
+            if sib is not None:
+                self._tsv_events = _read_events_tsv(sib)
+
+    def _refresh_event_controls(self) -> None:
+        sources = []
+        if self._tsv_events:
+            sources.append("events.tsv")
+        if self._stim_events:
+            sources.append("stim")
+        has_any = bool(sources)
+        self.chk_events.blockSignals(True)
+        self.chk_events.setChecked(False)
+        self.chk_events.setEnabled(has_any)
+        self.chk_events.blockSignals(False)
+        self._show_events = False
+        self.cmb_event_src.blockSignals(True)
+        self.cmb_event_src.clear()
+        self.cmb_event_src.addItem("auto")
+        for s in sources:
+            self.cmb_event_src.addItem(s)
+        self.cmb_event_src.setEnabled(has_any)
+        self.cmb_event_src.blockSignals(False)
+        self._event_source = "auto"
+        if has_any:
+            n = len(self._tsv_events) + len(self._stim_events)
+            self.chk_events.setToolTip(
+                f"Overlay {n} event marker(s) from "
+                f"{' + '.join(sources)}"
+            )
+        else:
+            self.chk_events.setToolTip(
+                "No events found (no sibling events.tsv and no stim channel)"
+            )
+
+    def _active_events(self) -> List[tuple]:
+        """Return ``[(time, label), ...]`` for the chosen source."""
+        src = self._event_source
+        out: List[tuple] = []
+        if src in ("auto", "events.tsv") and self._tsv_events:
+            out.extend((float(t), str(lbl)) for t, lbl in self._tsv_events)
+            if src == "auto":
+                return out
+        if src in ("auto", "stim") and self._stim_events:
+            out.extend((float(t), str(eid)) for t, eid in self._stim_events)
+        return out
+
+    # ------------------------------------------------------------- display
+    def _update_display_indices(self) -> None:
+        if self._active_ch_type == "all":
+            indices = list(range(len(self._ch_names)))
+        elif self._active_ch_type == "mag+grad":
+            indices = [
+                i for i, t in enumerate(self._ch_types) if t in ("mag", "grad")
+            ]
+        else:
+            indices = [
+                i
+                for i, t in enumerate(self._ch_types)
+                if t == self._active_ch_type
+            ]
+        if self._selected_channels is not None:
+            indices = [
+                i for i in indices if self._ch_names[i] in self._selected_channels
+            ]
+        self._display_indices = indices
+        self._update_channel_scrollbar()
+
+    def _update_channel_scrollbar(self) -> None:
+        n = len(self._display_indices)
+        visible = min(self._visible_channels, n)
+        self._chan_scroll.setRange(0, max(0, n - visible))
+        self._chan_scroll.setValue(self._channel_offset)
+
+    def _get_data_segment(self, ch_indices, tmin, tmax):
+        if self._raw is None:
+            return None, None
+        smin = max(0, int(tmin * self._sfreq))
+        smax = min(self._n_samples, int(tmax * self._sfreq))
+        if smax <= smin:
+            return None, None
+        try:
+            data, times = self._raw[ch_indices, smin:smax]
+        except Exception:
+            return None, None
+        if self._current_filter or self._notch_freq:
+            import mne
+
+            l_freq = (
+                self._current_filter[0]
+                if self._current_filter and self._current_filter[0]
+                else None
+            )
+            h_freq = (
+                self._current_filter[1]
+                if self._current_filter and self._current_filter[1]
+                else None
+            )
+            if l_freq or h_freq:
+                try:
+                    data = mne.filter.filter_data(
+                        data, self._sfreq, l_freq, h_freq, verbose=False
+                    )
+                except Exception:
+                    pass
+            if self._notch_freq and self._notch_freq > 0:
+                try:
+                    data = mne.filter.notch_filter(
+                        data, self._sfreq, self._notch_freq, verbose=False
+                    )
+                except Exception:
+                    pass
+        return data, times
+
+    def _redraw(self) -> None:
+        self._plot_widget.clear()
+        self._clear_labels()
+        self._overlay_items = []
+        self._shown_ch_info = []
+        if self._raw is None:
+            return
+        n_disp = len(self._display_indices)
+        if n_disp == 0:
+            return
+        vis = min(self._visible_channels, n_disp)
+        start = min(self._channel_offset, max(0, n_disp - vis))
+        shown = self._display_indices[start:start + vis]
+        n_shown = len(shown)
+        if n_shown == 0:
+            return
+        tmin = self._time_start
+        tmax = min(self._time_start + self._time_window, self._duration)
+        data, times = self._get_data_segment(shown, tmin, tmax)
+        if data is None:
+            return
+        scale = self._scale_factor
+        plot_item = self._plot_widget.getPlotItem()
+        # Channel labels sit on the themed strip, so they always use the
+        # theme text colour (NOT the canvas colour) - fixes wash-out when
+        # "Dark plot" is on in light theme.
+        label_color = self.palette().color(QPalette.ColorRole.Text).name()
+
+        if self._normalize:
+            for i in range(n_shown):
+                trace = data[i]
+                rng = np.ptp(trace) if np.ptp(trace) > 0 else 1.0
+                offset = n_shown - 1 - i
+                y = ((trace - np.mean(trace)) / rng) * scale + offset
+                self._plot_one(plot_item, times, y, shown[i], offset, label_color,
+                               n_shown)
+        else:
+            type_ranges: dict = {}
+            for i in range(n_shown):
+                ct = self._ch_types[shown[i]]
+                type_ranges.setdefault(ct, []).append(np.ptp(data[i]))
+            type_scale = {}
+            for ct, ranges in type_ranges.items():
+                valid = [r for r in ranges if r > 0]
+                type_scale[ct] = float(np.median(valid)) if valid else 1.0
+            for i in range(n_shown):
+                ct = self._ch_types[shown[i]]
+                ref = type_scale.get(ct, 1.0) or 1.0
+                trace = data[i]
+                offset = n_shown - 1 - i
+                y = ((trace - np.mean(trace)) / ref) * scale + offset
+                self._plot_one(plot_item, times, y, shown[i], offset, label_color,
+                               n_shown)
+
+        plot_item.setXRange(tmin, tmax, padding=0)
+        plot_item.setYRange(-0.5, n_shown - 0.5, padding=0.02)
+        if self._show_events:
+            self._draw_events(tmin, tmax, n_shown)
+        self.lbl_time.setText(
+            f"{tmin:.1f} - {tmax:.1f} / {self._duration:.1f} s"
+        )
+        if self._duration > 0:
+            denom = max(0.01, self._duration - self._time_window)
+            self.sld_time.blockSignals(True)
+            self.sld_time.setValue(max(0, min(1000, int((tmin / denom) * 1000))))
+            self.sld_time.blockSignals(False)
+
+    def _plot_one(self, plot_item, times, y, ch_idx, offset, label_color,
+                  n_shown) -> None:
+        ch_name = self._ch_names[ch_idx]
+        ch_type = self._ch_types[ch_idx]
+        pen = self._pg.mkPen(color=_type_color(ch_type), width=1)
+        plot_item.plot(times, y, pen=pen)
+        self._add_channel_label(ch_name, n_shown, label_color)
+        self._shown_ch_info.append((offset, ch_name, ch_type))
+
+    def _clear_labels(self) -> None:
+        while self._label_layout.count() > 0:
+            item = self._label_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+    def _add_channel_label(self, ch_name, n_shown, color) -> None:
+        lbl = QLabel(ch_name)
+        lbl.setFixedHeight(
+            max(1, int(self._plot_widget.height() / max(n_shown, 1)))
+        )
+        lbl.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        lbl.setStyleSheet(f"QLabel {{ color: {color}; font-size: 9px; }}")
+        self._label_layout.addWidget(lbl)
+
+    def _draw_events(self, tmin, tmax, n_shown) -> None:
+        events = self._active_events()
+        if not events:
+            return
+        visible = [e for e in events if tmin <= e[0] <= tmax]
+        if len(visible) > 500:
+            step = len(visible) // 500
+            visible = visible[::step]
+        labels = sorted({lbl for _, lbl in visible})
+        color_map = {lbl: _series_color(i) for i, lbl in enumerate(labels)}
+        override = self._event_color_override
+        width = self._event_line_width
+        for t, lbl in visible:
+            color = (
+                override.name() if override and override.isValid()
+                else color_map.get(lbl, _series_color(0))
+            )
+            pen = self._pg.mkPen(color=color, width=width)
+            line = self._pg.InfiniteLine(pos=t, angle=90, pen=pen, movable=False)
+            self._plot_widget.addItem(line)
+            self._overlay_items.append(line)
+            if lbl:
+                txt = self._pg.TextItem(str(lbl), color=color, anchor=(0.5, 1.0))
+                txt.setPos(t, n_shown - 0.3)
+                font = txt.textItem.font()
+                font.setPointSize(7)
+                txt.setFont(font)
+                self._plot_widget.addItem(txt)
+                self._overlay_items.append(txt)
+
+    # ------------------------------------------------------------- handlers
+    def _on_ch_type_changed(self, text) -> None:
+        idx = self.cmb_ch_type.currentIndex()
+        user_data = self.cmb_ch_type.itemData(idx)
+        self._active_ch_type = user_data if user_data else text
+        self._channel_offset = 0
+        self._update_display_indices()
+        self._redraw()
+
+    def _on_n_changed(self, val) -> None:
+        self._visible_channels = val
+        self._update_channel_scrollbar()
+        self._redraw()
+
+    def _on_scale_changed(self, val) -> None:
+        self._scale_factor = val
+        self._redraw()
+
+    def _on_window_changed(self, val) -> None:
+        self._time_window = val
+        self._redraw()
+
+    def _on_time_slider(self, val) -> None:
+        if self._duration <= 0:
+            return
+        max_start = max(0.0, self._duration - self._time_window)
+        self._time_start = (val / 1000.0) * max_start
+        self._redraw()
+
+    def _on_channel_scroll(self, val) -> None:
+        self._channel_offset = val
+        self._redraw()
+
+    def _on_plot_wheel(self, event) -> None:
+        delta = event.angleDelta().y()
+        if delta != 0:
+            step = -1 if delta > 0 else 1
+            new = max(
+                self._chan_scroll.minimum(),
+                min(self._chan_scroll.maximum(), self._chan_scroll.value() + step),
+            )
+            self._chan_scroll.setValue(new)
+        event.accept()
+
+    def _navigate(self, direction) -> None:
+        step = self._time_window * 0.8
+        if direction == "start":
+            self._time_start = 0.0
+        elif direction == "prev":
+            self._time_start = max(0.0, self._time_start - step)
+        elif direction == "next":
+            self._time_start = min(
+                max(0.0, self._duration - self._time_window),
+                self._time_start + step,
+            )
+        elif direction == "end":
+            self._time_start = max(0.0, self._duration - self._time_window)
+        self._time_start = max(0.0, self._time_start)
+        self._redraw()
+
+    def _on_norm_toggled(self, checked) -> None:
+        self._normalize = checked
+        if self._raw is not None:
+            self._redraw()
+
+    def _on_dark_toggled(self, checked) -> None:
+        self._dark_plot = checked
+        self._apply_plot_theme()
+        if self._raw is not None:
+            self._redraw()
+
+    def _on_mouse_moved(self, evt) -> None:
+        pos = evt[0]
+        if not self._plot_widget.sceneBoundingRect().contains(pos):
+            return
+        if not self._shown_ch_info:
+            return
+        view_pt = self._plot_widget.getPlotItem().vb.mapSceneToView(pos)
+        y = view_pt.y()
+        nearest = ""
+        min_dist = float("inf")
+        for y_off, ch_name, _ in self._shown_ch_info:
+            d = abs(y - y_off)
+            if d < min_dist:
+                min_dist = d
+                nearest = ch_name
+        if min_dist < 0.6:
+            QToolTip.showText(QCursor.pos(), nearest, self._plot_widget)
+        else:
+            QToolTip.hideText()
+
+    def _on_events_toggled(self, checked) -> None:
+        self._show_events = checked
+        if checked and self._raw is not None:
+            self._jump_to_first_event_if_needed()
+        if self._raw is not None:
+            self._redraw()
+
+    def _on_event_src_changed(self, text) -> None:
+        self._event_source = text
+        if self._show_events:
+            self._jump_to_first_event_if_needed()
+            self._redraw()
+
+    def _jump_to_first_event_if_needed(self) -> None:
+        """If events are enabled but none fall in the current window, scroll
+        to the first one. Events often start well into a recording (the MEG
+        sample's first trigger is at ~102 s), so without this "Show events"
+        looks like it does nothing at t=0.
+        """
+        events = self._active_events()
+        if not events:
+            return
+        tmin = self._time_start
+        tmax = min(self._time_start + self._time_window, self._duration)
+        if any(tmin <= t <= tmax for t, _ in events):
+            return
+        first = min(t for t, _ in events)
+        max_start = max(0.0, self._duration - self._time_window)
+        self._time_start = max(0.0, min(first - self._time_window * 0.1, max_start))
+        self.status_message.emit(
+            f"{len(events)} events; jumped to the first at {first:.1f}s"
+        )
+
+    def _on_event_width_changed(self, val) -> None:
+        self._event_line_width = val
+        if self._show_events:
+            self._redraw()
+
+    def _pick_event_color(self) -> None:
+        color = QColorDialog.getColor(
+            self._event_color_override or QColor("#ffcc00"),
+            self,
+            "Pick event line colour",
+        )
+        if color.isValid():
+            self._event_color_override = color
+            if self._show_events:
+                self._redraw()
+
+    def _reset_event_color(self) -> None:
+        self._event_color_override = None
+        if self._show_events:
+            self._redraw()
+
+    # --------------------------------------------------------------- filters
+    def _apply_filters(self) -> None:
+        hp = self.spn_hp.value()
+        lp = self.spn_lp.value()
+        notch = self.spn_notch.value()
+        self._current_filter = (hp if hp > 0 else None, lp if lp > 0 else None)
+        self._notch_freq = notch if notch > 0 else None
+        self._redraw()
+        self.status_message.emit(
+            f"Filter applied: HP={hp:g}Hz LP={lp:g}Hz Notch={notch:g}Hz"
+        )
+
+    def _reset_filters(self) -> None:
+        for w in (self.spn_hp, self.spn_lp, self.spn_notch):
+            w.blockSignals(True)
+            w.setValue(0.0)
+            w.blockSignals(False)
+        self._current_filter = None
+        self._notch_freq = None
+        self._redraw()
+        self.status_message.emit("Filters reset")
+
+    def _apply_resample(self) -> None:
+        freq = self.spn_resample.value()
+        if freq <= 0 or self._raw is None:
+            return
+        from ...workers import RecordingResampleWorker
+
+        self.loading_changed.emit(True, f"Resampling to {freq:.0f} Hz…")
+        self.btn_resample.setEnabled(False)
+        worker = RecordingResampleWorker(self._raw, freq, parent=self)
+        worker.finished_with_raw.connect(self._on_resampled)
+        worker.failed.connect(self._on_resample_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._resample_worker = worker
+        worker.start()
+
+    def _on_resampled(self, raw, freq) -> None:
+        self._resample_worker = None
+        self.loading_changed.emit(False, "")
+        self.btn_resample.setEnabled(True)
+        self._raw = raw
+        self._sfreq = float(raw.info["sfreq"])
+        self._n_samples = int(raw.n_times)
+        self._duration = float(raw.times[-1]) if raw.n_times else 0.0
+        self.spn_window.setMaximum(max(0.1, self._duration))
+        self._redraw()
+        self.status_message.emit(
+            f"Resampled to {freq:.0f} Hz ({self._n_samples} samples)"
+        )
+
+    def _on_resample_failed(self, msg) -> None:
+        self._resample_worker = None
+        self.loading_changed.emit(False, "")
+        self.btn_resample.setEnabled(True)
+        QMessageBox.warning(self, "Resample error", msg)
+
+    # ------------------------------------------------------------------ PSD
+    def _show_psd(self) -> None:
+        if self._raw is None:
+            return
+        from ...workers import RecordingComputeWorker
+
+        self.loading_changed.emit(True, "Computing PSD…")
+        self.btn_psd.setEnabled(False)
+        raw = self._raw
+        sfreq = self._sfreq
+
+        def _compute():
+            import mne
+
+            fmax = min(sfreq / 2.0, 150.0)
+            psd = raw.compute_psd(fmin=0.1, fmax=fmax, verbose=False)
+            data = np.asarray(psd.get_data())
+            freqs = np.asarray(psd.freqs)
+            # compute_psd returns only data channels, in its own order - the
+            # rows align with psd.ch_names, NOT the raw channel list. Derive
+            # types from the raw info by name so labels/types stay correct.
+            names = list(psd.ch_names)
+            raw_names = list(raw.ch_names)
+            types = []
+            for ch in names:
+                try:
+                    types.append(mne.channel_type(raw.info, raw_names.index(ch)))
+                except ValueError:
+                    types.append("misc")
+            n = min(data.shape[0], len(names), len(types))
+            return {
+                "freqs": freqs,
+                "data": data[:n],
+                "ch_names": names[:n],
+                "ch_types": types[:n],
+            }
+
+        worker = RecordingComputeWorker(_compute, parent=self)
+        worker.finished_with_result.connect(self._on_psd_ready)
+        worker.failed.connect(self._on_psd_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._psd_worker = worker
+        worker.start()
+
+    def _on_psd_ready(self, result) -> None:
+        self._psd_worker = None
+        self.loading_changed.emit(False, "")
+        self.btn_psd.setEnabled(True)
+        dlg = _PsdDialog(result, parent=self)
+        dlg.show()
+        self.status_message.emit("PSD computed")
+
+    def _on_psd_failed(self, msg) -> None:
+        self._psd_worker = None
+        self.loading_changed.emit(False, "")
+        self.btn_psd.setEnabled(True)
+        QMessageBox.warning(self, "PSD error", msg)
+
+    # ----------------------------------------------------------- selection
+    def _open_channel_selector(self) -> None:
+        if not self._ch_names:
+            return
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Select channels")
+        dlg.resize(360, 520)
+        lay = QVBoxLayout(dlg)
+
+        search = QLineEdit()
+        search.setPlaceholderText("Search channels…")
+        lay.addWidget(search)
+
+        type_row = QHBoxLayout()
+        type_row.addWidget(QLabel("Type:"))
+        cmb = QComboBox()
+        display = []
+        for ct in self._available_ch_types:
+            display.append("mag (axial grad)" if self._is_ctf and ct == "mag" else ct)
+        cmb.addItems(["all"] + display)
+        type_row.addWidget(cmb, 1)
+        lay.addLayout(type_row)
+
+        lst = QListWidget()
+        lst.setSelectionMode(QListWidget.SelectionMode.MultiSelection)
+        for i, name in enumerate(self._ch_names):
+            ct = self._ch_types[i]
+            disp = "mag (axial grad)" if self._is_ctf and ct == "mag" else ct
+            item = QListWidgetItem(f"{name}  [{disp}]")
+            item.setData(Qt.ItemDataRole.UserRole, name)
+            if self._selected_channels is None or name in self._selected_channels:
+                item.setSelected(True)
+            lst.addItem(item)
+        lay.addWidget(lst, 1)
+
+        qrow = QHBoxLayout()
+        b_all = QPushButton("Select all")
+        b_none = QPushButton("Select none")
+        b_all.clicked.connect(lst.selectAll)
+        b_none.clicked.connect(lst.clearSelection)
+        qrow.addWidget(b_all)
+        qrow.addWidget(b_none)
+        lay.addLayout(qrow)
+
+        def _filter():
+            text = search.text().lower()
+            ct = cmb.currentText()
+            if ct == "mag (axial grad)":
+                ct = "mag"
+            for idx in range(lst.count()):
+                item = lst.item(idx)
+                name = item.data(Qt.ItemDataRole.UserRole)
+                ch_type = self._ch_types[self._ch_names.index(name)]
+                visible = True
+                if text and text not in name.lower():
+                    visible = False
+                if ct != "all" and ch_type != ct:
+                    visible = False
+                item.setHidden(not visible)
+
+        search.textChanged.connect(_filter)
+        cmb.currentTextChanged.connect(lambda _=None: _filter())
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        lay.addWidget(buttons)
+
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            selected = {
+                lst.item(i).data(Qt.ItemDataRole.UserRole)
+                for i in range(lst.count())
+                if lst.item(i).isSelected()
+            }
+            if len(selected) == len(self._ch_names):
+                self._selected_channels = None
+            else:
+                self._selected_channels = selected
+            self._channel_offset = 0
+            self._update_display_indices()
+            self._redraw()
+            n = len(selected) if self._selected_channels else len(self._ch_names)
+            self.status_message.emit(f"Displaying {n} channels")
+
+    # ----------------------------------------------------------------- reset
+    def _reset_view(self) -> None:
+        if self._raw is None:
+            return
+        self._time_start = 0.0
+        self._channel_offset = 0
+        self._scale_factor = 1.0
+        self._time_window = min(10.0, max(0.1, self._duration))
+        self._active_ch_type = "all"
+        self._current_filter = None
+        self._notch_freq = None
+        self._selected_channels = None
+        self._visible_channels = 20
+        self._normalize = False
+        for w in (self.spn_scale, self.spn_window, self.spn_n, self.cmb_ch_type,
+                  self.spn_hp, self.spn_lp, self.spn_notch, self.chk_norm):
+            w.blockSignals(True)
+        self.spn_scale.setValue(1.0)
+        self.spn_window.setValue(self._time_window)
+        self.spn_n.setValue(20)
+        self.cmb_ch_type.setCurrentText("all")
+        self.spn_hp.setValue(0.0)
+        self.spn_lp.setValue(0.0)
+        self.spn_notch.setValue(0.0)
+        self.chk_norm.setChecked(False)
+        for w in (self.spn_scale, self.spn_window, self.spn_n, self.cmb_ch_type,
+                  self.spn_hp, self.spn_lp, self.spn_notch, self.chk_norm):
+            w.blockSignals(False)
+        self._update_display_indices()
+        self._update_channel_scrollbar()
+        self._redraw()
+        self.status_message.emit("View reset")
+
+    # ---------------------------------------------------------------- unload
+    def unload(self) -> None:
+        for w in (self._resample_worker, self._psd_worker):
+            if w is not None:
+                w.cancel()
+        self._resample_worker = None
+        self._psd_worker = None
+        self._plot_widget.clear()
+        self._clear_labels()
+        self._raw = None
+        self._ch_names = []
+        self._ch_types = []
+        self._available_ch_types = []
+        self._display_indices = []
+        self._shown_ch_info = []
+        self._overlay_items = []
+        self._current_filter = None
+        self._notch_freq = None
+        self._selected_channels = None
+        self._is_ctf = False
+        self._duration = 0.0
+        self._n_samples = 0
+        self._tsv_events = []
+        self._stim_events = []
+        self.chk_events.setChecked(False)
+        self.chk_events.setEnabled(False)
+        self.lbl_time.setText("0.0 / 0.0 s")
+
+    # ----------------------------------------------------------------- theme
+    def _app_is_dark(self) -> bool:
+        return self.palette().color(QPalette.ColorRole.Base).lightness() < 128
+
+    def _apply_plot_theme(self) -> None:
+        pg = self._pg
+        dark_theme = self._app_is_dark()
+        # In dark theme the canvas is already dark, so the "Dark plot" override
+        # is redundant - disable + force it off.
+        self.chk_dark.blockSignals(True)
+        if dark_theme:
+            self._dark_plot = False
+            self.chk_dark.setChecked(False)
+            self.chk_dark.setEnabled(False)
+            self.chk_dark.setToolTip("Dark plot is automatic in dark theme")
+        else:
+            self.chk_dark.setEnabled(True)
+            self.chk_dark.setToolTip(
+                "Force a dark plot canvas (the canvas otherwise follows the "
+                "app theme)."
+            )
+        self.chk_dark.blockSignals(False)
+
+        if self._dark_plot and not dark_theme:
+            bg = QColor("#11161d")
+            x_fg = QColor("#cccccc")
+        else:
+            bg = self.palette().color(QPalette.ColorRole.Base)
+            x_fg = self.palette().color(QPalette.ColorRole.Text)
+        y_fg = self.palette().color(QPalette.ColorRole.Text)
+        self._plot_widget.setBackground(bg)
+        x_axis = self._plot_widget.getPlotItem().getAxis("bottom")
+        x_axis.setPen(pg.mkPen(color=x_fg))
+        x_axis.setTextPen(pg.mkPen(color=x_fg))
+        y_axis = self._plot_widget.getPlotItem().getAxis("left")
+        y_axis.setPen(pg.mkPen(color=y_fg))
+        y_axis.setTextPen(pg.mkPen(color=y_fg))
+
+    def repaint_for_palette(self, pal: dict) -> None:
+        del pal
+        style = self.style()
+        for w in [self, *self.findChildren(QWidget)]:
+            style.unpolish(w)
+            style.polish(w)
+            w.update()
+        for cmb in self.findChildren(QComboBox):
+            view = cmb.view()
+            targets = [cmb, view] + (
+                [view.viewport()] if view and view.viewport() else []
+            )
+            for t in targets:
+                style.unpolish(t)
+                style.polish(t)
+                t.update()
+        for name, btn in (
+            ("channels", self.btn_select),
+            ("reset_view", self.btn_reset),
+            ("close_data", self.btn_close),
+            ("filter", self.btn_filter),
+            ("resample", self.btn_resample),
+            ("psd", self.btn_psd),
+        ):
+            icons.apply_button(btn, name)
+        self._apply_plot_theme()
+        if self._raw is not None:
+            self._redraw()
+
+
+# ===========================================================================
+# The pane (metadata-first + time-series, with threaded loading)
+# ===========================================================================
+class RecordingViewerPane(QWidget):
+    """Center pane for EEG/MEG/iEEG recordings.
+
+    Bound to a single recording via :meth:`set_file`; pass ``None`` to
+    clear and unload. Metadata loads on a worker thread first; a "Load
+    signal" button loads the full recording (also threaded) and reveals
+    the interactive time-series view. The view's Close returns here.
+    """
+
+    status_message = pyqtSignal(str)
+    loading_changed = pyqtSignal(bool, str)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("pane-dark")
+        self.setMinimumWidth(0)
+
+        self._current_file: Optional[Path] = None
+        self._current_root: Optional[Path] = None
+        self._meta: Optional[dict] = None
+        self._meta_worker = None
+        self._signal_worker = None
+
+        v = QVBoxLayout(self)
+        v.setContentsMargins(0, 0, 0, 0)
+        v.setSpacing(0)
+        v.addWidget(PaneHeader("Recording"))
+
+        self._stack = QStackedWidget()
+        v.addWidget(self._stack, 1)
+
+        self._hint = QLabel(
+            "Select an EEG / MEG recording in the BIDS tree to view it."
+        )
+        self._hint.setObjectName("pane-hint")
+        self._hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._hint.setWordWrap(True)
+        self._stack.addWidget(self._hint)
+
+        self._loading_page = self._build_loading_page()
+        self._stack.addWidget(self._loading_page)
+
+        self._meta_page = self._build_meta_page()
+        self._stack.addWidget(self._meta_page)
+
+        # The pyqtgraph time-series view is built lazily, only when a signal
+        # is actually loaded. Editor sessions that just browse JSON/TSV never
+        # construct a pyqtgraph plot (cheaper + avoids offscreen-teardown
+        # flakiness in the test suite), mirroring the NIfTI viewer.
+        self._view: Optional[_TimeSeriesView] = None
+
+        self._stack.setCurrentWidget(self._hint)
+
+    def _ensure_view(self) -> "_TimeSeriesView":
+        if self._view is None:
+            self._view = _TimeSeriesView()
+            self._view.status_message.connect(self.status_message)
+            self._view.loading_changed.connect(self.loading_changed)
+            self._view.close_requested.connect(self._on_view_close)
+            self._stack.addWidget(self._view)
+        return self._view
+
+    # ------------------------------------------------------------------ UI
+    def _build_loading_page(self) -> QWidget:
+        page = QWidget()
+        page.setObjectName("pane-dark")
+        lay = QVBoxLayout(page)
+        lay.addStretch(1)
+        row = QHBoxLayout()
+        row.addStretch(1)
+        self._spinner = BusySpinner()
+        row.addWidget(self._spinner)
+        row.addStretch(1)
+        lay.addLayout(row)
+        self._loading_label = QLabel("")
+        self._loading_label.setObjectName("pane-hint")
+        self._loading_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lay.addWidget(self._loading_label)
+        lay.addStretch(1)
+        return page
+
+    def _build_meta_page(self) -> QWidget:
+        page = QWidget()
+        page.setObjectName("pane-dark")
+        outer = QVBoxLayout(page)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setObjectName("viewer-meta-scroll")
+        self._meta_body = QWidget()
+        self._meta_body.setObjectName("pane-dark")
+        self._meta_layout = QVBoxLayout(self._meta_body)
+        self._meta_layout.setContentsMargins(18, 16, 18, 16)
+        self._meta_layout.setSpacing(6)
+        self._meta_layout.addStretch(1)
+        scroll.setWidget(self._meta_body)
+        outer.addWidget(scroll, 1)
+
+        bar = QFrame()
+        bar.setObjectName("toolbar")
+        bl = QHBoxLayout(bar)
+        bl.setContentsMargins(14, 8, 14, 8)
+        bl.setSpacing(8)
+        bl.addStretch(1)
+        self._load_btn = QPushButton("Load signal")
+        self._load_btn.setObjectName("load-signal-btn")
+        self._load_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._load_btn.clicked.connect(self._load_signal)
+        bl.addWidget(self._load_btn)
+        bl.addStretch(1)
+        outer.addWidget(bar)
+        return page
+
+    def _meta_section(self, title: str) -> None:
+        lbl = QLabel(title)
+        lbl.setObjectName("viewer-meta-section")
+        self._meta_layout.insertWidget(self._meta_layout.count() - 1, lbl)
+
+    def _meta_row(self, label: str, value: str) -> None:
+        row = QWidget()
+        row.setObjectName("viewer-meta-row")
+        rl = QHBoxLayout(row)
+        rl.setContentsMargins(0, 0, 0, 0)
+        rl.setSpacing(10)
+        k = QLabel(label)
+        k.setObjectName("viewer-meta-key")
+        k.setMinimumWidth(96)
+        k.setMaximumWidth(140)
+        val = QLabel(value)
+        val.setObjectName("viewer-meta-val")
+        val.setWordWrap(True)
+        val.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+        rl.addWidget(k)
+        rl.addWidget(val, 1)
+        self._meta_layout.insertWidget(self._meta_layout.count() - 1, row)
+
+    def _clear_meta(self) -> None:
+        while self._meta_layout.count() > 1:
+            item = self._meta_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+    def _populate_meta(self, meta: dict) -> None:
+        self._clear_meta()
+
+        title = QLabel(meta.get("name", ""))
+        title.setObjectName("viewer-meta-title")
+        title.setWordWrap(True)
+        self._meta_layout.insertWidget(self._meta_layout.count() - 1, title)
+
+        self._meta_section("Recording")
+        self._meta_row("Channels", str(meta.get("n_channels", 0)))
+        self._meta_row("Sampling rate", f"{meta.get('sfreq', 0):.1f} Hz")
+        dur = meta.get("duration", 0.0)
+        self._meta_row("Duration", f"{dur:.1f} s ({dur / 60:.1f} min)")
+        self._meta_row("Time points", str(meta.get("n_times", 0)))
+        if meta.get("meas_date"):
+            self._meta_row("Measurement date", str(meta["meas_date"]))
+
+        self._meta_section("Filters")
+        hp = meta.get("highpass")
+        lp = meta.get("lowpass")
+        lf = meta.get("line_freq")
+        self._meta_row("High-pass", f"{hp:g} Hz" if hp not in (None, "") else "n/a")
+        self._meta_row("Low-pass", f"{lp:g} Hz" if lp not in (None, "") else "n/a")
+        self._meta_row("Line frequency", f"{lf:g} Hz" if lf not in (None, "") else "n/a")
+
+        self._meta_section("Channel types")
+        counts = meta.get("ch_type_counts", {})
+        for ct, n in sorted(counts.items()):
+            label = "mag (axial grad)" if meta.get("is_ctf") and ct == "mag" else ct
+            self._meta_row(label, str(n))
+        if meta.get("is_ctf"):
+            note = QLabel(
+                "CTF dataset: MEG sensors are axial gradiometers "
+                "(MNE labels them “mag”)."
+            )
+            note.setObjectName("viewer-meta-note")
+            note.setWordWrap(True)
+            self._meta_layout.insertWidget(self._meta_layout.count() - 1, note)
+
+        bads = meta.get("bads") or []
+        if bads:
+            self._meta_section(f"Bad channels ({len(bads)})")
+            self._meta_row("", ", ".join(bads))
+
+    # -------------------------------------------------------------- public
+    def current_file(self) -> Optional[Path]:
+        return self._current_file
+
+    def set_file(self, path: Optional[Path], root: Optional[Path]) -> None:
+        """Bind to a recording (or ``None`` to clear + unload)."""
+        self._cancel_workers()
+        self._current_file = path
+        self._current_root = root
+        if path is None:
+            if self._view is not None:
+                self._view.unload()
+            self._spinner.set_busy(False)
+            self._stack.setCurrentWidget(self._hint)
+            self._hint.setText(
+                "Select an EEG / MEG recording in the BIDS tree to view it."
+            )
+            self.loading_changed.emit(False, "")
+            return
+
+        from ...workers import RecordingMetaWorker
+
+        self._show_loading(f"Loading metadata: {path.name}…")
+        worker = RecordingMetaWorker(path, parent=self)
+        worker.finished_with_meta.connect(self._on_meta)
+        worker.failed.connect(self._on_meta_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._meta_worker = worker
+        worker.start()
+
+    def _show_loading(self, message: str) -> None:
+        self._loading_label.setText(message)
+        self._spinner.set_busy(True, message="")
+        self._stack.setCurrentWidget(self._loading_page)
+        self.loading_changed.emit(True, message)
+
+    def _cancel_workers(self) -> None:
+        for w in (self._meta_worker, self._signal_worker):
+            if w is not None:
+                w.cancel()
+        self._meta_worker = None
+        self._signal_worker = None
+
+    # ----------------------------------------------------------- callbacks
+    def _on_meta(self, meta: dict, path: Path) -> None:
+        if path != self._current_file:
+            return
+        self._meta_worker = None
+        self._meta = meta
+        self._spinner.set_busy(False)
+        self.loading_changed.emit(False, "")
+        self._populate_meta(meta)
+        self._stack.setCurrentWidget(self._meta_page)
+        self.status_message.emit(
+            f"{meta.get('name', '')}: {meta.get('n_channels', 0)} ch, "
+            f"{meta.get('sfreq', 0):.0f} Hz, {meta.get('duration', 0):.1f}s"
+        )
+
+    def _on_meta_failed(self, path: Path, error: str) -> None:
+        if path != self._current_file:
+            return
+        self._meta_worker = None
+        self._spinner.set_busy(False)
+        self.loading_changed.emit(False, "")
+        self._stack.setCurrentWidget(self._hint)
+        self._hint.setText(f"Could not read {path.name}:\n{error}")
+        self.status_message.emit(f"Error: {error.splitlines()[0] if error else ''}")
+
+    def _load_signal(self) -> None:
+        if self._current_file is None:
+            return
+        from ...workers import RecordingSignalWorker
+
+        path = self._current_file
+        self._show_loading(f"Loading signal: {path.name}…")
+        worker = RecordingSignalWorker(path, parent=self)
+        worker.finished_with_raw.connect(self._on_raw)
+        worker.failed.connect(self._on_raw_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._signal_worker = worker
+        worker.start()
+
+    def _on_raw(self, raw, path: Path) -> None:
+        if path != self._current_file:
+            return
+        self._signal_worker = None
+        self._spinner.set_busy(False)
+        self.loading_changed.emit(False, "")
+        view = self._ensure_view()
+        view.set_current_filepath(path, self._current_root)
+        view.load_raw(raw)
+        self._stack.setCurrentWidget(view)
+
+    def _on_raw_failed(self, path: Path, error: str) -> None:
+        if path != self._current_file:
+            return
+        self._signal_worker = None
+        self._spinner.set_busy(False)
+        self.loading_changed.emit(False, "")
+        self._stack.setCurrentWidget(self._meta_page)
+        QMessageBox.warning(
+            self, "Load error", f"Could not load {path.name}:\n{error}"
+        )
+
+    def _on_view_close(self) -> None:
+        """Close button in the viewer: drop the signal, show metadata."""
+        if self._view is not None:
+            self._view.unload()
+        if self._meta is not None:
+            self._stack.setCurrentWidget(self._meta_page)
+        else:
+            self._stack.setCurrentWidget(self._hint)
+        self.status_message.emit("Signal closed")
+
+    # -------------------------------------------------------------- theme
+    def repaint_for_palette(self, pal: dict) -> None:
+        style = self.style()
+        for w in [self, *self._meta_page.findChildren(QWidget),
+                  self._loading_page, self._hint]:
+            style.unpolish(w)
+            style.polish(w)
+            w.update()
+        if self._view is not None:
+            self._view.repaint_for_palette(pal)
+
+
+__all__ = ["RecordingViewerPane", "is_recording_path"]

--- a/bidsmgr/gui/widgets/sidecar_form_pane.py
+++ b/bidsmgr/gui/widgets/sidecar_form_pane.py
@@ -283,10 +283,17 @@ class SidecarFormPane(QWidget):
     # commit, save, revert, or set_file). Allows the toolbar / window
     # title / status bar to react.
     dirty_changed = pyqtSignal(int)  # number of fields changed since load
+    # Emitted when undo/redo availability changes (Editor toolbar syncs).
+    history_changed = pyqtSignal()
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("pane-dark")
+
+        # Undo/redo of in-memory JSON edits (snapshot = deep-copied cache).
+        from .edit_history import SnapshotHistory
+        self._history = SnapshotHistory()
+        self._pre_edit: Optional[OrderedDict[str, Any]] = None
 
         # Bound state — kept so the form can be rebuilt on file change.
         self._current_file: Optional[Path] = None
@@ -498,6 +505,9 @@ class SidecarFormPane(QWidget):
             self._tree_view.set_data(None)
             self._update_footer(None, None, None)
             self._refresh_dirty_ui()
+            self._history.clear()
+            self._pre_edit = None
+            self.history_changed.emit()
             return
 
         # Seed the JSON cache from disk so subsequent saves preserve
@@ -533,6 +543,9 @@ class SidecarFormPane(QWidget):
         )
         self._update_footer(path, root, verdict)
         self._refresh_dirty_ui()
+        self._history.clear()
+        self._pre_edit = self._snapshot()
+        self.history_changed.emit()
 
     def repaint_for_palette(self, pal: dict) -> None:
         """Force Qt to re-evaluate the global QSS for every widget here.
@@ -706,7 +719,53 @@ class SidecarFormPane(QWidget):
         if current == parsed_value:
             return
         self._json_cache[key] = parsed_value
+        self._after_edit()
+
+    # ----------------------------------------------------------------------
+    # Undo / redo (snapshot-based, in-memory; disk write still via Save)
+    # ----------------------------------------------------------------------
+
+    def _snapshot(self) -> Optional[OrderedDict]:
+        return copy.deepcopy(self._json_cache) if self._json_cache is not None else None
+
+    def _after_edit(self) -> None:
+        """Record the pre-edit cache for undo, then refresh the dirty UI.
+
+        Called at every in-memory mutation site (field commit + tree edits)
+        in place of a bare ``_refresh_dirty_ui`` so each edit is undoable.
+        """
+        if self._pre_edit is not None:
+            self._history.record(self._pre_edit)
+        self._pre_edit = self._snapshot()
         self._refresh_dirty_ui()
+        self.history_changed.emit()
+
+    def _restore(self, snap: Optional[OrderedDict]) -> None:
+        self._json_cache = copy.deepcopy(snap) if snap is not None else None
+        self._sync_active_view()
+        self._pre_edit = self._snapshot()
+        self._refresh_dirty_ui()
+        self.history_changed.emit()
+
+    def can_undo(self) -> bool:
+        return self._json_cache is not None and self._history.can_undo
+
+    def can_redo(self) -> bool:
+        return self._json_cache is not None and self._history.can_redo
+
+    def undo(self) -> None:
+        if self._json_cache is None:
+            return
+        snap = self._history.undo(self._snapshot())
+        if snap is not None:
+            self._restore(snap)
+
+    def redo(self) -> None:
+        if self._json_cache is None:
+            return
+        snap = self._history.redo(self._snapshot())
+        if snap is not None:
+            self._restore(snap)
 
     # ----------------------------------------------------------------------
     # View-mode toggle + tree handlers
@@ -948,7 +1007,7 @@ class SidecarFormPane(QWidget):
         for k, v in new_dict.items():
             if k not in self._json_cache:
                 self._json_cache[k] = v
-        self._refresh_dirty_ui()
+        self._after_edit()
 
     # ----------------------------------------------------------------------
     # Save / Revert / dirty introspection
@@ -1031,6 +1090,11 @@ class SidecarFormPane(QWidget):
             self._json_cache, levels=self._levels_from_fields(fields),
         )
         self._refresh_dirty_ui()
+        # Revert discards unsaved edits, so the undo history of those edits is
+        # no longer meaningful: reset it to the just-restored state.
+        self._history.clear()
+        self._pre_edit = self._snapshot()
+        self.history_changed.emit()
 
     def _dirty_count(self) -> int:
         """Number of keys whose value differs between cache and disk."""

--- a/bidsmgr/gui/widgets/status_badge.py
+++ b/bidsmgr/gui/widgets/status_badge.py
@@ -28,6 +28,7 @@ KIND_CHAR: dict[str, str] = {
     "phys": "P",
     "skip": "−",
     "info": "i",
+    "noimg": "⊘",   # DERIVED non-image object (no pixel data; not convertible)
 }
 
 # Background color: which palette token to tint, and at what alpha.
@@ -38,12 +39,14 @@ KIND_BG_TOKEN: dict[str, tuple[str, float]] = {
     "phys": ("accent",  0.18),
     "skip": ("muted",   0.20),
     "info": ("accent",  0.18),
+    "noimg": ("teal",   0.20),
 }
 
 # Foreground (glyph) color token.
 KIND_FG_TOKEN: dict[str, str] = {
     "ok": "success", "warn": "warning", "err": "error",
     "phys": "accent", "skip": "dim", "info": "accent",
+    "noimg": "teal",
 }
 
 

--- a/bidsmgr/gui/widgets/tsv_viewer_pane.py
+++ b/bidsmgr/gui/widgets/tsv_viewer_pane.py
@@ -114,6 +114,9 @@ class TsvViewerPane(QWidget):
     # Emitted whenever the dirty state flips (after a commit, save,
     # revert, or set_file). ``True`` means there are unsaved edits.
     dirty_changed = pyqtSignal(bool)
+    # Emitted whenever the undo/redo availability changes, so the Editor
+    # toolbar can sync its Undo/Redo buttons.
+    history_changed = pyqtSignal()
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -130,6 +133,11 @@ class TsvViewerPane(QWidget):
         # Suppress dirty bookkeeping while we're populating the model.
         self._suppress_dirty = False
         self._dirty = False
+        # Undo/redo of in-memory table edits (snapshot = (header, rows)).
+        # ``_pre_edit`` holds the committed state so the next edit records it.
+        from .edit_history import SnapshotHistory
+        self._history = SnapshotHistory()
+        self._pre_edit: Optional[tuple] = None
 
         v = QVBoxLayout(self)
         v.setContentsMargins(0, 0, 0, 0)
@@ -260,6 +268,8 @@ class TsvViewerPane(QWidget):
         """Bind the pane to a TSV (or ``None`` to clear)."""
         self._current_file = path
         self._current_root = root
+        # A new file resets the edit history.
+        self._history.clear()
         if path is None:
             self._reset_model()
             self._original_header = []
@@ -274,6 +284,8 @@ class TsvViewerPane(QWidget):
             self._footer_summary.setText("")
             self._edit_toolbar.setVisible(False)
             self._refresh_dirty_ui()
+            self._pre_edit = self._snapshot()
+            self.history_changed.emit()
             return
 
         header, rows, total = _read_tsv(path)
@@ -296,6 +308,8 @@ class TsvViewerPane(QWidget):
         # when there's something to save.
         self._edit_toolbar.setVisible(True)
         self._refresh_dirty_ui()
+        self._pre_edit = self._snapshot()
+        self.history_changed.emit()
 
     def save(self) -> bool:
         """Flush the model to disk. Returns ``True`` on success or
@@ -475,9 +489,54 @@ class TsvViewerPane(QWidget):
         self._mark_dirty()
 
     def _mark_dirty(self) -> None:
+        # Record the pre-edit state for undo (a fresh edit clears redo).
+        if self._pre_edit is not None:
+            self._history.record(self._pre_edit)
+        self._pre_edit = self._snapshot()
         if not self._dirty:
             self._dirty = True
         self._refresh_dirty_ui()
+        self.history_changed.emit()
+
+    # ----------------------------------------------------------------------
+    # Undo / redo (snapshot-based, in-memory; disk write still via Save)
+    # ----------------------------------------------------------------------
+
+    def _snapshot(self) -> tuple[list[str], list[list[str]]]:
+        return (self._current_header(), self._current_rows())
+
+    def _restore(self, snap: tuple[list[str], list[list[str]]]) -> None:
+        header, rows = snap
+        self._populate_model(list(header), [list(r) for r in rows])
+        self._stack.setCurrentIndex(1 if (header or rows) else 0)
+        # Dirty iff the restored state differs from what is on disk.
+        self._dirty = (
+            list(header) != list(self._original_header)
+            or [list(r) for r in rows] != [list(r) for r in self._original_rows]
+        )
+        self._pre_edit = self._snapshot()
+        self._refresh_dirty_ui()
+        self.history_changed.emit()
+
+    def can_undo(self) -> bool:
+        return self._current_file is not None and self._history.can_undo
+
+    def can_redo(self) -> bool:
+        return self._current_file is not None and self._history.can_redo
+
+    def undo(self) -> None:
+        if self._current_file is None:
+            return
+        snap = self._history.undo(self._snapshot())
+        if snap is not None:
+            self._restore(snap)
+
+    def redo(self) -> None:
+        if self._current_file is None:
+            return
+        snap = self._history.redo(self._snapshot())
+        if snap is not None:
+            self._restore(snap)
 
     def _refresh_dirty_ui(self) -> None:
         has_file = self._current_file is not None

--- a/bidsmgr/gui/widgets/tsv_viewer_pane.py
+++ b/bidsmgr/gui/widgets/tsv_viewer_pane.py
@@ -4,22 +4,23 @@ Sister widget to :class:`SidecarFormPane`. When the user clicks a
 ``.tsv`` (or ``.tsv.gz``) file in the BIDS tree, :class:`EditorPanel`
 swaps its center pane to this viewer.
 
-* Loads via the standard library (``csv`` + ``gzip``).
-* Renders headers + rows in a ``QTableView`` over a
-  ``QStandardItemModel``.
+* Parsed with pandas' C engine on a :class:`bidsmgr.workers.TsvLoaderWorker`
+  thread (releases the GIL, so the GUI stays responsive) and bounded to a
+  preview cap so even a multi-million-row table reads quickly.
+* Rendered through a **lazy** :class:`_TsvTableModel`
+  (:class:`~PyQt6.QtCore.QAbstractTableModel`) backed by plain Python
+  lists. Crucially this creates **no per-cell objects** and only the
+  visible cells are queried, so binding the data is O(1) - no main-thread
+  freeze regardless of how many rows / columns the file has.
 * Cells are inline-editable (double-click / F2 / select-then-click).
-* Toolbar provides ``+ Add row`` / ``+ Add column`` /
-  ``− Delete row`` / ``− Delete column`` plus ``Revert`` / ``Save``
-  (same manual-save model as the JSON sidecar pane).
-* Edits update the model only; ``Save`` flushes the table to disk.
-* ``Revert`` reloads from disk.
-* Switching files silently discards unsaved edits (the dirty chip
-  warned them while the file was bound — same UX as the sidecar pane).
+* Toolbar: ``+ Add row`` / ``+ Add column`` / ``− Delete row`` /
+  ``− Delete column`` plus ``Revert`` / ``Save`` (manual-save model, same
+  as the JSON sidecar pane). ``Save`` flushes to disk; ``Revert`` reloads.
+* Switching files silently discards unsaved edits.
 
 Theme handling: every palette colour comes from the global QSS.
 :meth:`repaint_for_palette` runs the same unpolish/polish dance the
-sidecar pane uses so cached per-widget styles invalidate on theme
-swap.
+sidecar pane uses.
 """
 
 from __future__ import annotations
@@ -30,8 +31,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QStandardItem, QStandardItemModel
+from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QFrame,
@@ -51,19 +51,11 @@ log = logging.getLogger(__name__)
 
 
 # Don't slurp arbitrarily-large TSVs into memory. BIDS TSVs (events /
-# channels / participants / scans) are small in practice; if anyone
-# passes a multi-million-row table we cap the preview here and the
-# footer warns about truncation. Saving a truncated TSV would be
-# destructive — when the file was truncated on load, the Save button
-# stays disabled.
+# channels / participants / scans) are small in practice; if anyone passes
+# a multi-million-row table we cap the preview here (the read is bounded to
+# this, and the footer warns about truncation). Saving a truncated TSV
+# would be destructive, so Save stays disabled when truncated on load.
 _MAX_PREVIEW_ROWS = 5000
-
-
-def _open_tsv(path: Path):
-    """Open a ``.tsv`` or ``.tsv.gz`` for text reading (UTF-8)."""
-    if path.name.lower().endswith(".gz"):
-        return gzip.open(path, "rt", encoding="utf-8", newline="")
-    return path.open("r", encoding="utf-8", newline="")
 
 
 def _open_tsv_write(path: Path):
@@ -73,6 +65,29 @@ def _open_tsv_write(path: Path):
     return path.open("w", encoding="utf-8", newline="")
 
 
+def _count_data_rows(path: Path) -> int:
+    """Count data rows (newlines minus the header) at the C level.
+
+    Used only when the preview was truncated, to report an exact total in
+    the footer. Reads in binary chunks so the I/O (and zlib for ``.gz``)
+    releases the GIL - it never freezes the worker.
+    """
+    is_gz = str(path).lower().endswith(".gz")
+    opener = gzip.open if is_gz else open
+    newlines = 0
+    last = b""
+    try:
+        with opener(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                newlines += chunk.count(b"\n")
+                last = chunk[-1:] or last
+    except OSError:
+        return 0
+    if last and last != b"\n":
+        newlines += 1  # final line had no trailing newline
+    return max(0, newlines - 1)  # minus the header line
+
+
 def _read_tsv(
     path: Path,
     *,
@@ -80,43 +95,186 @@ def _read_tsv(
 ) -> tuple[list[str], list[list[str]], int]:
     """Read a TSV file. Returns ``(header, rows, total_rows)``.
 
-    ``total_rows`` is the count of data rows actually present on disk
-    (so the footer can report truncation). When the file is malformed
-    or empty, returns ``([], [], 0)``.
+    ``total_rows`` is the count of data rows on disk (so the footer can
+    report truncation). Empty / malformed / missing files return
+    ``([], [], 0)``.
+
+    Parsed with pandas' **C engine** (releases the GIL during tokenising;
+    Python's ``csv`` module is pure-Python and would hold the GIL, starving
+    the worker so the loading spinner freezes). The read is **bounded** to
+    ``max_rows + 1`` rows so a huge / wide file never materialises in full
+    on the worker; the exact total is then counted cheaply at the C level.
     """
+    import pandas as pd
+
     try:
-        with _open_tsv(path) as f:
-            reader = csv.reader(f, delimiter="\t")
-            try:
-                header = next(reader)
-            except StopIteration:
-                return [], [], 0
-            rows: list[list[str]] = []
-            total = 0
-            for row in reader:
-                total += 1
-                if len(rows) < max_rows:
-                    rows.append(row)
-            return header, rows, total
-    except (OSError, UnicodeDecodeError, csv.Error) as exc:
+        compression = "gzip" if str(path).lower().endswith(".gz") else "infer"
+        df = pd.read_csv(
+            path,
+            sep="\t",
+            dtype=str,
+            header=0,
+            keep_default_na=False,
+            na_filter=False,
+            compression=compression,
+            engine="c",
+            on_bad_lines="skip",
+            nrows=max_rows + 1,
+        )
+    except Exception as exc:  # noqa: BLE001 - empty / missing / malformed
         log.debug("could not read TSV %s: %s", path, exc)
         return [], [], 0
+
+    header = [str(c) for c in df.columns]
+    n_read = int(len(df))
+    if not header and n_read == 0:
+        return [], [], 0
+    truncated = n_read > max_rows
+    # Ragged rows: pandas pads short rows with NaN; coerce to "" so the
+    # table mirrors the on-disk blanks.
+    preview = df.head(max_rows).fillna("")
+    rows = preview.astype(str).values.tolist()
+    total = _count_data_rows(path) if truncated else n_read
+    return header, rows, total
+
+
+# ===========================================================================
+# Lazy table model (no per-cell objects -> O(1) bind, no freeze)
+# ===========================================================================
+class _TsvTableModel(QAbstractTableModel):
+    """A ``QAbstractTableModel`` over ``header: list[str]`` + ``rows``.
+
+    Stores the parsed table as plain lists and serves cells on demand, so
+    loading is O(1) (no ``QStandardItem`` per cell) and only visible cells
+    are rendered. Supports inline cell editing + row/column add/remove for
+    the toolbar.
+    """
+
+    # Emitted on any user cell edit (the pane uses it for dirty tracking).
+    cellEdited = pyqtSignal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._header: list[str] = []
+        self._rows: list[list[str]] = []
+
+    # --- data ----------------------------------------------------------
+    def set_table(self, header, rows) -> None:
+        """Replace the whole table (load / restore). Rectangular-padded."""
+        self.beginResetModel()
+        self._header = [str(h) for h in header]
+        w = len(self._header)
+        self._rows = []
+        for r in rows:
+            cells = [str(x) for x in list(r)[:w]]
+            if len(cells) < w:
+                cells += [""] * (w - len(cells))
+            self._rows.append(cells)
+        self.endResetModel()
+
+    def header(self) -> list[str]:
+        return list(self._header)
+
+    def rows(self) -> list[list[str]]:
+        return [list(r) for r in self._rows]
+
+    # --- QAbstractTableModel API --------------------------------------
+    def rowCount(self, parent=QModelIndex()) -> int:  # noqa: N802
+        return 0 if parent.isValid() else len(self._rows)
+
+    def columnCount(self, parent=QModelIndex()) -> int:  # noqa: N802
+        return 0 if parent.isValid() else len(self._header)
+
+    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
+        if not index.isValid():
+            return None
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole):
+            r, c = index.row(), index.column()
+            if 0 <= r < len(self._rows) and 0 <= c < len(self._rows[r]):
+                return self._rows[r][c]
+            return ""
+        return None
+
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):  # noqa: N802
+        if role != Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == Qt.Orientation.Horizontal:
+            return self._header[section] if 0 <= section < len(self._header) else ""
+        return section + 1
+
+    def flags(self, index):
+        if not index.isValid():
+            return Qt.ItemFlag.NoItemFlags
+        return (
+            Qt.ItemFlag.ItemIsEnabled
+            | Qt.ItemFlag.ItemIsSelectable
+            | Qt.ItemFlag.ItemIsEditable
+        )
+
+    def setData(self, index, value, role=Qt.ItemDataRole.EditRole) -> bool:  # noqa: N802
+        if role != Qt.ItemDataRole.EditRole or not index.isValid():
+            return False
+        r, c = index.row(), index.column()
+        if not (0 <= r < len(self._rows)):
+            return False
+        while len(self._rows[r]) <= c:
+            self._rows[r].append("")
+        self._rows[r][c] = str(value)
+        self.dataChanged.emit(
+            index, index,
+            [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole],
+        )
+        self.cellEdited.emit()
+        return True
+
+    # --- structural edits (toolbar) -----------------------------------
+    def insert_row(self) -> None:
+        n = len(self._rows)
+        self.beginInsertRows(QModelIndex(), n, n)
+        self._rows.append([""] * max(1, len(self._header)))
+        self.endInsertRows()
+
+    def remove_row(self, r: int) -> None:
+        if 0 <= r < len(self._rows):
+            self.beginRemoveRows(QModelIndex(), r, r)
+            del self._rows[r]
+            self.endRemoveRows()
+
+    def add_column(self, name: str) -> None:
+        c = len(self._header)
+        self.beginInsertColumns(QModelIndex(), c, c)
+        self._header.append(str(name))
+        for row in self._rows:
+            row.append("")
+        self.endInsertColumns()
+
+    def remove_column(self, c: int) -> None:
+        if 0 <= c < len(self._header):
+            self.beginRemoveColumns(QModelIndex(), c, c)
+            del self._header[c]
+            for row in self._rows:
+                if c < len(row):
+                    del row[c]
+            self.endRemoveColumns()
 
 
 class TsvViewerPane(QWidget):
     """Editable table view for BIDS ``.tsv`` files."""
 
-    # Emitted after a successful save. Per-file revalidation (Step 6b)
-    # hooks here, same as :class:`SidecarFormPane.file_saved`.
+    # Emitted after a successful save. Per-file revalidation hooks here.
     file_saved = pyqtSignal(Path)
     # Emitted when the disk write fails. Args: (file_path, error_msg).
     save_failed = pyqtSignal(Path, str)
-    # Emitted whenever the dirty state flips (after a commit, save,
-    # revert, or set_file). ``True`` means there are unsaved edits.
+    # Emitted whenever the dirty state flips. ``True`` means unsaved edits.
     dirty_changed = pyqtSignal(bool)
-    # Emitted whenever the undo/redo availability changes, so the Editor
-    # toolbar can sync its Undo/Redo buttons.
+    # Emitted whenever undo/redo availability changes (Editor toolbar sync).
     history_changed = pyqtSignal()
+    # Emitted after a background load completes (success or empty). Tests
+    # wait on this; the Editor mirrors it to its busy spinner.
+    loaded = pyqtSignal(Path)
+    # Emitted while a background load is in flight / finishes. Args:
+    # ``(busy, message)``. The Editor mirrors it to its toolbar spinner.
+    loading_changed = pyqtSignal(bool, str)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -124,17 +282,16 @@ class TsvViewerPane(QWidget):
 
         self._current_file: Optional[Path] = None
         self._current_root: Optional[Path] = None
+        # Background TSV parse worker. Kept on self so it isn't GC'd.
+        self._loader = None
         # Disk snapshot — used to compute dirty + restore on revert.
         self._original_header: list[str] = []
         self._original_rows: list[list[str]] = []
-        # When True the on-disk file is larger than the preview cap;
-        # saving would drop the tail rows, so Save stays disabled.
+        # True when the on-disk file is larger than the preview cap (Save
+        # disabled so we never drop the tail rows).
         self._truncated_on_load: bool = False
-        # Suppress dirty bookkeeping while we're populating the model.
-        self._suppress_dirty = False
         self._dirty = False
         # Undo/redo of in-memory table edits (snapshot = (header, rows)).
-        # ``_pre_edit`` holds the committed state so the next edit records it.
         from .edit_history import SnapshotHistory
         self._history = SnapshotHistory()
         self._pre_edit: Optional[tuple] = None
@@ -145,8 +302,6 @@ class TsvViewerPane(QWidget):
         v.addWidget(PaneHeader("Table"))
 
         # --- Edit toolbar ----------------------------------------------
-        # Mirrors :class:`SidecarFormPane`'s toolbar. Hidden when no
-        # TSV is bound.
         self._edit_toolbar = QFrame()
         self._edit_toolbar.setObjectName("sidecar-toolbar")
         et = QHBoxLayout(self._edit_toolbar)
@@ -196,7 +351,7 @@ class TsvViewerPane(QWidget):
         self._edit_toolbar.setVisible(False)
         v.addWidget(self._edit_toolbar)
 
-        # --- Stacked content: hint on top of the table -----------------
+        # --- Stacked content -------------------------------------------
         self._stack = QStackedLayout()
         self._stack.setContentsMargins(0, 0, 0, 0)
         v.addLayout(self._stack, 1)
@@ -213,13 +368,14 @@ class TsvViewerPane(QWidget):
             | QAbstractItemView.EditTrigger.SelectedClicked
         )
         self._table.horizontalHeader().setStretchLastSection(False)
+        # Resize-to-contents must only SAMPLE a few rows, or it measures
+        # every cell and freezes on big tables. 50 rows is plenty for a
+        # sensible default width.
+        self._table.horizontalHeader().setResizeContentsPrecision(50)
         self._table.verticalHeader().setVisible(True)
-        self._model = QStandardItemModel(self)
-        self._model.itemChanged.connect(self._on_item_changed)
+        self._model = _TsvTableModel(self)
+        self._model.cellEdited.connect(self._on_cell_edited)
         self._table.setModel(self._model)
-        # Track current selection so the Delete row/col buttons can
-        # know which row/col to operate on (and we can grey them out
-        # when nothing useful is selected).
         sel_model = self._table.selectionModel()
         if sel_model is not None:
             sel_model.currentChanged.connect(self._sync_delete_button_state)
@@ -231,9 +387,30 @@ class TsvViewerPane(QWidget):
         self._empty_hint.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._empty_hint.setWordWrap(True)
 
-        # Index 0 = empty hint, 1 = table.
+        # Loading page (index 2): an animated spinner, mirroring the NIfTI
+        # viewer.
+        from .spinner import BusySpinner
+
+        self._loading_page = QWidget()
+        self._loading_page.setObjectName("pane-dark")
+        lp = QVBoxLayout(self._loading_page)
+        lp.addStretch(1)
+        srow = QHBoxLayout()
+        srow.addStretch(1)
+        self._loading_spinner = BusySpinner()
+        srow.addWidget(self._loading_spinner)
+        srow.addStretch(1)
+        lp.addLayout(srow)
+        self._loading_label = QLabel("")
+        self._loading_label.setObjectName("pane-hint")
+        self._loading_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lp.addWidget(self._loading_label)
+        lp.addStretch(1)
+
+        # Index 0 = empty hint, 1 = table, 2 = loading.
         self._stack.addWidget(self._empty_hint)
         self._stack.addWidget(self._table)
+        self._stack.addWidget(self._loading_page)
         self._stack.setCurrentIndex(0)
 
         # Footer (path + summary), QSS-driven so theme follows.
@@ -265,10 +442,18 @@ class TsvViewerPane(QWidget):
         path: Optional[Path],
         root: Optional[Path],
     ) -> None:
-        """Bind the pane to a TSV (or ``None`` to clear)."""
+        """Bind the pane to a TSV (or ``None`` to clear).
+
+        The parse runs on a :class:`bidsmgr.workers.TsvLoaderWorker`; the
+        spinner page shows while it reads and the table (lazy model) is
+        bound instantly when it lands.
+        """
+        if self._loader is not None:
+            self._loader.cancel()
+            self._loader = None
+
         self._current_file = path
         self._current_root = root
-        # A new file resets the edit history.
         self._history.clear()
         if path is None:
             self._reset_model()
@@ -286,9 +471,39 @@ class TsvViewerPane(QWidget):
             self._refresh_dirty_ui()
             self._pre_edit = self._snapshot()
             self.history_changed.emit()
+            self.loading_changed.emit(False, "")
             return
 
-        header, rows, total = _read_tsv(path)
+        self._reset_model()
+        self._loading_label.setText(f"Loading {path.name}…")
+        self._loading_spinner.set_busy(True, message="")
+        self._stack.setCurrentIndex(2)
+        self._edit_toolbar.setVisible(False)
+        self._footer_path.setText("")
+        self._footer_summary.setText("")
+        self.loading_changed.emit(True, f"Loading {path.name}…")
+
+        from ...workers import TsvLoaderWorker
+
+        worker = TsvLoaderWorker(path, _MAX_PREVIEW_ROWS, parent=self)
+        worker.finished_with_data.connect(self._on_loaded)
+        worker.failed.connect(self._on_load_failed)
+        worker.finished.connect(worker.deleteLater)
+        self._loader = worker
+        worker.start()
+
+    def _on_loaded(
+        self,
+        header: list,
+        rows: list,
+        total: int,
+        path: Path,
+    ) -> None:
+        """Background parse finished — bind the table (guarded for staleness)."""
+        if path != self._current_file:
+            return
+        self._loader = None
+        self._loading_spinner.set_busy(False)
         self._original_header = list(header)
         self._original_rows = [list(r) for r in rows]
         self._truncated_on_load = total > len(rows)
@@ -303,25 +518,37 @@ class TsvViewerPane(QWidget):
         else:
             self._populate_model(header, rows)
             self._stack.setCurrentIndex(1)
-        self._update_footer(path, root, len(rows), len(header), total)
-        # Toolbar appears once a file is bound; Save / Revert wake up
-        # when there's something to save.
+        self._update_footer(path, self._current_root, len(rows), len(header), total)
         self._edit_toolbar.setVisible(True)
         self._refresh_dirty_ui()
         self._pre_edit = self._snapshot()
         self.history_changed.emit()
+        self.loading_changed.emit(False, "")
+        self.loaded.emit(path)
+
+    def _on_load_failed(self, path: Path, error: str) -> None:
+        if path != self._current_file:
+            return
+        self._loader = None
+        self._loading_spinner.set_busy(False)
+        self._reset_model()
+        self._stack.setCurrentIndex(0)
+        self._empty_hint.setText(f"Could not load {path.name}:\n{error}")
+        self._edit_toolbar.setVisible(False)
+        self._dirty = False
+        self._refresh_dirty_ui()
+        self._pre_edit = self._snapshot()
+        self.history_changed.emit()
+        self.loading_changed.emit(False, "")
+        self.loaded.emit(path)
 
     def save(self) -> bool:
-        """Flush the model to disk. Returns ``True`` on success or
-        no-op, ``False`` on I/O error."""
+        """Flush the model to disk. ``True`` on success / no-op."""
         if self._current_file is None:
             return True
         if not self._dirty:
             return True
         if self._truncated_on_load:
-            # We loaded only the first N rows; writing back would
-            # destroy the tail of the file. Surface as a save failure
-            # so the user knows nothing happened.
             msg = (
                 f"File was truncated on load ({_MAX_PREVIEW_ROWS} rows "
                 "shown); refusing to overwrite — saving would discard "
@@ -336,7 +563,6 @@ class TsvViewerPane(QWidget):
             log.warning("save failed for %s: %s", self._current_file, exc)
             self.save_failed.emit(self._current_file, str(exc))
             return False
-        # Snapshot the new on-disk state.
         self._snapshot_current_model()
         self._dirty = False
         self._refresh_dirty_ui()
@@ -347,7 +573,6 @@ class TsvViewerPane(QWidget):
         """Reload the bound file from disk, dropping unsaved edits."""
         if self._current_file is None:
             return
-        # set_file re-reads from disk and clears dirty.
         path, root = self._current_file, self._current_root
         self.set_file(path, root)
 
@@ -365,34 +590,22 @@ class TsvViewerPane(QWidget):
     # ----------------------------------------------------------------------
 
     def _on_add_row(self) -> None:
-        """Append a fresh row at the bottom."""
         if self._current_file is None:
             return
-        cols = max(self._model.columnCount(), 1)
-        new_items = [QStandardItem("") for _ in range(cols)]
-        self._model.appendRow(new_items)
-        # If the table was empty (no header) before this, the new row
-        # still has 0 columns — give us at least one cell to type in.
         if self._model.columnCount() == 0:
-            self._model.setColumnCount(1)
-            self._model.setHorizontalHeaderItem(0, QStandardItem("col1"))
+            self._model.add_column("col1")
+        self._model.insert_row()
         self._mark_dirty()
-        # Make the new row visible.
         self._stack.setCurrentIndex(1)
 
     def _on_delete_row(self) -> None:
         idx = self._table.currentIndex()
         if not idx.isValid():
             return
-        self._model.removeRow(idx.row())
+        self._model.remove_row(idx.row())
         self._mark_dirty()
 
     def _on_add_column(self) -> None:
-        """Append a fresh column on the right.
-
-        Pops a small QInputDialog for the column name (defaults to
-        ``newCol``). Cancel skips the operation.
-        """
         if self._current_file is None:
             return
         name, ok = QInputDialog.getText(
@@ -400,16 +613,7 @@ class TsvViewerPane(QWidget):
         )
         if not ok or not name.strip():
             return
-        col = self._model.columnCount()
-        self._model.setColumnCount(col + 1)
-        self._model.setHorizontalHeaderItem(col, QStandardItem(name.strip()))
-        # Fill empty cells in the new column for every existing row.
-        self._suppress_dirty = True
-        try:
-            for row in range(self._model.rowCount()):
-                self._model.setItem(row, col, QStandardItem(""))
-        finally:
-            self._suppress_dirty = False
+        self._model.add_column(name.strip())
         self._mark_dirty()
         self._stack.setCurrentIndex(1)
 
@@ -417,7 +621,7 @@ class TsvViewerPane(QWidget):
         idx = self._table.currentIndex()
         if not idx.isValid():
             return
-        self._model.removeColumn(idx.column())
+        self._model.remove_column(idx.column())
         self._mark_dirty()
 
     # ----------------------------------------------------------------------
@@ -425,71 +629,41 @@ class TsvViewerPane(QWidget):
     # ----------------------------------------------------------------------
 
     def _reset_model(self) -> None:
-        self._suppress_dirty = True
-        try:
-            self._model.clear()
-        finally:
-            self._suppress_dirty = False
+        self._model.set_table([], [])
 
     def _populate_model(
         self,
         header: list[str],
         rows: list[list[str]],
     ) -> None:
-        self._suppress_dirty = True
-        try:
-            self._model.clear()
-            self._model.setHorizontalHeaderLabels(header)
-            for row in rows:
-                # Pad / truncate row to match the header width — guards
-                # against ragged TSVs.
-                cells = list(row[: len(header)])
-                cells += [""] * (len(header) - len(cells))
-                self._model.appendRow(
-                    [QStandardItem(c) for c in cells]
-                )
-        finally:
-            self._suppress_dirty = False
+        # O(1) bind: the lazy model just stores the lists. Resize only
+        # samples a few rows (precision set in __init__), so this is fast
+        # no matter how big / wide the table is.
+        self._model.set_table(header, rows)
         self._table.resizeColumnsToContents()
 
     def _snapshot_current_model(self) -> None:
-        """Capture the current model as the new disk snapshot."""
-        self._original_header = self._current_header()
-        self._original_rows = self._current_rows()
+        self._original_header = self._model.header()
+        self._original_rows = self._model.rows()
 
     def _current_header(self) -> list[str]:
-        out = []
-        for i in range(self._model.columnCount()):
-            it = self._model.horizontalHeaderItem(i)
-            out.append(it.text() if it is not None else "")
-        return out
+        return self._model.header()
 
     def _current_rows(self) -> list[list[str]]:
-        rows = []
-        for r in range(self._model.rowCount()):
-            row = []
-            for c in range(self._model.columnCount()):
-                it = self._model.item(r, c)
-                row.append(it.text() if it is not None else "")
-            rows.append(row)
-        return rows
+        return self._model.rows()
 
     def _write_model_to_disk(self, path: Path) -> None:
-        header = self._current_header()
-        rows = self._current_rows()
+        header = self._model.header()
+        rows = self._model.rows()
         with _open_tsv_write(path) as f:
             writer = csv.writer(f, delimiter="\t")
             writer.writerow(header)
             writer.writerows(rows)
 
-    def _on_item_changed(self, item: QStandardItem) -> None:
-        del item
-        if self._suppress_dirty:
-            return
+    def _on_cell_edited(self) -> None:
         self._mark_dirty()
 
     def _mark_dirty(self) -> None:
-        # Record the pre-edit state for undo (a fresh edit clears redo).
         if self._pre_edit is not None:
             self._history.record(self._pre_edit)
         self._pre_edit = self._snapshot()
@@ -503,13 +677,12 @@ class TsvViewerPane(QWidget):
     # ----------------------------------------------------------------------
 
     def _snapshot(self) -> tuple[list[str], list[list[str]]]:
-        return (self._current_header(), self._current_rows())
+        return (self._model.header(), self._model.rows())
 
     def _restore(self, snap: tuple[list[str], list[list[str]]]) -> None:
         header, rows = snap
         self._populate_model(list(header), [list(r) for r in rows])
         self._stack.setCurrentIndex(1 if (header or rows) else 0)
-        # Dirty iff the restored state differs from what is on disk.
         self._dirty = (
             list(header) != list(self._original_header)
             or [list(r) for r in rows] != [list(r) for r in self._original_rows]

--- a/bidsmgr/gui/widgets/validation_pane.py
+++ b/bidsmgr/gui/widgets/validation_pane.py
@@ -53,22 +53,22 @@ from ...editor.types import (
     SidecarField,
     ValidationReport,
 )
-from .primitives import PaneHeader
+from .primitives import Chip, PaneHeader
 from .val_message import ValMessage
 
 log = logging.getLogger(__name__)
 
 
-def _count_chip_object_name(issues: list[Issue]) -> str:
-    """Pick the ``val-count-*`` QSS object name for a count chip.
+def _count_chip_kind(issues: list[Issue]) -> str:
+    """Pick the :class:`Chip` ``kind`` for a section count chip.
 
     Worst severity wins — one ``err`` in a section flips its chip red.
     """
     if any(i.severity is Severity.ERR for i in issues):
-        return "val-count-err"
+        return "err"
     if any(i.severity is Severity.WARN for i in issues):
-        return "val-count-warn"
-    return "val-count-ok"
+        return "warn"
+    return ""  # default (neutral) chip
 
 
 def _find_verdict(
@@ -134,7 +134,9 @@ class ValidationPane(QWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("pane")
-        self.setMinimumWidth(320)
+        # Keep a small floor so the user can squeeze it down when they want
+        # more room for the viewer / tree (the splitter respects this).
+        self.setMinimumWidth(72)
 
         self._report: Optional[ValidationReport] = None
         self._current_file: Optional[Path] = None
@@ -159,6 +161,9 @@ class ValidationPane(QWidget):
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QFrame.Shape.NoFrame)
+        # No early horizontal scrollbar - let the cards wrap/clip so the pane
+        # can be squeezed narrow without a scrollbar popping in.
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         scroll.setWidget(self._body)
         v.addWidget(scroll, 1)
 
@@ -315,8 +320,7 @@ class ValidationPane(QWidget):
         title_l.setObjectName("val-section-title")
         head.addWidget(title_l)
         head.addStretch(1)
-        count_l = QLabel(str(len(issues)))
-        count_l.setObjectName(_count_chip_object_name(issues))
+        count_l = Chip(str(len(issues)), _count_chip_kind(issues))
         head.addWidget(count_l)
         sl.addLayout(head)
 
@@ -394,16 +398,15 @@ class ValidationPane(QWidget):
         # Header chip — severity reflects the worst missing level.
         total_fields = sum(len(v) for v in by_level.values())
         if missing_req:
-            chip_obj = "val-count-err"
+            chip_kind = "err"
             chip_text = f"{len(missing_req)} missing required"
         elif missing_rec:
-            chip_obj = "val-count-warn"
+            chip_kind = "warn"
             chip_text = f"{len(missing_rec)} missing recommended"
         else:
-            chip_obj = "val-count-ok"
+            chip_kind = ""
             chip_text = f"{total_fields} fields"
-        chip = QLabel(chip_text)
-        chip.setObjectName(chip_obj)
+        chip = Chip(chip_text, chip_kind)
         head.addWidget(chip)
         sl.addLayout(head)
 

--- a/bidsmgr/inventory/dataset_identity.py
+++ b/bidsmgr/inventory/dataset_identity.py
@@ -1,0 +1,192 @@
+"""Compare an incoming scan's subjects against an already-converted BIDS dataset.
+
+Powers the specific incremental-conversion hint: when a scanned subject id is
+already present on disk, is it the SAME person (and is this a NEW session), or a
+DIFFERENT person reusing the id? The comparison uses ``participants.tsv``
+(``patient_id`` / ``given_name`` / ``family_name``, written by the metadata
+engine) plus the on-disk ``ses-*`` directories. When there is nothing to compare
+(no participants.tsv identity), it degrades to a generic heads-up.
+
+Qt-free and pure-data so it is unit-testable without the GUI.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+from typing import Optional
+
+_SUBNUM_RE = re.compile(r"^sub-(\d+)$")
+
+# Stable marker prefixed to every incremental-collision note written into
+# ``proposed_issues``. It lets the GUI find and strip a stale collision note so
+# the warning can be recomputed against the CURRENT subject id + on-disk state
+# (e.g. after the user renames sub-001 -> sub-002 to resolve the clash). The
+# wording after the token deliberately avoids the model's error-token
+# substrings so the row reads as a warning, not an error.
+EXISTING_SUBJECT_TOKEN = "existing-subject"
+
+
+def read_existing_identities(bids_root: Path) -> dict[str, dict]:
+    """Map ``participant_id`` -> identity dict from ``participants.tsv``.
+
+    Returns ``{}`` when the file is absent or unreadable. Identity dict carries
+    ``patient_id`` / ``given_name`` / ``family_name`` (blank when the column is
+    missing).
+    """
+    p = Path(bids_root) / "participants.tsv"
+    out: dict[str, dict] = {}
+    if not p.exists():
+        return out
+    try:
+        with open(p, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh, delimiter="\t")
+            for row in reader:
+                pid = (row.get("participant_id") or "").strip()
+                if not pid:
+                    continue
+                out[pid] = {
+                    "patient_id": (row.get("patient_id") or "").strip(),
+                    "given_name": (row.get("given_name") or "").strip(),
+                    "family_name": (row.get("family_name") or "").strip(),
+                }
+    except OSError:
+        return {}
+    return out
+
+
+def existing_sessions(bids_root: Path, subject: str) -> set[str]:
+    """Return the ``ses-*`` directory names already present for ``subject``."""
+    sub = Path(bids_root) / subject
+    if not sub.is_dir():
+        return set()
+    return {p.name for p in sub.iterdir() if p.is_dir() and p.name.startswith("ses-")}
+
+
+def next_free_subject_id(bids_root: Path) -> str:
+    """Return the next free zero-padded ``sub-<NNN>`` (max numeric + 1)."""
+    mx = 0
+    width = 3
+    for p in Path(bids_root).glob("sub-*"):
+        if not p.is_dir():
+            continue
+        m = _SUBNUM_RE.match(p.name)
+        if m:
+            mx = max(mx, int(m.group(1)))
+            width = max(width, len(m.group(1)))
+    return f"sub-{mx + 1:0{width}d}"
+
+
+_FIELD_LABEL = {
+    "patient_id": "PatientID",
+    "given_name": "given name",
+    "family_name": "family name",
+}
+
+
+def compare_identity(existing: Optional[dict], scanned: dict) -> tuple[list[str], list[str]]:
+    """Return ``(matched, differing)`` field names among the three identity fields.
+
+    Only fields that are non-empty on BOTH sides are comparable. Names are
+    compared case-insensitively. A field is ``matched`` when the values are equal,
+    ``differing`` otherwise. Fields blank on either side are ignored (no info).
+    """
+    matched: list[str] = []
+    differing: list[str] = []
+    if not existing:
+        return matched, differing
+    for field in ("patient_id", "given_name", "family_name"):
+        e = (existing.get(field) or "").strip()
+        s = (scanned.get(field) or "").strip()
+        if field != "patient_id":
+            e, s = e.lower(), s.lower()
+        if e and s:
+            (matched if e == s else differing).append(field)
+    return matched, differing
+
+
+def identity_match(existing: Optional[dict], scanned: dict) -> Optional[bool]:
+    """``True`` if ANY field coincides (possible same subject), ``False`` if
+    fields are comparable but none coincide, ``None`` if nothing is comparable.
+
+    A single coincidence (e.g. given name) is treated as a possible match even
+    when another field differs (technicians sometimes relabel PatientID per
+    session while the name stays the same).
+    """
+    matched, differing = compare_identity(existing, scanned)
+    if matched:
+        return True
+    if differing:
+        return False
+    return None
+
+
+def _labels(fields: list[str]) -> str:
+    return ", ".join(_FIELD_LABEL[f] for f in fields)
+
+
+def classify(
+    subject: str,
+    scanned_ident: dict,
+    scanned_session: str,
+    existing_ident: Optional[dict],
+    on_disk_sessions: set[str],
+    next_free: str,
+) -> str:
+    """Return a specific hint for a scanned subject whose id is already on disk.
+
+    Any single identity coincidence (PatientID / given name / family name) is
+    surfaced as a possible same-subject, even when another field differs.
+    """
+    matched, differing = compare_identity(existing_ident, scanned_ident)
+    is_new_session = bool(scanned_session) and scanned_session not in on_disk_sessions
+
+    if matched and not differing:
+        # Every comparable field agrees: confident same subject.
+        if is_new_session:
+            return (
+                f"same subject already in dataset ({subject}; {_labels(matched)} "
+                f"match); new session ({scanned_session}) - safe to add"
+            )
+        sess = f", {scanned_session}" if scanned_session else ""
+        return (
+            f"re-scan of {subject} (same subject{sess}; {_labels(matched)} match); "
+            f"convert merges per the Existing-subjects policy"
+        )
+
+    if matched:
+        # At least one coincidence but something else differs: flag the possible
+        # match and what to check (the relabeled-PatientID case).
+        sess_hint = (
+            f" If it is, this looks like a new session ({scanned_session})."
+            if is_new_session else ""
+        )
+        return (
+            f"{subject} may be the same subject ({_labels(matched)} match) but "
+            f"{_labels(differing)} differ - verify.{sess_hint} If it is a "
+            f"different person, rename to {next_free}"
+        )
+
+    if differing:
+        return (
+            f"{subject} appears to be a DIFFERENT subject ({_labels(differing)} "
+            f"differ); rename to {next_free} if this is a new person"
+        )
+
+    # No comparable identity info.
+    return (
+        f"subject id {subject} already in the dataset; rename if this is a "
+        f"different subject"
+    )
+
+
+__all__ = [
+    "EXISTING_SUBJECT_TOKEN",
+    "read_existing_identities",
+    "existing_sessions",
+    "next_free_subject_id",
+    "compare_identity",
+    "identity_match",
+    "classify",
+]

--- a/bidsmgr/inventory/eeg_meg.py
+++ b/bidsmgr/inventory/eeg_meg.py
@@ -82,9 +82,16 @@ EEG_MEG_COLUMNS: tuple[str, ...] = (
 
 
 # Extensions mne-bids accepts as raw inputs.
+# NOTE: ``.pdf`` is deliberately NOT here. It is the 4D / BTi "processed data
+# file" label, but that collides with Adobe PDF documents (consent forms,
+# reports, READMEs) which routinely sit in a data folder - the scanner must
+# never try to read those. 4D/BTi data is a directory (``c,rfDC`` + ``config``
+# + ``hs_file``) anyway and ``mne.io.read_raw`` does not dispatch a bare
+# ``.pdf``, so nothing real is lost; genuine 4D support would key on the
+# directory structure instead.
 _RECOGNISED_EXTS: tuple[str, ...] = (
     # MEG
-    ".fif", ".fif.gz", ".con", ".sqd", ".pdf",
+    ".fif", ".fif.gz", ".con", ".sqd",
     # EEG
     ".vhdr", ".edf", ".bdf", ".gdf", ".set", ".cnt", ".eeg", ".egi", ".mff",
     # iEEG
@@ -102,7 +109,7 @@ _DIR_FORMATS: tuple[str, ...] = (".ds", ".mff")
 # Force-EDF option; the scan flags such rows so the user is not surprised.
 _BIDS_NATIVE_EXTS: frozenset[str] = frozenset({
     # MEG (all recognised MEG formats are BIDS-native)
-    ".fif", ".fif.gz", ".ds", ".con", ".sqd", ".kdf", ".pdf",
+    ".fif", ".fif.gz", ".ds", ".con", ".sqd", ".kdf",
     # EEG / iEEG
     ".vhdr", ".edf", ".bdf", ".set", ".mef", ".nwb",
     # NIRS
@@ -240,8 +247,6 @@ def _format_label(path: Path) -> str:
         return "Nihon Kohden"
     if name.endswith((".sqd", ".con")):
         return "KIT"
-    if name.endswith(".pdf"):
-        return "4D"
     if name.endswith(".ds"):
         return "CTF"
     if name.endswith(".mef"):

--- a/bidsmgr/inventory/eeg_meg.py
+++ b/bidsmgr/inventory/eeg_meg.py
@@ -20,6 +20,7 @@ Reference: ported from
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import os
@@ -38,7 +39,8 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Unified-TSV column group for EEG/MEG-specific fields.
 # Appended last in the unified-TSV column order:
-#   TSV(22) + BIDS_GUESS(8) + DATASET(1) + PROBE(4) + EXTENDED(3) + EEG_MEG(9)
+#   TSV(24) + BIDS_GUESS(8) + ENTITIES(1) + DATASET(1) + PROBE(4)
+#   + EXTENDED(3) + EEG_MEG(15) = 56
 # ---------------------------------------------------------------------------
 
 EEG_MEG_COLUMNS: tuple[str, ...] = (
@@ -63,6 +65,14 @@ EEG_MEG_COLUMNS: tuple[str, ...] = (
                        # before write_raw_bids → fills electrodes.tsv +
                        # coordsystem.json. Empty = leave positions to whatever the
                        # recording carries.
+    "eeg_reference",   # User-editable per-row override of the reference electrode
+                       # (e.g. "Cz", "average"). Written to EEGReference / iEEGReference
+                       # in the sidecar. Empty = use the recording-metadata default.
+    "eeg_ground",      # User-editable per-row override of the ground electrode.
+                       # Written to EEGGround / iEEGGround. Empty = use the default.
+    "montage_suggestion",  # Read-only scan suggestion: "<montage> (matched/total)"
+                       # by channel-name overlap. Surfaced in the GUI next to the
+                       # montage dropdown; the user picks the actual montage.
 )
 
 
@@ -108,6 +118,19 @@ class ProbeResult:
     datatype: str         # 'eeg' | 'meg' | 'ieeg' | 'nirs' | ''
     has_positions: bool
     fmt: str              # short label: 'EDF', 'FIF', 'BrainVision', ...
+    # Seeded enrichment facts read from the recording header (best-effort;
+    # rich for FIF/MEG, often empty for legacy EDF). These pre-fill the
+    # demographics columns and the recording-metadata scaffold so the user
+    # only supplies what the machine cannot read.
+    manufacturer: str = ""   # device manufacturer/type
+    model: str = ""          # device model
+    subj_sex: str = ""       # 'M' | 'F' | '' (only when a real birthday exists)
+    subj_age: str = ""       # integer years as a string, or ''
+    # Handedness is deliberately NOT extracted: file headers commonly default
+    # it (so reading it would be assuming data we do not have). The user
+    # enters it explicitly.
+    event_codes: tuple[str, ...] = ()  # distinct annotation/trigger labels
+    montage_suggestion: str = ""       # "name (matched/total)" for EEG/iEEG, else ""
 
 
 def _detect_datatype(raw) -> str:
@@ -223,6 +246,15 @@ def _probe(path: Path) -> Optional[ProbeResult]:
         except Exception:
             recording_time = str(meas_date)
 
+    manufacturer, model = _device_info(raw)
+    subj_sex, subj_age = _subject_info(raw, meas_date)
+    event_codes = _event_codes(raw)
+    datatype = _detect_datatype(raw)
+    # Best-matching montage is a SCAN-time suggestion (channel-name overlap)
+    # so the user can pick it while curating; not auto-applied. Montage is an
+    # EEG/iEEG concept (MEG carries intrinsic sensor geometry).
+    montage_suggestion = _best_montage(raw.ch_names) if datatype in ("eeg", "ieeg") else ""
+
     return ProbeResult(
         source=path,
         sfreq=sfreq,
@@ -230,10 +262,129 @@ def _probe(path: Path) -> Optional[ProbeResult]:
         n_times=n_times,
         duration_sec=duration_sec,
         recording_time=recording_time,
-        datatype=_detect_datatype(raw),
+        datatype=datatype,
         has_positions=_has_positions(raw),
         fmt=_format_label(path),
+        manufacturer=manufacturer,
+        model=model,
+        subj_sex=subj_sex,
+        subj_age=subj_age,
+        event_codes=event_codes,
+        montage_suggestion=montage_suggestion,
     )
+
+
+def _device_info(raw) -> tuple[str, str]:
+    """Best-effort (manufacturer, model) from ``raw.info['device_info']``."""
+    try:
+        dev = raw.info.get("device_info") or {}
+        return str(dev.get("type", "") or ""), str(dev.get("model", "") or "")
+    except Exception:
+        return "", ""
+
+
+# MNE FIFF subject sex codes -> BIDS-conventional letters.
+_SEX_MAP = {1: "M", 2: "F"}
+
+
+def _subject_info(raw, meas_date) -> tuple[str, str]:
+    """Best-effort (sex, age) from ``raw.info['subject_info']``.
+
+    Conservative on purpose: a real, non-placeholder ``birthday`` is required
+    as the signal that the record is genuine (anonymised FIF headers stamp
+    ``1900-01-01`` and often default the other fields too). When there is no
+    real birthday we seed nothing rather than assume. Handedness is never
+    auto-seeded (headers commonly default it). Returns ``("", "")`` when the
+    header carries nothing trustworthy.
+    """
+    try:
+        info = raw.info.get("subject_info") or {}
+    except Exception:
+        return "", ""
+    if meas_date is None:
+        return "", ""
+
+    birthday = info.get("birthday")
+    try:
+        by = (
+            birthday.year if hasattr(birthday, "year")
+            else int(birthday[0]) if birthday else None
+        )
+    except Exception:
+        by = None
+    # No real birthday (missing or the 1900 anonymisation placeholder) ->
+    # treat the whole record as untrustworthy and seed nothing.
+    if by is None or by <= 1900:
+        return "", ""
+
+    age = ""
+    try:
+        years = meas_date.year - by
+        if 0 < years <= 120:
+            age = str(years)
+    except Exception:
+        age = ""
+    sex = _SEX_MAP.get(info.get("sex"), "")
+    return sex, age
+
+
+@functools.lru_cache(maxsize=1)
+def _montage_chname_sets() -> dict[str, frozenset[str]]:
+    """Map each built-in MNE montage name to its normalised channel-name set.
+
+    Built once per process (montage construction is not free). Channel names
+    are lower-cased and stripped of non-alphanumerics so EDF padding (``Fc5.``)
+    matches the montage's ``FC5``.
+    """
+    out: dict[str, frozenset[str]] = {}
+    try:
+        import mne
+    except Exception:
+        return out
+    for name in mne.channels.get_builtin_montages():
+        try:
+            m = mne.channels.make_standard_montage(name)
+        except Exception:
+            continue
+        out[name] = frozenset(re.sub(r"[^a-z0-9]", "", c.lower()) for c in m.ch_names)
+    return out
+
+
+def _best_montage(ch_names) -> str:
+    """Return ``"<montage> (matched/total)"`` for the best channel-name overlap.
+
+    A scan-time *suggestion* only: the user confirms or changes it in the GUI.
+    Empty string when nothing matches (or MNE is unavailable).
+    """
+    sets = _montage_chname_sets()
+    if not sets:
+        return ""
+    cleaned = {re.sub(r"[^a-z0-9]", "", str(c).lower()) for c in ch_names}
+    cleaned.discard("")
+    if not cleaned:
+        return ""
+    best_name, best_n = "", 0
+    for name, mset in sets.items():
+        n = len(cleaned & mset)
+        if n > best_n:
+            best_n, best_name = n, name
+    if best_n == 0:
+        return ""
+    return f"{best_name} ({best_n}/{len(ch_names)})"
+
+
+def _event_codes(raw) -> tuple[str, ...]:
+    """Distinct annotation/trigger labels present in the recording."""
+    try:
+        descriptions = list(raw.annotations.description)
+    except Exception:
+        return ()
+    seen: list[str] = []
+    for d in descriptions:
+        s = str(d)
+        if s and s not in seen:
+            seen.append(s)
+    return tuple(sorted(seen))
 
 
 # ---------------------------------------------------------------------------
@@ -562,6 +713,22 @@ def scan_eeg_meg(
             "has_positions": int(probe.has_positions),
             "line_freq": "" if line_freq is None else line_freq,
             "montage": montage or "",
+            "eeg_reference": "",
+            "eeg_ground": "",
+            "montage_suggestion": probe.montage_suggestion,
+            # Demographics seeded only when the header is genuinely real
+            # (non-placeholder birthday); user-editable. Handedness is never
+            # auto-seeded (see _subject_info). Written to participants.tsv by
+            # the metadata engine.
+            "PatientSex": probe.subj_sex,
+            "Handedness": "",
+            "PatientAge": probe.subj_age,
+            # Internal scaffold seeds (leading underscore -> dropped from the
+            # final TSV by the unified column-order selection). Read by the
+            # scan verb to pre-populate the recording-metadata scaffold.
+            "_event_codes": json.dumps(list(probe.event_codes)),
+            "_manufacturer": probe.manufacturer,
+            "_model": probe.model,
             "dataset": dataset or "",
             # Surface the classifier-style columns so the inspector's
             # ``suffix`` and ``data`` columns show useful values for

--- a/bidsmgr/inventory/eeg_meg.py
+++ b/bidsmgr/inventory/eeg_meg.py
@@ -73,6 +73,11 @@ EEG_MEG_COLUMNS: tuple[str, ...] = (
     "montage_suggestion",  # Read-only scan suggestion: "<montage> (matched/total)"
                        # by channel-name overlap. Surfaced in the GUI next to the
                        # montage dropdown; the user picks the actual montage.
+    "manufacturer_suggestion",  # Read-only scan suggestion: the manufacturer
+                       # detected from the recording header (EEG) or inferred
+                       # from the file format (MEG: .fif -> MEGIN, .ds -> CTF,
+                       # ...). Surfaced as a hint next to the manufacturer field;
+                       # NOT auto-applied (mne-bids fills MEG Manufacturer itself).
 )
 
 
@@ -246,10 +251,10 @@ def _probe(path: Path) -> Optional[ProbeResult]:
         except Exception:
             recording_time = str(meas_date)
 
-    manufacturer, model = _device_info(raw)
+    datatype = _detect_datatype(raw)
+    manufacturer, model = _device_info(raw, path, datatype)
     subj_sex, subj_age = _subject_info(raw, meas_date)
     event_codes = _event_codes(raw)
-    datatype = _detect_datatype(raw)
     # Best-matching montage is a SCAN-time suggestion (channel-name overlap)
     # so the user can pick it while curating; not auto-applied. Montage is an
     # EEG/iEEG concept (MEG carries intrinsic sensor geometry).
@@ -274,13 +279,37 @@ def _probe(path: Path) -> Optional[ProbeResult]:
     )
 
 
-def _device_info(raw) -> tuple[str, str]:
-    """Best-effort (manufacturer, model) from ``raw.info['device_info']``."""
+# MEG file format -> manufacturer (the format effectively identifies the
+# system, so the manufacturer is known even when the header carries no
+# device_info). Used as the estimate when device_info is empty.
+_MEG_FORMAT_MANUFACTURER: dict[str, str] = {
+    ".fif": "MEGIN / Elekta / Neuromag",
+    ".ds": "CTF",
+    ".con": "KIT / Yokogawa",
+    ".sqd": "KIT / Yokogawa",
+    ".kdf": "KRISS",
+}
+
+
+def _device_info(raw, path=None, datatype: str = "") -> tuple[str, str]:
+    """Best-effort (manufacturer, model) for a recording.
+
+    Reads ``raw.info['device_info']`` first; for MEG, when the header carries no
+    manufacturer, falls back to inferring it from the file format (``.fif`` ->
+    MEGIN, ``.ds`` -> CTF, ``.con/.sqd`` -> KIT, ``.kdf`` -> KRISS) since the
+    format identifies the system. This is an estimate the user can override.
+    """
+    manufacturer, model = "", ""
     try:
         dev = raw.info.get("device_info") or {}
-        return str(dev.get("type", "") or ""), str(dev.get("model", "") or "")
+        manufacturer = str(dev.get("type", "") or "")
+        model = str(dev.get("model", "") or "")
     except Exception:
-        return "", ""
+        pass
+    if not manufacturer and datatype == "meg" and path is not None:
+        suffix = Path(path).suffix.lower()
+        manufacturer = _MEG_FORMAT_MANUFACTURER.get(suffix, "")
+    return manufacturer, model
 
 
 # MNE FIFF subject sex codes -> BIDS-conventional letters.
@@ -716,6 +745,9 @@ def scan_eeg_meg(
             "eeg_reference": "",
             "eeg_ground": "",
             "montage_suggestion": probe.montage_suggestion,
+            # Read-only manufacturer suggestion (header for EEG, format for MEG);
+            # surfaced as a hint, not auto-applied.
+            "manufacturer_suggestion": probe.manufacturer,
             # Demographics seeded only when the header is genuinely real
             # (non-placeholder birthday); user-editable. Handedness is never
             # auto-seeded (see _subject_info). Written to participants.tsv by
@@ -723,12 +755,12 @@ def scan_eeg_meg(
             "PatientSex": probe.subj_sex,
             "Handedness": "",
             "PatientAge": probe.subj_age,
-            # Internal scaffold seeds (leading underscore -> dropped from the
-            # final TSV by the unified column-order selection). Read by the
-            # scan verb to pre-populate the recording-metadata scaffold.
+            # Internal scaffold seed (leading underscore -> dropped from the
+            # final TSV by the unified column-order selection). Read by the scan
+            # verb to pre-populate the recording-metadata scaffold's event map.
+            # Manufacturer is NOT seeded here - it is a read-only suggestion
+            # (manufacturer_suggestion) and mne-bids fills the MEG sidecar value.
             "_event_codes": json.dumps(list(probe.event_codes)),
-            "_manufacturer": probe.manufacturer,
-            "_model": probe.model,
             "dataset": dataset or "",
             # Surface the classifier-style columns so the inspector's
             # ``suffix`` and ``data`` columns show useful values for

--- a/bidsmgr/inventory/eeg_meg.py
+++ b/bidsmgr/inventory/eeg_meg.py
@@ -95,6 +95,41 @@ _RECOGNISED_EXTS: tuple[str, ...] = (
 # Folder-shaped recordings (CTF MEG, EGI MFF). Treated as single candidates.
 _DIR_FORMATS: tuple[str, ...] = (".ds", ".mff")
 
+# Extensions mne-bids can write to BIDS natively (copy, or native re-encode).
+# A recording in any OTHER recognised format (Neuroscan ``.cnt``, ``.gdf``,
+# EGI ``.egi``/``.mff``, Nihon Kohden ``.eeg`` ...) needs conversion to a
+# BIDS-allowed format. For EEG / iEEG that is EDF, available behind the
+# Force-EDF option; the scan flags such rows so the user is not surprised.
+_BIDS_NATIVE_EXTS: frozenset[str] = frozenset({
+    # MEG (all recognised MEG formats are BIDS-native)
+    ".fif", ".fif.gz", ".ds", ".con", ".sqd", ".kdf", ".pdf",
+    # EEG / iEEG
+    ".vhdr", ".edf", ".bdf", ".set", ".mef", ".nwb",
+    # NIRS
+    ".snirf",
+})
+
+# Tokens prepended to a row's ``proposed_issues`` so the GUI surfaces the
+# reason (warnings chip / Issues dialog / tooltip) and the CLI logs it. Kept
+# free of the model's error-token substrings (``required`` / ``missing`` /
+# ``build_basename`` / ``suspected_abort``) so the row reads as warn / skip,
+# not a hard error.
+UNSUPPORTED_FORMAT_TOKEN = "unsupported format"
+NONNATIVE_FORMAT_TOKEN = "non-native format"
+
+
+def _full_ext(path: Path) -> str:
+    """Lower-case extension, preserving the ``.fif.gz`` double suffix."""
+    name = path.name.lower()
+    if name.endswith(".fif.gz"):
+        return ".fif.gz"
+    # Folder-shaped recordings (.ds / .mff) report the dir suffix.
+    return path.suffix.lower()
+
+
+def _is_bids_native(path: Path) -> bool:
+    return _full_ext(path) in _BIDS_NATIVE_EXTS
+
 
 # ``mne`` is heavy; lazy-import so the module is cheap to import in
 # environments without mne (e.g. fresh venv, unit tests that mock probes).
@@ -650,10 +685,6 @@ def scan_eeg_meg(
     bids_id_for_subject: dict[str, str] = {}
 
     for path in candidates:
-        probe = _probe(path)
-        if probe is None:
-            continue
-
         sub_hint, ses_hint, task_hint, run_hint = guess_subject_session_task(path, root)
         sub_token = sub_hint or _bids_id_from_filename(path.parent.name)
         if not sub_token:
@@ -663,6 +694,23 @@ def scan_eeg_meg(
             bids_counter += 1
             bids_id_for_subject[sub_token] = f"sub-{bids_counter:03d}"
         bids_name = bids_id_for_subject[sub_token]
+
+        probe = _probe(path)
+        if probe is None:
+            # A recognised EEG/MEG extension we could not read. Surface it as
+            # an excluded row with a clear reason instead of silently dropping
+            # it, so the user sees the file and why it was skipped.
+            fmt = _format_label(path)
+            note = (
+                f"{UNSUPPORTED_FORMAT_TOKEN}: this {fmt} recording could not be "
+                f"read by mne's generic reader and is excluded from conversion. "
+                f"If it is a valid recording, convert it to EDF / BrainVision "
+                f"with the vendor's tools (or mne's format-specific reader) "
+                f"first, then re-scan."
+            )
+            log.warning("EEG/MEG scan: %s (%s)", note, path)
+            rows.append(_unsupported_row(path, root, dataset, bids_name, sub_token, fmt, note))
+            continue
 
         datatype = probe.datatype or "eeg"
         # Build the BIDS basename via the schema engine so the row's
@@ -707,6 +755,19 @@ def scan_eeg_meg(
         except ValueError:
             rel_source = str(path)
 
+        # The recording read fine, but its format is not one mne-bids writes
+        # natively (e.g. Neuroscan .cnt, GDF, EGI). Such a row still converts,
+        # but only by re-encoding to EDF (EEG / iEEG). Flag it so the user
+        # knows to enable Force EDF; the note is non-fatal (warn), the row
+        # stays included.
+        nonnative_note = ""
+        if not _is_bids_native(path):
+            nonnative_note = (
+                f"{NONNATIVE_FORMAT_TOKEN}: {probe.fmt} is not a BIDS-native "
+                f"format; conversion re-encodes it to EDF (enable Force EDF for "
+                f"EEG / iEEG)."
+            )
+
         # The canonical entities dict — same one used to build the
         # basename, JSON-encoded for the TSV's ``entities`` column.
         # This is the **source of truth**: ``bidsmgr-rebuild`` and the
@@ -729,6 +790,7 @@ def scan_eeg_meg(
             "proposed_datatype": datatype,
             "proposed_basename": basename,
             "Proposed BIDS name": f"{basename}",
+            "proposed_issues": nonnative_note,
             "entities": json.dumps(entities_for_tsv, sort_keys=True),
             "task": task_hint,
             "run": run_hint,
@@ -865,6 +927,72 @@ def _splice_session_into_basename(basename: str, session_label: str) -> str:
         return f"{session_label}_{basename}"
     parts.insert(1, session_label)
     return "_".join(parts)
+
+
+def _unsupported_row(
+    path: Path,
+    root: Path,
+    dataset: Optional[str],
+    bids_name: str,
+    sub_token: str,
+    fmt: str,
+    note: str,
+) -> dict:
+    """Build a complete, excluded inventory row for an unreadable recording.
+
+    Mirrors the shape of a normal EEG/MEG row (so the unified TSV stays
+    rectangular) but with ``include=0`` + ``bids_guess_skip=True`` + the
+    ``unsupported format`` note, no probe-derived metadata, and an empty
+    proposed basename. The user sees the file and the reason; conversion skips
+    it.
+    """
+    try:
+        rel_source = path.relative_to(root).as_posix()
+    except ValueError:
+        rel_source = str(path)
+    return {
+        "subject": sub_token,
+        "BIDS_name": bids_name,
+        "session": "",
+        "source_folder": str(path.parent.relative_to(root))
+            if path.parent != root else "",
+        "include": 0,
+        "modality": "eeg",            # best-effort; we could not probe channels
+        "modality_bids": "eeg",
+        "proposed_datatype": "eeg",
+        "proposed_basename": "",
+        "Proposed BIDS name": "",
+        "proposed_issues": note,
+        "entities": json.dumps({"subject": bids_name[len("sub-"):]
+                                if bids_name.startswith("sub-") else bids_name},
+                               sort_keys=True),
+        "task": "",
+        "run": "",
+        "format": fmt,
+        "source_file": rel_source,
+        "n_channels": "",
+        "sfreq": "",
+        "duration_sec": "",
+        "n_times": "",
+        "recording_time": "",
+        "has_positions": "",
+        "line_freq": "",
+        "montage": "",
+        "eeg_reference": "",
+        "eeg_ground": "",
+        "montage_suggestion": "",
+        "manufacturer_suggestion": "",
+        "PatientSex": "",
+        "Handedness": "",
+        "PatientAge": "",
+        "_event_codes": json.dumps([]),
+        "dataset": dataset or "",
+        "bids_guess_classifier": "eeg_meg_scanner",
+        "bids_guess_datatype": "eeg",
+        "bids_guess_suffix": "eeg",
+        "bids_guess_confidence": "0.00",
+        "bids_guess_skip": True,
+    }
 
 
 def _empty_dataframe() -> pd.DataFrame:

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -54,14 +54,19 @@ PHASE_IMGTYPE = ["ORIGINAL", "PRIMARY", "P", "ND"]
 SESSION_RE = re.compile(r"ses-([a-zA-Z0-9]+)", re.IGNORECASE)
 
 
-# v0.2.5 22-column TSV contract — keep this list in sync with the docstring.
+# Core TSV column contract — keep this list in sync with the docstring.
+# Originally 22 columns (the v0.2.5 contract). Added since: ``Handedness``
+# (participant demographic) and ``companion_files`` (per-row, any modality:
+# JSON list of already-curated sidecar companions - events / beh / stim - to
+# copy into the BIDS tree on convert).
 TSV_COLUMNS: tuple[str, ...] = (
     "subject", "BIDS_name", "session", "source_folder",
     "include", "sequence", "series_uid", "rep", "acq_time",
     "image_type", "modality", "modality_bids", "n_files",
     "GivenName", "FamilyName", "PatientID",
-    "PatientSex", "PatientAge", "StudyDescription",
+    "PatientSex", "PatientAge", "Handedness", "StudyDescription",
     "proposed_datatype", "proposed_basename", "Proposed BIDS name",
+    "companion_files",
 )
 
 # Extended columns added to support longitudinal session inference and

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -230,6 +230,7 @@ def scan_dicoms_long(
     output_tsv: Optional[str | os.PathLike] = None,
     n_jobs: int = 1,
     dataset: Optional[str] = None,
+    cancel_check=None,
 ) -> pd.DataFrame:
     """Walk ``root_dir`` and return a long-format inventory DataFrame.
 
@@ -278,7 +279,21 @@ def scan_dicoms_long(
             if is_dicom_file(fpath):
                 file_list.append(fpath)
 
-    results = Parallel(n_jobs=n_jobs)(delayed(_read_one)(fp, root_dir) for fp in file_list)
+    # Consume the parallel reads as a generator so a Stop request can
+    # break out promptly (the loky/threading pool stops dispatching new
+    # reads once we abandon the generator). Results stream back in
+    # submission order, so the collected list is identical to the eager
+    # ``Parallel(...)(...)`` form when not cancelled.
+    from ..util.cancel import OperationCancelled, is_cancelled
+    _gen = Parallel(n_jobs=n_jobs, return_as="generator")(
+        delayed(_read_one)(fp, root_dir) for fp in file_list
+    )
+    results = []
+    for _i, _res in enumerate(_gen):
+        # Poll periodically (every 64 reads) to keep the check cheap.
+        if (_i & 63) == 0 and is_cancelled(cancel_check):
+            raise OperationCancelled("scan cancelled by user")
+        results.append(_res)
     for res in results:
         if not res:
             continue

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -171,6 +171,13 @@ def _read_one(fpath: str, root_dir: Path) -> Optional[dict]:
     folder = root_dir.name if rel == "." else rel
     series = str(getattr(ds, "SeriesDescription", "n/a")).strip()
     uid = str(getattr(ds, "SeriesInstanceUID", ""))
+    # Pixel presence: a real image carries the Image Pixel module's
+    # Rows + Columns (0028,0010 / 0028,0011). DERIVED non-image objects
+    # (a Siemens diffusion TENSOR map, a structured report, a
+    # spectroscopy frame, ...) omit them and dcm2niix cannot turn them
+    # into a NIfTI. We OR this across a series' files downstream so a
+    # series counts as an image if ANY of its files carries pixels.
+    has_pixels = ("Rows" in ds) and ("Columns" in ds)
     img_list = normalize_image_type(getattr(ds, "ImageType", None))
     img3 = classify_fieldmap_type(img_list)
     if not img3:
@@ -206,6 +213,7 @@ def _read_one(fpath: str, root_dir: Path) -> Optional[dict]:
         "study_uid": study_uid,
         "study_date": study_date,
         "study_time": study_time,
+        "has_pixels": has_pixels,
         "demo": {
             "GivenName": given,
             "FamilyName": family_name,
@@ -249,6 +257,10 @@ def scan_dicoms_long(
     imgtypes: dict = defaultdict(lambda: defaultdict(dict))
     sessset: dict = defaultdict(lambda: defaultdict(set))
     file_dirs: dict = defaultdict(lambda: defaultdict(dict))
+    # Per-series pixel presence: True once any file in the series carries
+    # an Image Pixel module (Rows/Columns). Series with no pixel-bearing
+    # file are DERIVED non-image objects dcm2niix cannot convert.
+    haspix: dict = defaultdict(lambda: defaultdict(dict))
     # study-level metadata (per series): subj_key -> folder -> (series,uid) -> study tuple
     study_uids: dict = defaultdict(lambda: defaultdict(dict))
     # all distinct study tuples seen for each subject (for session inference).
@@ -281,6 +293,9 @@ def scan_dicoms_long(
             acq_times[subj_key][folder][key] = res["acq_time"]
         if key not in file_dirs[subj_key][folder]:
             file_dirs[subj_key][folder][key] = res["file_dir"]
+        haspix[subj_key][folder][key] = (
+            haspix[subj_key][folder].get(key, False) or bool(res.get("has_pixels"))
+        )
         # Track every DICOM file path per UID for later per-series probe.
         uid_str = res["uid"]
         if uid_str:
@@ -397,6 +412,12 @@ def scan_dicoms_long(
                     "study_date": study_tuple[1],
                     "study_time": study_tuple[2],
                     "_source_dir": file_dirs[subj_key][folder].get((series, uid), ""),
+                    # Internal flag (leading underscore -> dropped from the
+                    # final TSV by ``cli/scan._unified_column_order``).
+                    # Consumed by ``cli/scan`` to flag/exclude non-image
+                    # DERIVED objects (e.g. Siemens TENSOR) that dcm2niix
+                    # cannot convert.
+                    "_has_pixel_data": haspix[subj_key][folder].get((series, uid), False),
                     **demo[subj_key],
                 })
 

--- a/bidsmgr/main.py
+++ b/bidsmgr/main.py
@@ -5,10 +5,10 @@ Usage::
     bidsmgr [--theme dark|light] [--project PATH]
 
 * ``--theme``  selects the initial palette (defaults to ``dark``).
-* ``--project`` opens or creates a ``*.bidsmgr`` project bundle. If the
-  path doesn't exist, a fresh project is created at that location;
-  otherwise it is opened and any prior overrides are applied to the
-  inventory when one is loaded.
+* ``--project`` opens (or creates / adopts) a BIDS dataset project at the
+  given directory and lands in the Converter bound to it - the same
+  project-first flow as the Welcome tab's Open / Create. The output is locked
+  to the dataset and the header project switcher appears.
 
 The CLI side of the workflow stays available — ``bidsmgr-scan``,
 ``-rebuild``, ``-convert``, ``-metadata``, ``-validate`` are unchanged.
@@ -39,8 +39,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--project", type=Path, default=None,
         help=(
-            "Open (or create if absent) a `.bidsmgr` project bundle. "
-            "Edits made in the GUI append to its event log."
+            "Open (or create / adopt) a BIDS dataset project at this directory "
+            "and land in the Converter bound to it (same as the Welcome tab's "
+            "Open / Create). The output is locked to the dataset."
         ),
     )
     parser.add_argument(
@@ -62,20 +63,21 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     from .gui.main_window import MainWindow
     from .gui.theme_manager import ThemeManager
-    from .project import Project, ProjectError
 
+    # ``--project`` is a BIDS dataset directory (the project-first model). Open
+    # or create/adopt the project bundle nested at <dir>/.bidsmgr/project, then
+    # bind it through the same flow the Welcome tab uses (set below, after the
+    # window exists).
     project = None
+    bids_root = None
     if args.project is not None:
-        path = args.project
-        if path.exists():
-            try:
-                project = Project.open(path)
-            except ProjectError as exc:
-                print(f"could not open project {path}: {exc}", file=sys.stderr)
-                return 2
-        else:
-            project = Project.create(path, name=path.stem)
-            print(f"created new project at {path}")
+        from .cli.create import open_or_create_workspace
+        bids_root = Path(args.project)
+        try:
+            project = open_or_create_workspace(bids_root)
+        except Exception as exc:
+            print(f"could not open project {bids_root}: {exc}", file=sys.stderr)
+            return 2
 
     app = QApplication(sys.argv)
     # QSettings keys these to find the right per-user config file on
@@ -104,7 +106,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     theme = ThemeManager(app, font_scale=persisted.font_scale)
     theme.apply(initial_theme)
 
-    win = MainWindow(theme, project=project)
+    win = MainWindow(theme)
+    # Bind the --project dataset through the standard open-project flow so the
+    # Converter is set_project'd (output locked), the Editor points at the root,
+    # and the header project switcher appears - identical to a Welcome open.
+    if project is not None and bids_root is not None:
+        win._on_project_opened(project, bids_root)
     win.show()
     return app.exec()
 

--- a/bidsmgr/main.py
+++ b/bidsmgr/main.py
@@ -106,6 +106,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     theme = ThemeManager(app, font_scale=persisted.font_scale)
     theme.apply(initial_theme)
 
+    # Round every QComboBox dropdown (frameless + translucent popup window),
+    # matching the header project menu. Safe no-op if it ever fails.
+    from .gui.combo_popup import install as install_combo_popup_rounder
+    install_combo_popup_rounder(app)
+
     win = MainWindow(theme)
     # Bind the --project dataset through the standard open-project flow so the
     # Converter is set_project'd (output locked), the Editor points at the root,

--- a/bidsmgr/metadata/demographics.py
+++ b/bidsmgr/metadata/demographics.py
@@ -1,0 +1,130 @@
+"""Demographic normalization + optional participant-spreadsheet import.
+
+Modality-agnostic helpers used by the metadata engine to write a clean
+``participants.tsv``. Sex and handedness arrive in many forms (DICOM
+``PatientSex`` codes, MNE-derived ``M``/``R`` letters, free-text ``female`` /
+``left-handed`` from a hand-kept spreadsheet); these map them to the
+BIDS-conventional single letters. An optional participants spreadsheet
+(TSV/CSV/XLSX/ODS) keyed by ``participant_id`` can supply or override the
+demographic columns.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+# String -> BIDS letter maps (lower-cased lookup). Numeric codes follow the
+# common 0/1/2 (sex) and 1/2/3 (hand) conventions.
+_SEX_MAP = {
+    "m": "M", "male": "M", "1": "M",
+    "f": "F", "female": "F", "2": "F",
+    "o": "O", "other": "O", "intersex": "O",
+    "u": "", "unknown": "", "0": "",
+}
+_HAND_MAP = {
+    "r": "R", "right": "R", "right-handed": "R", "1": "R",
+    "l": "L", "left": "L", "left-handed": "L", "2": "L",
+    "a": "A", "ambi": "A", "ambidextrous": "A", "both": "A", "3": "A",
+}
+
+
+def normalize_sex(value: object) -> str:
+    """Map a sex value to ``M`` / ``F`` / ``O``; ``""`` when unknown/blank."""
+    s = str(value or "").strip()
+    if not s:
+        return ""
+    if s in ("M", "F", "O"):  # already canonical
+        return s
+    return _SEX_MAP.get(s.lower(), "")
+
+
+def normalize_handedness(value: object) -> str:
+    """Map a handedness value to ``R`` / ``L`` / ``A``; ``""`` when unknown."""
+    s = str(value or "").strip()
+    if not s:
+        return ""
+    if s in ("R", "L", "A"):  # already canonical
+        return s
+    return _HAND_MAP.get(s.lower(), "")
+
+
+def _participant_key(value: object) -> str:
+    """Normalise a participant identifier to the ``sub-XXX`` form."""
+    s = str(value or "").strip()
+    if not s:
+        return ""
+    return s if s.startswith("sub-") else f"sub-{s}"
+
+
+def load_participants_table(path: Path) -> dict[str, dict[str, str]]:
+    """Read a participants spreadsheet, keyed by ``sub-XXX`` participant id.
+
+    Supports ``.tsv`` / ``.csv`` natively and ``.xlsx`` / ``.ods`` via pandas'
+    optional Excel engines (a clear error is logged if the engine is missing).
+    The file must carry a ``participant_id`` column; every other column is
+    returned verbatim so the caller can pick the demographic fields it knows.
+    """
+    path = Path(path)
+    suffix = path.suffix.lower()
+    try:
+        if suffix in (".tsv", ".txt"):
+            df = pd.read_csv(path, sep="\t", dtype=str, keep_default_na=False)
+        elif suffix == ".csv":
+            df = pd.read_csv(path, dtype=str, keep_default_na=False)
+        else:  # .xlsx / .ods / .xls
+            df = pd.read_excel(path, dtype=str).fillna("")
+    except Exception as exc:
+        log.warning("could not read participants file %s: %s", path, exc)
+        return {}
+
+    if "participant_id" not in df.columns:
+        log.warning(
+            "participants file %s has no 'participant_id' column; ignoring", path,
+        )
+        return {}
+
+    out: dict[str, dict[str, str]] = {}
+    for _, row in df.iterrows():
+        key = _participant_key(row.get("participant_id"))
+        if not key:
+            continue
+        out[key] = {
+            str(c): str(row.get(c, "") or "")
+            for c in df.columns
+            if c != "participant_id"
+        }
+    return out
+
+
+def merge_demographics(
+    base: dict[str, dict[str, str]],
+    overlay: Optional[dict[str, dict[str, str]]],
+) -> dict[str, dict[str, str]]:
+    """Overlay participant-file demographics on the inventory lookup.
+
+    A non-empty overlay value wins (the spreadsheet is the human-authored
+    source of truth); blank overlay cells leave the inventory value intact.
+    """
+    if not overlay:
+        return base
+    merged = {k: dict(v) for k, v in base.items()}
+    for pid, fields in overlay.items():
+        target = merged.setdefault(pid, {})
+        for col, val in fields.items():
+            if str(val).strip():
+                target[col] = val
+    return merged
+
+
+__all__ = [
+    "normalize_sex",
+    "normalize_handedness",
+    "load_participants_table",
+    "merge_demographics",
+]

--- a/bidsmgr/metadata/engine.py
+++ b/bidsmgr/metadata/engine.py
@@ -39,7 +39,7 @@ from .demographics import (
     normalize_handedness,
     normalize_sex,
 )
-from .phenotype import write_phenotype
+from .phenotype import load_sidecar_dictionary, write_phenotype
 from .types import DatasetMetadata, MetadataReport, SidecarFill, TodoFill
 from ..recording_meta import load_spec, scaffold_sidecar_path
 
@@ -168,10 +168,13 @@ def run_metadata(
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
 
-    # Auto-discover phenotype tables from the inventory's recording-metadata
-    # scaffold when not explicitly provided (the GUI dialog stores them there).
+    # Auto-discover phenotype tables + participants spreadsheet from the
+    # inventory's recording-metadata scaffold when not explicitly provided (the
+    # GUI dataset-metadata dialog stores them there).
     if phenotype_files is None and inventory_tsv is not None:
         phenotype_files = _phenotype_files_from_scaffold(inventory_tsv)
+    if participants_file is None and inventory_tsv is not None:
+        participants_file = _participants_file_from_scaffold(inventory_tsv)
 
     _write_dataset_description(bids_root, meta, generator_label, report)
     _write_participants(bids_root, inventory_tsv, report, participants_file=participants_file)
@@ -342,6 +345,27 @@ def _phenotype_files_from_scaffold(inventory_tsv: Path) -> Optional[list[Path]]:
     return out or None
 
 
+def _participants_file_from_scaffold(inventory_tsv: Path) -> Optional[Path]:
+    """Read the participants spreadsheet path from the recording-meta scaffold.
+
+    The GUI dataset-metadata dialog stores it in
+    ``<inventory>.tsv.recording_meta.json``. Resolved relative to the inventory
+    directory when not absolute. Returns ``None`` when unset.
+    """
+    try:
+        scaffold = scaffold_sidecar_path(inventory_tsv)
+        if not scaffold.exists():
+            return None
+        spec = load_spec(scaffold)
+    except Exception:
+        return None
+    raw = (spec.participants_file or "").strip()
+    if not raw:
+        return None
+    pp = Path(raw)
+    return pp if pp.is_absolute() else Path(inventory_tsv).parent / pp
+
+
 def _write_participants(
     bids_root: Path,
     inventory_tsv: Optional[Path],
@@ -353,12 +377,27 @@ def _write_participants(
         return
 
     demo_lookup = _load_demographics_from_inventory(inventory_tsv, report)
+    participant_codebook: dict = {}
     if participants_file is not None:
         # A user-supplied participants spreadsheet is the authoritative
         # demographic source: its non-empty cells override the inventory.
         demo_lookup = merge_demographics(
             demo_lookup, load_participants_table(Path(participants_file)),
         )
+        # Optional sibling JSON codebook (descriptions / levels / units for the
+        # spreadsheet's columns) -> participants.json.
+        participant_codebook = load_sidecar_dictionary(Path(participants_file))
+
+    # Any column the participants spreadsheet carries beyond the known
+    # demographics is preserved verbatim: it flows into participants.tsv and is
+    # described in participants.json. Order is the first-seen order across
+    # subjects for a stable, readable table.
+    known = set(_PARTICIPANT_COLUMNS)
+    extra_cols: list[str] = []
+    for sid in subjects:
+        for col in demo_lookup.get(sid, {}):
+            if col and col not in known and col not in extra_cols:
+                extra_cols.append(col)
 
     rows: list[dict[str, str]] = []
     for sid in subjects:
@@ -371,9 +410,12 @@ def _write_participants(
             elif col == "handedness":
                 v = normalize_handedness(v)
             row[col] = v if v else "n/a"
+        for col in extra_cols:
+            v = str(extra.get(col, "") or "").strip()
+            row[col] = v if v else "n/a"
         rows.append(row)
 
-    df_new = pd.DataFrame(rows, columns=list(_PARTICIPANT_COLUMNS))
+    df_new = pd.DataFrame(rows, columns=list(_PARTICIPANT_COLUMNS) + extra_cols)
 
     out_tsv = bids_root / "participants.tsv"
     df_existing: Optional[pd.DataFrame] = None
@@ -402,11 +444,20 @@ def _write_participants(
     report.files_written.append(out_tsv)
 
     out_json = bids_root / "participants.json"
-    json_payload = {
-        col: _PARTICIPANT_DESCRIPTIONS[col]
-        for col in df_out.columns
-        if col in _PARTICIPANT_DESCRIPTIONS
-    }
+    json_payload: dict = {}
+    for col in df_out.columns:
+        if col in _PARTICIPANT_DESCRIPTIONS:
+            json_payload[col] = _PARTICIPANT_DESCRIPTIONS[col]
+        elif col == "participant_id":
+            continue
+        else:
+            # Extra spreadsheet column: use the user's codebook entry if any,
+            # else a minimal Description = the column name.
+            entry = participant_codebook.get(str(col))
+            json_payload[col] = (
+                entry if isinstance(entry, dict) and entry
+                else {"Description": str(col)}
+            )
     out_json.write_text(json.dumps(json_payload, indent=2) + "\n", encoding="utf-8")
     report.files_written.append(out_json)
 

--- a/bidsmgr/metadata/engine.py
+++ b/bidsmgr/metadata/engine.py
@@ -33,7 +33,15 @@ import pandas as pd
 
 import bidsmgr
 from .. import schema as schema_mod
+from .demographics import (
+    load_participants_table,
+    merge_demographics,
+    normalize_handedness,
+    normalize_sex,
+)
+from .phenotype import write_phenotype
 from .types import DatasetMetadata, MetadataReport, SidecarFill, TodoFill
+from ..recording_meta import load_spec, scaffold_sidecar_path
 
 # The literal placeholder value written by ``--fill-todos`` for every
 # missing required / recommended field. Deliberately just the string
@@ -97,6 +105,8 @@ def run_metadata(
     fill_todos: bool = False,
     write_report: bool = True,
     generator_label: str = "bidsmgr",
+    participants_file: Optional[Path] = None,
+    phenotype_files: Optional[list[Path]] = None,
 ) -> MetadataReport:
     """Generate dataset-level metadata for the BIDS root at ``bids_root``.
 
@@ -123,6 +133,13 @@ def run_metadata(
         ``<bids_root>/.bidsmgr/metadata_report.json`` after every run.
     generator_label
         ``GeneratedBy.Name`` to record. Defaults to ``"bidsmgr"``.
+    participants_file
+        Optional participants spreadsheet (TSV/CSV/XLSX/ODS) keyed by
+        ``participant_id``. Its demographic columns (``age`` / ``sex`` /
+        ``handedness``) override the inventory-derived values.
+    phenotype_files
+        Optional list of phenotype measure tables. Each becomes
+        ``phenotype/<measure>.tsv`` + ``.json``.
 
     Returns
     -------
@@ -147,8 +164,14 @@ def run_metadata(
         generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
 
+    # Auto-discover phenotype tables from the inventory's recording-metadata
+    # scaffold when not explicitly provided (the GUI dialog stores them there).
+    if phenotype_files is None and inventory_tsv is not None:
+        phenotype_files = _phenotype_files_from_scaffold(inventory_tsv)
+
     _write_dataset_description(bids_root, meta, generator_label, report)
-    _write_participants(bids_root, inventory_tsv, report)
+    _write_participants(bids_root, inventory_tsv, report, participants_file=participants_file)
+    write_phenotype(bids_root, phenotype_files, report)
     _write_readme(bids_root, meta.name, report)
     _write_changes(bids_root, report)
     _refresh_scans_tsv(bids_root, report)
@@ -251,7 +274,8 @@ def _write_dataset_description(
 
 
 _PARTICIPANT_COLUMNS: tuple[str, ...] = (
-    "participant_id", "age", "sex", "given_name", "family_name", "patient_id",
+    "participant_id", "age", "sex", "handedness",
+    "given_name", "family_name", "patient_id",
 )
 
 
@@ -262,27 +286,69 @@ _PARTICIPANT_DESCRIPTIONS: dict[str, dict[str, object]] = {
         "Description": "Biological sex",
         "Levels": {"M": "male", "F": "female", "O": "other", "n/a": "not available"},
     },
+    "handedness": {
+        "Description": "Handedness of the participant",
+        "Levels": {"R": "right", "L": "left", "A": "ambidextrous", "n/a": "not available"},
+    },
     "given_name": {"Description": "Subject given name (kept for internal traceability)"},
     "family_name": {"Description": "Subject family name (kept for internal traceability)"},
     "patient_id": {"Description": "Original DICOM PatientID"},
 }
 
 
+def _phenotype_files_from_scaffold(inventory_tsv: Path) -> Optional[list[Path]]:
+    """Read phenotype table paths from the inventory's recording-meta scaffold.
+
+    The GUI dataset-metadata dialog stores phenotype file paths in
+    ``<inventory>.tsv.recording_meta.json``. Paths are resolved relative to the
+    inventory directory when not absolute. Returns ``None`` when there is no
+    scaffold or it lists no phenotype files.
+    """
+    try:
+        scaffold = scaffold_sidecar_path(inventory_tsv)
+        if not scaffold.exists():
+            return None
+        spec = load_spec(scaffold)
+    except Exception:
+        return None
+    if not spec.phenotype_files:
+        return None
+    base = Path(inventory_tsv).parent
+    out: list[Path] = []
+    for p in spec.phenotype_files:
+        pp = Path(p)
+        out.append(pp if pp.is_absolute() else base / pp)
+    return out or None
+
+
 def _write_participants(
-    bids_root: Path, inventory_tsv: Optional[Path], report: MetadataReport,
+    bids_root: Path,
+    inventory_tsv: Optional[Path],
+    report: MetadataReport,
+    participants_file: Optional[Path] = None,
 ) -> None:
     subjects = sorted(p.name for p in bids_root.glob("sub-*") if p.is_dir())
     if not subjects:
         return
 
     demo_lookup = _load_demographics_from_inventory(inventory_tsv, report)
+    if participants_file is not None:
+        # A user-supplied participants spreadsheet is the authoritative
+        # demographic source: its non-empty cells override the inventory.
+        demo_lookup = merge_demographics(
+            demo_lookup, load_participants_table(Path(participants_file)),
+        )
 
     rows: list[dict[str, str]] = []
     for sid in subjects:
         row: dict[str, str] = {"participant_id": sid}
         extra = demo_lookup.get(sid, {})
-        for col in ("age", "sex", "given_name", "family_name", "patient_id"):
+        for col in ("age", "sex", "handedness", "given_name", "family_name", "patient_id"):
             v = extra.get(col, "")
+            if col == "sex":
+                v = normalize_sex(v)
+            elif col == "handedness":
+                v = normalize_handedness(v)
             row[col] = v if v else "n/a"
         rows.append(row)
 
@@ -366,6 +432,7 @@ def _load_demographics_from_inventory(
             "patient_id": str(head.get("PatientID", "") or ""),
             "age": str(head.get("PatientAge", "") or head.get("age", "") or ""),
             "sex": str(head.get("PatientSex", "") or head.get("sex", "") or ""),
+            "handedness": str(head.get("Handedness", "") or head.get("handedness", "") or ""),
         }
     return lookup
 

--- a/bidsmgr/metadata/engine.py
+++ b/bidsmgr/metadata/engine.py
@@ -152,11 +152,15 @@ def run_metadata(
     if not bids_root.is_dir():
         raise FileNotFoundError(f"BIDS root not found: {bids_root}")
 
-    meta = dataset_meta or DatasetMetadata(name=bids_root.name)
-    if meta.name == "Untitled BIDS Dataset":
-        # Caller supplied an empty DatasetMetadata; use the directory name
-        # so dataset_description.json reads sensibly.
-        meta = meta.model_copy(update={"name": bids_root.name})
+    meta = dataset_meta or DatasetMetadata()
+    # Resolve the dataset Name without clobbering one already on disk. An
+    # explicit caller-supplied Name wins; otherwise preserve an existing
+    # dataset_description.json Name (set by ``bidsmgr create`` or hand-edited);
+    # else fall back to the folder name. A metadata run with no ``--name`` must
+    # not overwrite a Name the user already chose.
+    if meta.name in (None, "", "Untitled BIDS Dataset"):
+        resolved = _existing_dataset_name(bids_root) or bids_root.name
+        meta = meta.model_copy(update={"name": resolved})
 
     report = MetadataReport(
         bidsmgr_version=str(getattr(bidsmgr, "__version__", "0.0.0")),
@@ -187,6 +191,23 @@ def run_metadata(
 # ---------------------------------------------------------------------------
 # dataset_description.json
 # ---------------------------------------------------------------------------
+
+
+def _existing_dataset_name(bids_root: Path) -> Optional[str]:
+    """Return the ``Name`` from an existing ``dataset_description.json``, if any.
+
+    Used so a metadata run with no explicit ``--name`` preserves a Name the user
+    already set (via ``bidsmgr create`` or by hand) instead of overwriting it.
+    """
+    p = bids_root / "dataset_description.json"
+    if not p.exists():
+        return None
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    name = data.get("Name") if isinstance(data, dict) else None
+    return name if isinstance(name, str) and name.strip() else None
 
 
 def _write_dataset_description(

--- a/bidsmgr/metadata/phenotype.py
+++ b/bidsmgr/metadata/phenotype.py
@@ -40,6 +40,27 @@ def _measure_name(stem: str) -> str:
     return name or "measure"
 
 
+def load_sidecar_dictionary(table_path: Path) -> dict:
+    """Load an optional user-authored data dictionary (codebook) for a table.
+
+    For a measure / participants table ``foo.tsv`` (or ``.csv`` / ``.xlsx``), a
+    sibling ``foo.json`` lets the user supply real column descriptions, ``Levels``,
+    and ``Units`` (plus, for phenotype, a ``MeasurementToolMetadata`` block) - a
+    codebook expressed as the BIDS data dictionary itself.
+    Returns ``{}`` when there is no sibling JSON or it cannot be parsed.
+    """
+    path = Path(table_path)
+    sidecar = path.with_suffix(".json")
+    if sidecar == path or not sidecar.exists():
+        return {}
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        log.warning("could not read codebook %s: %s", sidecar, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def write_phenotype(
     bids_root: Path,
     phenotype_files: Optional[Sequence[Path]],
@@ -78,15 +99,31 @@ def write_phenotype(
         df.to_csv(tsv_out, sep="\t", index=False)
         report.files_written.append(tsv_out)
 
+        # Data dictionary: merge any user-authored codebook (sibling JSON) so
+        # real Descriptions / Levels / Units (and an optional
+        # MeasurementToolMetadata block) flow through; auto-fill the rest with
+        # the bare column name. The codebook entry wins where present.
+        codebook = load_sidecar_dictionary(path)
         json_out = pheno_dir / f"{measure}.json"
-        data_dict = {
-            str(col): {"Description": str(col)}
-            for col in df.columns
-            if col != "participant_id"
-        }
+        data_dict: dict = {}
+        tool_meta = codebook.get("MeasurementToolMetadata")
+        if isinstance(tool_meta, dict) and tool_meta:
+            data_dict["MeasurementToolMetadata"] = tool_meta
+        for col in df.columns:
+            if col == "participant_id":
+                continue
+            entry = codebook.get(str(col))
+            if isinstance(entry, dict) and entry:
+                data_dict[str(col)] = entry
+            else:
+                data_dict[str(col)] = {"Description": str(col)}
         json_out.write_text(json.dumps(data_dict, indent=2) + "\n", encoding="utf-8")
         report.files_written.append(json_out)
-        log.info("phenotype: wrote %s (%d rows, %d columns)", tsv_out.name, len(df), len(df.columns))
+        log.info(
+            "phenotype: wrote %s (%d rows, %d columns%s)",
+            tsv_out.name, len(df), len(df.columns),
+            "; codebook merged" if codebook else "",
+        )
 
 
-__all__ = ["write_phenotype"]
+__all__ = ["write_phenotype", "load_sidecar_dictionary"]

--- a/bidsmgr/metadata/phenotype.py
+++ b/bidsmgr/metadata/phenotype.py
@@ -1,0 +1,92 @@
+"""Write the BIDS ``phenotype/`` directory from user-supplied measure tables.
+
+Phenotype is participant-level, non-imaging measurement data (questionnaires,
+clinical scales, cognitive batteries) that does not fit a single
+``participants.tsv`` row. Each input table (TSV/CSV/XLSX/ODS), keyed by
+``participant_id``, becomes ``phenotype/<measure>.tsv`` plus a
+``<measure>.json`` data dictionary. Modality-agnostic: an MRI or EEG/MEG
+dataset uses it identically.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional, Sequence
+
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+def _read_table(path: Path) -> Optional[pd.DataFrame]:
+    suffix = path.suffix.lower()
+    try:
+        if suffix in (".tsv", ".txt"):
+            return pd.read_csv(path, sep="\t", dtype=str, keep_default_na=False)
+        if suffix == ".csv":
+            return pd.read_csv(path, dtype=str, keep_default_na=False)
+        return pd.read_excel(path, dtype=str).fillna("")
+    except Exception as exc:
+        log.warning("could not read phenotype table %s: %s", path, exc)
+        return None
+
+
+def _measure_name(stem: str) -> str:
+    """Sanitise a file stem into a BIDS-safe measure label."""
+    name = re.sub(r"[^A-Za-z0-9]+", "", stem)
+    return name or "measure"
+
+
+def write_phenotype(
+    bids_root: Path,
+    phenotype_files: Optional[Sequence[Path]],
+    report,
+) -> None:
+    """Emit ``phenotype/<measure>.tsv`` + ``.json`` for each input table.
+
+    Each table must have a ``participant_id`` column; tables that lack one are
+    skipped with a warning. The JSON is a minimal data dictionary describing
+    each non-id column. ``report`` collects written files and warnings, matching
+    the rest of the metadata engine.
+    """
+    if not phenotype_files:
+        return
+
+    pheno_dir = bids_root / "phenotype"
+    for raw_path in phenotype_files:
+        path = Path(raw_path)
+        if not path.exists():
+            report.warnings.append(f"phenotype file not found: {path}")
+            continue
+        df = _read_table(path)
+        if df is None:
+            report.warnings.append(f"could not read phenotype file: {path}")
+            continue
+        if "participant_id" not in df.columns:
+            report.warnings.append(
+                f"phenotype file {path} has no 'participant_id' column; skipping"
+            )
+            continue
+
+        pheno_dir.mkdir(parents=True, exist_ok=True)
+        measure = _measure_name(path.stem)
+
+        tsv_out = pheno_dir / f"{measure}.tsv"
+        df.to_csv(tsv_out, sep="\t", index=False)
+        report.files_written.append(tsv_out)
+
+        json_out = pheno_dir / f"{measure}.json"
+        data_dict = {
+            str(col): {"Description": str(col)}
+            for col in df.columns
+            if col != "participant_id"
+        }
+        json_out.write_text(json.dumps(data_dict, indent=2) + "\n", encoding="utf-8")
+        report.files_written.append(json_out)
+        log.info("phenotype: wrote %s (%d rows, %d columns)", tsv_out.name, len(df), len(df.columns))
+
+
+__all__ = ["write_phenotype"]

--- a/bidsmgr/metadata/types.py
+++ b/bidsmgr/metadata/types.py
@@ -13,6 +13,8 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ..schema import bids_version as _schema_bids_version
+
 
 class DatasetMetadata(BaseModel):
     """Caller-supplied fields for ``dataset_description.json``.
@@ -25,7 +27,10 @@ class DatasetMetadata(BaseModel):
     model_config = ConfigDict(frozen=False)
 
     name: str = "Untitled BIDS Dataset"
-    bids_version: str = "1.10.0"
+    # Sourced from the bundled BIDS schema so the stamped version always
+    # matches the rules the rest of the tool validates against (no hardcoded
+    # version to drift out of date).
+    bids_version: str = Field(default_factory=_schema_bids_version)
     dataset_type: str = "raw"  # 'raw' | 'derivative'
     license: Optional[str] = None
     authors: list[str] = Field(default_factory=list)

--- a/bidsmgr/project/orchestration.py
+++ b/bidsmgr/project/orchestration.py
@@ -1,0 +1,265 @@
+"""Qt-free project orchestration shared by the GUI and the CLI.
+
+The project-first model (event-sourced ``.bidsmgr/project/`` bundle, versioned
+scans under ``scans/<NNNN>__<slug>/``, resume by replaying edits, output locked
+to the dataset root) used to live only in the GUI's converter panel. This
+module extracts the pure-data pieces so both the GUI worker layer and the new
+``--project`` CLI flags drive the exact same logic:
+
+* :func:`import_scan_as_version` promotes a freshly-staged scan into a new
+  version bundle (the body of the GUI's ``_promote_scan_to_version``).
+* :func:`apply_project_state` replays a project's curation edits onto an
+  inventory DataFrame (the body of the model's ``_apply_project_overlay``).
+* :func:`row_id` is the stable per-row identity used to key those edits.
+* :func:`latest_version` / :func:`version_dataframe` resolve and load the
+  active scan version (with edits applied) for convert / metadata.
+
+Depends only on ``inventory`` + ``recording_meta`` primitives (project ->
+inventory is the safe direction; inventory never imports project).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from ..inventory.rebuild import rebuild_from_columns, rebuild_from_entities
+from . import workspace
+from .project import Project
+from .types import ProjectState, ScanImported, StageCompleted
+from .workspace import ScanVersion
+
+
+# ---------------------------------------------------------------------------
+# Row identity + edit replay (mirror of InventoryTableModel)
+# ---------------------------------------------------------------------------
+
+
+def row_id(df: pd.DataFrame, i: int) -> str:
+    """Stable per-row id used to key project edits.
+
+    Prefers ``series_uid`` (MRI) then ``source_file`` (EEG/MEG), else a
+    positional ``row-<i>`` fallback. Identical to
+    ``InventoryTableModel.row_id`` so GUI-recorded edits replay in the CLI.
+    """
+    for col in ("series_uid", "source_file"):
+        if col in df.columns:
+            v = df.at[i, col]
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+    return f"row-{i}"
+
+
+def _row_entities(df: pd.DataFrame, r: int) -> dict:
+    if "entities" not in df.columns:
+        return {}
+    raw = df.at[r, "entities"]
+    if pd.isna(raw):
+        return {}
+    text = str(raw).strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+
+
+def _rebuild_one_row(df: pd.DataFrame, r: int, *, direction: str = "columns") -> None:
+    sub = df.iloc[[r]].copy()
+    if direction == "entities":
+        new_sub, _ = rebuild_from_entities(sub)
+    else:
+        new_sub, _ = rebuild_from_columns(sub)
+    for col in new_sub.columns:
+        df.at[r, col] = new_sub.iloc[0][col]
+
+
+def apply_project_state(df: pd.DataFrame, state: ProjectState) -> None:
+    """Replay a project's curation edits onto ``df`` in place.
+
+    Mirrors ``InventoryTableModel._apply_project_overlay``: entity edits first
+    (subject renames keep ``BIDS_name`` in sync, then rebuild from entities),
+    then cell overrides (rebuild from columns), then include toggles. Unknown
+    row ids are ignored (the inventory may have been re-scanned).
+    """
+    if not (
+        state.cell_overrides or state.include_overrides or state.entity_overrides
+    ):
+        return
+
+    index_for_rid = {row_id(df, i): i for i in range(len(df))}
+
+    if "entities" in df.columns:
+        for rid, ents in state.entity_overrides.items():
+            r = index_for_rid.get(rid)
+            if r is None:
+                continue
+            current = _row_entities(df, r)
+            for ent, val in ents.items():
+                if val:
+                    current[ent] = val
+                else:
+                    current.pop(ent, None)
+                if ent == "subject" and "BIDS_name" in df.columns:
+                    df.at[r, "BIDS_name"] = f"sub-{val}" if val else ""
+            df.at[r, "entities"] = json.dumps(current, sort_keys=True)
+            _rebuild_one_row(df, r, direction="entities")
+
+    for rid, cells in state.cell_overrides.items():
+        r = index_for_rid.get(rid)
+        if r is None:
+            continue
+        for col, val in cells.items():
+            if col in df.columns:
+                df.at[r, col] = val
+        _rebuild_one_row(df, r)
+
+    if "include" in df.columns:
+        for rid, inc in state.include_overrides.items():
+            r = index_for_rid.get(rid)
+            if r is None:
+                continue
+            df.at[r, "include"] = 1 if inc else 0
+
+
+# ---------------------------------------------------------------------------
+# Scan versions
+# ---------------------------------------------------------------------------
+
+
+def _move_if_exists(src: Path, dst: Path) -> None:
+    src, dst = Path(src), Path(dst)
+    if src.exists():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(src), str(dst))
+
+
+def import_scan_as_version(
+    bids_root: Path,
+    staged_inventory: Path,
+    *,
+    raw_root: Optional[Path] = None,
+    source_label: Optional[str] = None,
+    row_ids: tuple[str, ...] = (),
+    n_rows: int = 0,
+) -> ScanVersion:
+    """Promote a freshly-staged scan into a new project version.
+
+    Creates ``.bidsmgr/project/scans/<NNNN>__<slug>/`` (its own Project bundle),
+    moves the inventory snapshot (+ recording-metadata scaffold + files_by_uid
+    sidecar) into it, writes the version descriptor, and appends
+    ``ScanImported`` + ``StageCompleted`` events. Returns the new
+    :class:`ScanVersion`. This is the engine behind both the GUI scan-finish
+    handler and ``bidsmgr-scan --project``.
+    """
+    from ..recording_meta import scaffold_sidecar_path
+
+    bids_root = Path(bids_root)
+    staged = Path(staged_inventory)
+    label = source_label or (Path(raw_root).name if raw_root else "scan")
+
+    version_dir = workspace.allocate_version_dir(bids_root, label)
+    proj = Project.create(version_dir, name=bids_root.name)
+
+    dest = workspace.version_inventory(version_dir)
+    _move_if_exists(staged, dest)
+    _move_if_exists(scaffold_sidecar_path(staged), scaffold_sidecar_path(dest))
+    _move_if_exists(
+        Path(str(staged) + ".files_by_uid.json.gz"),
+        Path(str(dest) + ".files_by_uid.json.gz"),
+    )
+    workspace.write_version_meta(
+        version_dir,
+        source_label=label,
+        raw_root=str(raw_root) if raw_root else None,
+        status="curating",
+    )
+    proj.append(ScanImported(
+        inventory_tsv=str(dest),
+        row_ids=tuple(row_ids),
+        raw_root=str(raw_root) if raw_root else None,
+    ))
+    proj.append(StageCompleted(
+        stage="scan",
+        success=True,
+        summary={
+            "raw_root": str(raw_root) if raw_root else "",
+            "inventory_tsv": str(dest),
+            "rows": int(n_rows),
+        },
+    ))
+
+    for v in workspace.list_versions(bids_root):
+        if Path(v.dir) == version_dir:
+            return v
+    # Fallback (should not happen now the inventory exists).
+    return ScanVersion(
+        dir=version_dir, version_id=version_dir.name, index=0,
+        source_label=label, raw_root=str(raw_root) if raw_root else None,
+        status="curating", inventory=dest,
+    )
+
+
+def latest_version(bids_root: Path) -> Optional[ScanVersion]:
+    """Return the most recent scan version, or ``None`` if there are none."""
+    versions = workspace.list_versions(Path(bids_root))
+    return versions[-1] if versions else None
+
+
+def find_version(bids_root: Path, selector: str) -> Optional[ScanVersion]:
+    """Resolve a scan version by a lenient ``selector``.
+
+    Matches (in order): exact ``version_id`` (e.g. ``"0001__neuro2"``), the
+    numeric index (``"1"`` or ``"0001"``), or an ``id__``-prefix. Returns
+    ``None`` when nothing matches.
+    """
+    sel = str(selector).strip()
+    versions = workspace.list_versions(Path(bids_root))
+    if not sel:
+        return None
+    for v in versions:
+        if v.version_id == sel:
+            return v
+    if sel.isdigit():
+        idx = int(sel)
+        for v in versions:
+            if v.index == idx:
+                return v
+    for v in versions:
+        if v.version_id.startswith(f"{sel}__") or v.version_id.startswith(sel):
+            return v
+    return None
+
+
+def version_dataframe(
+    version: ScanVersion, *, apply_edits: bool = True,
+) -> pd.DataFrame:
+    """Load a version's inventory DataFrame, replaying its curation edits.
+
+    With ``apply_edits`` (the default) the version's project events are replayed
+    onto the table so the CLI converts exactly what the user curated in the GUI.
+    """
+    df = pd.read_csv(version.inventory, sep="\t", dtype=str).fillna("")
+    if apply_edits:
+        try:
+            proj = Project.open(version.dir)
+            apply_project_state(df, proj.state())
+        except Exception:
+            pass  # a missing/corrupt bundle just means no edits to replay
+    return df
+
+
+__all__ = [
+    "row_id",
+    "apply_project_state",
+    "import_scan_as_version",
+    "latest_version",
+    "find_version",
+    "version_dataframe",
+]

--- a/bidsmgr/project/project.py
+++ b/bidsmgr/project/project.py
@@ -150,6 +150,26 @@ class Project:
         """
         return self.log.truncate_last()
 
+    def undo_last_user_edit(self):
+        """Pop the last event if it is a user edit; return it (else ``None``).
+
+        The GUI Undo button rides this rather than :meth:`undo_last` so it never
+        pops a structural event (ScanImported / StageCompleted / ProjectCreated)
+        and orphans the scan; it reverts the most recent cell / entity / include
+        edit and is a no-op when the last event is not a user edit. The popped
+        event is returned so the GUI can stash it on a redo stack.
+        """
+        from .types import UserSetCell, UserSetEntity, UserToggleInclude
+
+        events = list(self.log)
+        if not events:
+            return None
+        last = events[-1]
+        if isinstance(last, (UserSetCell, UserSetEntity, UserToggleInclude)):
+            if self.log.truncate_last():
+                return last
+        return None
+
     # ------------------------------------------------------------------
     # Bundle housekeeping
     # ------------------------------------------------------------------

--- a/bidsmgr/project/replay.py
+++ b/bidsmgr/project/replay.py
@@ -61,6 +61,7 @@ def replay(events: Iterable[Event]) -> ProjectState:
     name: "str | None" = None
     description: "str | None" = None
     inventory_tsv: "str | None" = None
+    raw_root: "str | None" = None
     row_ids: tuple[str, ...] = ()
 
     for ev in events:
@@ -73,6 +74,7 @@ def replay(events: Iterable[Event]) -> ProjectState:
             description = ev.description
         elif isinstance(ev, ScanImported):
             inventory_tsv = ev.inventory_tsv
+            raw_root = ev.raw_root
             row_ids = ev.row_ids
         elif isinstance(ev, UserSetEntity):
             entity_overrides.setdefault(ev.row_id, {})[ev.entity] = ev.value
@@ -94,6 +96,7 @@ def replay(events: Iterable[Event]) -> ProjectState:
         name=name,
         description=description,
         inventory_tsv=inventory_tsv,
+        raw_root=raw_root,
         row_ids=row_ids,
         entity_overrides=entity_overrides,
         cell_overrides=cell_overrides,

--- a/bidsmgr/project/types.py
+++ b/bidsmgr/project/types.py
@@ -91,6 +91,10 @@ class ScanImported(_EventBase):
     type: Literal["scan_imported"] = "scan_imported"
     inventory_tsv: str
     row_ids: tuple[str, ...]
+    # Raw source folder the scan read from. Optional for back-compat with logs
+    # written before resume support; needed so reopening a project can restore
+    # the source location (and convert can find the files).
+    raw_root: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +255,7 @@ class ProjectState(BaseModel):
     description: Optional[str] = None
 
     inventory_tsv: Optional[str] = None
+    raw_root: Optional[str] = None
     row_ids: tuple[str, ...] = ()
 
     entity_overrides: dict[str, dict[str, Optional[str]]] = Field(default_factory=dict)

--- a/bidsmgr/project/workspace.py
+++ b/bidsmgr/project/workspace.py
@@ -1,0 +1,145 @@
+"""Per-scan version management inside a dataset's project bundle.
+
+Each scan of a source folder is stored as its own version directory under
+``<bids_root>/.bidsmgr/project/scans/<NNNN>__<slug>/``. A version directory is
+itself a :class:`~bidsmgr.project.Project` bundle (``events.jsonl`` +
+``meta.json``), so each scan's curation history is fully isolated, plus the
+inventory snapshot (+ recording-metadata scaffold + files_by_uid sidecar) and a
+``version.json`` descriptor used by the GUI version picker. A second scan of a
+different source therefore never overwrites the first table.
+
+Qt-free (architectural rule 2). Imports only ``util`` (a leaf utility); nothing
+in this subpackage imports the GUI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..util.paths import safe_path_component
+
+VERSION_META = "version.json"
+INVENTORY_NAME = "inventory.tsv"
+
+_INDEX_RE = re.compile(r"^(\d{4})__")
+
+
+def scans_dir(bids_root: Path) -> Path:
+    """Return ``<bids_root>/.bidsmgr/project/scans``."""
+    return Path(bids_root) / ".bidsmgr" / "project" / "scans"
+
+
+def version_inventory(version_dir: Path) -> Path:
+    """Return the inventory snapshot path inside a version directory."""
+    return Path(version_dir) / INVENTORY_NAME
+
+
+@dataclass(frozen=True)
+class ScanVersion:
+    """A single scan version (one source folder scanned into the dataset)."""
+
+    dir: Path
+    version_id: str          # e.g. "0001__neuro2"
+    index: int
+    source_label: str
+    raw_root: Optional[str]
+    status: str              # "curating" | "converted"
+    inventory: Path
+
+
+def _next_index(sd: Path) -> int:
+    mx = 0
+    if sd.is_dir():
+        for child in sd.iterdir():
+            m = _INDEX_RE.match(child.name)
+            if m:
+                mx = max(mx, int(m.group(1)))
+    return mx + 1
+
+
+def allocate_version_dir(bids_root: Path, source_label: str) -> Path:
+    """Return the next free version directory path (not created).
+
+    ``<scans>/<NNNN>__<slug>`` where ``NNNN`` is one past the highest existing
+    index and ``slug`` is a filesystem-safe form of the source folder name.
+    """
+    sd = scans_dir(bids_root)
+    idx = _next_index(sd)
+    slug = safe_path_component(source_label) or "scan"
+    return sd / f"{idx:04d}__{slug}"
+
+
+def write_version_meta(
+    version_dir: Path,
+    *,
+    source_label: str,
+    raw_root: Optional[str],
+    status: str,
+) -> None:
+    """Write/merge the version.json descriptor (preserves unset fields)."""
+    p = Path(version_dir) / VERSION_META
+    meta: dict = {}
+    if p.exists():
+        try:
+            old = json.loads(p.read_text())
+            if isinstance(old, dict):
+                meta = old
+        except (OSError, json.JSONDecodeError):
+            meta = {}
+    meta["source_label"] = source_label
+    meta["raw_root"] = raw_root
+    meta["status"] = status
+    p.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+
+
+def read_version_meta(version_dir: Path) -> dict:
+    p = Path(version_dir) / VERSION_META
+    if not p.exists():
+        return {}
+    try:
+        d = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return d if isinstance(d, dict) else {}
+
+
+def list_versions(bids_root: Path) -> list[ScanVersion]:
+    """List complete scan versions (those with an inventory), oldest first."""
+    sd = scans_dir(bids_root)
+    out: list[ScanVersion] = []
+    if not sd.is_dir():
+        return out
+    for child in sorted(sd.iterdir()):
+        m = _INDEX_RE.match(child.name)
+        if not (child.is_dir() and m):
+            continue
+        inv = version_inventory(child)
+        if not inv.exists():
+            continue  # incomplete / aborted scan
+        meta = read_version_meta(child)
+        out.append(ScanVersion(
+            dir=child,
+            version_id=child.name,
+            index=int(m.group(1)),
+            source_label=str(meta.get("source_label") or child.name),
+            raw_root=meta.get("raw_root"),
+            status=str(meta.get("status") or "curating"),
+            inventory=inv,
+        ))
+    out.sort(key=lambda v: v.index)
+    return out
+
+
+__all__ = [
+    "ScanVersion",
+    "scans_dir",
+    "version_inventory",
+    "allocate_version_dir",
+    "write_version_meta",
+    "read_version_meta",
+    "list_versions",
+]

--- a/bidsmgr/recording_meta/__init__.py
+++ b/bidsmgr/recording_meta/__init__.py
@@ -14,6 +14,8 @@ The enrichment is *applied* to written BIDS files by
 from __future__ import annotations
 
 from .models import (
+    COMMON_CAP_MANUFACTURERS,
+    COMMON_MANUFACTURERS,
     AcceptableImpedance,
     AcquisitionSpec,
     AuxChannelSpec,
@@ -36,6 +38,8 @@ from .serialize import (
 )
 
 __all__ = [
+    "COMMON_MANUFACTURERS",
+    "COMMON_CAP_MANUFACTURERS",
     "AcceptableImpedance",
     "AcquisitionSpec",
     "AuxChannelSpec",

--- a/bidsmgr/recording_meta/__init__.py
+++ b/bidsmgr/recording_meta/__init__.py
@@ -1,0 +1,59 @@
+"""Recording-level enrichment metadata: pure-data models + resolution + I/O.
+
+This subpackage holds the information a raw EEG/MEG/iEEG recording cannot carry
+on its own (reference, ground, filters, device, institution, event-code meaning,
+task protocol) as I/O-free Pydantic models, plus the logic to resolve a
+dataset-default-plus-per-row-override spec into a single effective view for one
+recording. It imports only from :mod:`bidsmgr.schema` and standard scientific
+deps; it is Qt-free and depends on no other ``bidsmgr`` subpackage.
+
+The enrichment is *applied* to written BIDS files by
+:mod:`bidsmgr.fixups.eeg_sidecar`; this subpackage only describes and resolves.
+"""
+
+from __future__ import annotations
+
+from .models import (
+    AcceptableImpedance,
+    AcquisitionSpec,
+    AuxChannelSpec,
+    EventMap,
+    ExtrasSpec,
+    FilterSpec,
+    LightingConditions,
+    RecordingMetaSpec,
+    TaskProtocol,
+)
+from .resolve import EffectiveSpec, merge_acquisition, resolve_effective
+from .schema_types import bids_channel_types, mne_channel_types
+from .serialize import (
+    DEFAULT_POWER_LINE_FREQ,
+    RECORDING_META_SIDECAR,
+    default_spec,
+    dump_spec,
+    load_spec,
+    scaffold_sidecar_path,
+)
+
+__all__ = [
+    "AcceptableImpedance",
+    "AcquisitionSpec",
+    "AuxChannelSpec",
+    "EventMap",
+    "ExtrasSpec",
+    "FilterSpec",
+    "LightingConditions",
+    "RecordingMetaSpec",
+    "TaskProtocol",
+    "EffectiveSpec",
+    "merge_acquisition",
+    "resolve_effective",
+    "bids_channel_types",
+    "mne_channel_types",
+    "DEFAULT_POWER_LINE_FREQ",
+    "RECORDING_META_SIDECAR",
+    "default_spec",
+    "dump_spec",
+    "load_spec",
+    "scaffold_sidecar_path",
+]

--- a/bidsmgr/recording_meta/models.py
+++ b/bidsmgr/recording_meta/models.py
@@ -1,0 +1,179 @@
+"""Pure-data models for recording-level enrichment metadata.
+
+These describe the information a recording file cannot carry on its own:
+the reference and ground electrodes, hardware/software filters, amplifier and
+cap details, institution, the meaning of trigger codes, and per-task protocol
+notes. A scan seeds what it can detect; the user fills the rest. The models are
+deliberately I/O-free (Pydantic v2 only): reading, writing, resolving, and
+applying live in sibling modules.
+
+Every leaf field is optional. Enrichment is *additive*: a field left unset means
+"leave whatever the converter already wrote". The structure separates a single
+dataset-wide ``defaults`` block from sparse per-recording ``overrides`` keyed by
+the inventory row id, so a heterogeneous cohort (mixed caps, amplifiers, or
+references) is expressible without repeating shared values.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from .schema_types import bids_channel_types, mne_channel_types
+
+# A trigger-code -> human-label mapping (e.g. {"S 20": "eyes_open"}).
+EventMap = dict[str, str]
+
+
+class _Model(BaseModel):
+    """Shared config: forbid unknown keys so typos surface at load time."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AcceptableImpedance(_Model):
+    """Impedance acceptance threshold recorded during acquisition."""
+
+    value: Optional[float] = None
+    units: Optional[str] = None
+
+
+class LightingConditions(_Model):
+    """Ambient lighting of the recording environment."""
+
+    description: Optional[str] = None
+    measurement: Optional[str] = None
+
+
+class ExtrasSpec(_Model):
+    """Supplemental, non-required acquisition conditions.
+
+    These are not BIDS-required sidecar keys; they are written as additional
+    fields (BIDS permits extra keys) when present.
+    """
+
+    acceptable_impedance: Optional[AcceptableImpedance] = None
+    electrode_type: Optional[str] = None
+    conductive_medium: Optional[str] = None
+    faraday_cage: Optional[bool] = None
+    sound_proof: Optional[bool] = None
+    lighting_conditions: Optional[LightingConditions] = None
+
+
+class FilterSpec(_Model):
+    """One hardware or software filter applied during acquisition.
+
+    ``info`` is copied verbatim into the sidecar under the filter's ``name``,
+    grouped by ``kind`` into ``HardwareFilters`` / ``SoftwareFilters``.
+    """
+
+    name: str
+    kind: str  # "Hardware" | "Software"
+    info: dict[str, Any] = {}
+
+    @field_validator("kind")
+    @classmethod
+    def _check_kind(cls, v: str) -> str:
+        if v not in ("Hardware", "Software"):
+            raise ValueError("filter kind must be 'Hardware' or 'Software'")
+        return v
+
+
+class AuxChannelSpec(_Model):
+    """How one auxiliary (non-data) channel should be typed and described.
+
+    Used to upgrade a channel the reader saw as generic ``misc`` to its real
+    BIDS type and to fill its units / description in ``channels.tsv``.
+    """
+
+    mne_type: Optional[str] = None
+    bids_type: Optional[str] = None
+    description: Optional[str] = None
+    units: Optional[str] = None
+    location: Optional[Union[str, dict[str, str]]] = None
+
+    @field_validator("bids_type")
+    @classmethod
+    def _check_bids_type(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in bids_channel_types():
+            raise ValueError(
+                f"{v!r} is not a BIDS channel type "
+                f"(allowed: {', '.join(sorted(bids_channel_types()))})"
+            )
+        return v
+
+    @field_validator("mne_type")
+    @classmethod
+    def _check_mne_type(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in mne_channel_types():
+            raise ValueError(
+                f"{v!r} is not an MNE channel type "
+                f"(allowed: {', '.join(sorted(mne_channel_types()))})"
+            )
+        return v
+
+
+class TaskProtocol(_Model):
+    """Free-form per-task protocol notes that map into the task sidecar."""
+
+    task_description: Optional[str] = None
+    instructions: Optional[str] = None
+
+
+class AcquisitionSpec(_Model):
+    """The recording-level technical block (defaults and per-row overrides).
+
+    Carries both the values applied during the write (``power_line_freq``,
+    ``montage``) and the values folded into the sidecar afterwards (reference,
+    ground, device, institution, filters, extras, aux channels).
+    """
+
+    power_line_freq: Optional[float] = None
+    montage: Optional[str] = None
+    eeg_reference: Optional[str] = None
+    eeg_ground: Optional[str] = None
+    manufacturer: Optional[str] = None
+    amplifier_model: Optional[str] = None  # -> ManufacturersModelName
+    software: Optional[str] = None
+    software_versions: Optional[str] = None
+    cap_manufacturer: Optional[str] = None
+    cap_model: Optional[str] = None
+    institution_name: Optional[str] = None
+    institution_dept: Optional[str] = None
+    aux_channels: dict[str, AuxChannelSpec] = {}
+    filters: list[FilterSpec] = []
+    extras: Optional[ExtrasSpec] = None
+
+
+class RecordingMetaSpec(_Model):
+    """Root enrichment object for one dataset.
+
+    ``defaults`` applies to every recording; ``overrides`` carries the sparse
+    per-recording deltas keyed by the inventory ``row_id`` (the recording's
+    source path for EEG/MEG). ``event_maps`` and ``task_protocols`` are keyed by
+    BIDS task label, with ``"*"`` as a fallback event map for all tasks.
+    """
+
+    schema_version: int = 1
+    defaults: AcquisitionSpec = AcquisitionSpec()
+    task_protocols: dict[str, TaskProtocol] = {}
+    event_maps: dict[str, EventMap] = {}
+    overrides: dict[str, AcquisitionSpec] = {}
+    # Dataset-level phenotype measure tables (TSV/CSV/XLSX/ODS paths keyed by
+    # participant_id). Written to ``phenotype/<measure>.tsv`` + ``.json`` by the
+    # metadata engine. Agnostic: applies to any modality.
+    phenotype_files: list[str] = []
+
+
+__all__ = [
+    "EventMap",
+    "AcceptableImpedance",
+    "LightingConditions",
+    "ExtrasSpec",
+    "FilterSpec",
+    "AuxChannelSpec",
+    "TaskProtocol",
+    "AcquisitionSpec",
+    "RecordingMetaSpec",
+]

--- a/bidsmgr/recording_meta/models.py
+++ b/bidsmgr/recording_meta/models.py
@@ -25,6 +25,38 @@ from .schema_types import bids_channel_types, mne_channel_types
 # A trigger-code -> human-label mapping (e.g. {"S 20": "eyes_open"}).
 EventMap = dict[str, str]
 
+# Electrophysiology amplifier / system manufacturers, offered as an editable
+# dropdown in the dataset dialog and the per-row recording section (the user can
+# always type any other value). Grouped by modality but presented as one list.
+# Pure reference data - no Qt - so both GUI surfaces import the one list instead
+# of duplicating it.
+COMMON_MANUFACTURERS: tuple[str, ...] = (
+    # EEG amplifiers / systems
+    "Brain Products", "BioSemi", "EGI / Philips Neuro", "ANT Neuro",
+    "Compumedics Neuroscan", "g.tec", "Cognionics / CGX", "mBrainTrain",
+    "OpenBCI", "Wearable Sensing", "Neuroelectrics", "Bittium", "Nihon Kohden",
+    "Natus", "Nicolet", "Grass", "Cadwell", "Deymed", "Emotiv", "InteraXon",
+    "Advanced Brain Monitoring",
+    # MEG systems (BIDS Manufacturer convention)
+    "MEGIN / Elekta / Neuromag", "CTF", "4D Neuroimaging / BTi",
+    "KIT / Yokogawa", "ITAB", "KRISS",
+    # OPM-MEG
+    "FieldLine", "QuSpin", "Cerca Magnetics",
+    # iEEG / ECoG / sEEG acquisition + electrodes
+    "Blackrock Neurotech", "Ripple Neuro", "Tucker-Davis Technologies",
+    "Plexon", "Medtronic", "Ad-Tech", "PMT Corporation", "DIXI Medical",
+    # fNIRS
+    "NIRx", "Artinis", "Hitachi", "Shimadzu", "Gowerlabs", "Kernel",
+    "Cortivision",
+)
+
+# Common EEG/iEEG cap (electrode-holder) manufacturers. Editable dropdown too.
+COMMON_CAP_MANUFACTURERS: tuple[str, ...] = (
+    "EasyCap", "Brain Products", "BioSemi", "EGI", "ANT Neuro",
+    "Compumedics Neuroscan", "Electro-Cap International", "g.tec",
+    "Cognionics", "Greentek",
+)
+
 
 class _Model(BaseModel):
     """Shared config: forbid unknown keys so typos surface at load time."""
@@ -141,6 +173,15 @@ class AcquisitionSpec(_Model):
     cap_model: Optional[str] = None
     institution_name: Optional[str] = None
     institution_dept: Optional[str] = None
+    # MEG-specific sidecar fields (written only into the meg sidecar). Only the
+    # ones mne-bids CANNOT derive from the recording are exposed: dewar position
+    # (a physical setup fact), the associated empty-room link (a curation
+    # decision), and the subject-artefact note (free text). Channel-derived
+    # facts (ContinuousHeadLocalization, DigitizedLandmarks, DigitizedHeadPoints,
+    # HeadCoilFrequency, ...) are left to mne-bids - never duplicated here.
+    dewar_position: Optional[str] = None            # -> DewarPosition
+    associated_empty_room: Optional[str] = None     # -> AssociatedEmptyRoom
+    subject_artefact_description: Optional[str] = None  # -> SubjectArtefactDescription
     aux_channels: dict[str, AuxChannelSpec] = {}
     filters: list[FilterSpec] = []
     extras: Optional[ExtrasSpec] = None
@@ -168,6 +209,8 @@ class RecordingMetaSpec(_Model):
 
 __all__ = [
     "EventMap",
+    "COMMON_MANUFACTURERS",
+    "COMMON_CAP_MANUFACTURERS",
     "AcceptableImpedance",
     "LightingConditions",
     "ExtrasSpec",

--- a/bidsmgr/recording_meta/models.py
+++ b/bidsmgr/recording_meta/models.py
@@ -205,6 +205,12 @@ class RecordingMetaSpec(_Model):
     # participant_id). Written to ``phenotype/<measure>.tsv`` + ``.json`` by the
     # metadata engine. Agnostic: applies to any modality.
     phenotype_files: list[str] = []
+    # Optional participants spreadsheet (TSV/CSV/XLSX/ODS keyed by
+    # participant_id). Its demographic columns override the inventory-derived
+    # values and any extra columns are carried into participants.tsv (described
+    # in participants.json, optionally via a sibling ``.json`` codebook).
+    # Agnostic: applies to any modality.
+    participants_file: str = ""
 
 
 __all__ = [

--- a/bidsmgr/recording_meta/resolve.py
+++ b/bidsmgr/recording_meta/resolve.py
@@ -1,0 +1,92 @@
+"""Resolve the effective enrichment for one recording.
+
+Merges the dataset-wide ``defaults`` with the per-recording ``overrides`` and
+picks the task-scoped event map and protocol. The result is a flat object the
+enrichment step consumes. Per-row inventory cells (montage, line_freq, reference,
+ground) take precedence over the resolved spec and are layered on by the caller
+(the convert verb), so this module stays spec-only and pure.
+
+Precedence (low to high): ``defaults`` < ``overrides[row_id]`` < inventory cells.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+from .models import AcquisitionSpec, EventMap, RecordingMetaSpec, TaskProtocol
+
+_GLOBAL_EVENT_KEY = "*"
+
+
+class EffectiveSpec(BaseModel):
+    """The resolved enrichment for a single recording."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    acquisition: AcquisitionSpec
+    task_protocol: Optional[TaskProtocol] = None
+    event_map: EventMap = {}
+
+
+def merge_acquisition(
+    base: AcquisitionSpec, over: Optional[AcquisitionSpec]
+) -> AcquisitionSpec:
+    """Return ``base`` with every set field of ``over`` layered on top.
+
+    Scalars: a non-None override value wins. ``aux_channels``: the two maps are
+    merged key-by-key (override entries replace same-named base entries).
+    ``filters``: a non-empty override list replaces the base list outright (the
+    set of filters is treated as a unit, not merged element-wise).
+    """
+    if over is None:
+        return base.model_copy(deep=True)
+
+    merged = base.model_dump()
+    over_dump = over.model_dump(exclude_none=True)
+
+    for key, value in over_dump.items():
+        if key == "aux_channels":
+            combined = dict(merged.get("aux_channels") or {})
+            combined.update(value or {})
+            merged["aux_channels"] = combined
+        elif key == "filters":
+            # exclude_none drops a None list; an explicit empty list would not
+            # reach here, so a present value means "replace".
+            if value:
+                merged["filters"] = value
+        else:
+            merged[key] = value
+
+    return AcquisitionSpec.model_validate(merged)
+
+
+def resolve_effective(
+    spec: RecordingMetaSpec,
+    row_id: str,
+    task_label: Optional[str] = None,
+) -> EffectiveSpec:
+    """Resolve the effective enrichment for the recording identified by ``row_id``.
+
+    ``task_label`` selects the task protocol and event map; the event map falls
+    back to the ``"*"`` global map when no task-specific map exists.
+    """
+    acquisition = merge_acquisition(spec.defaults, spec.overrides.get(row_id))
+
+    task_protocol = spec.task_protocols.get(task_label) if task_label else None
+
+    event_map: EventMap = {}
+    if task_label and task_label in spec.event_maps:
+        event_map = dict(spec.event_maps[task_label])
+    elif _GLOBAL_EVENT_KEY in spec.event_maps:
+        event_map = dict(spec.event_maps[_GLOBAL_EVENT_KEY])
+
+    return EffectiveSpec(
+        acquisition=acquisition,
+        task_protocol=task_protocol,
+        event_map=event_map,
+    )
+
+
+__all__ = ["EffectiveSpec", "merge_acquisition", "resolve_effective"]

--- a/bidsmgr/recording_meta/schema_types.py
+++ b/bidsmgr/recording_meta/schema_types.py
@@ -1,0 +1,71 @@
+"""Allowed channel-type vocabularies, sourced from the live schema / MNE.
+
+These back the validators on :class:`~bidsmgr.recording_meta.models.AuxChannelSpec`
+so a user-authored auxiliary-channel mapping cannot smuggle in a misspelled or
+non-standard channel type. We read the BIDS vocabulary straight from the bundled
+``bidsschematools`` schema (so it tracks the BIDS version automatically) and the
+MNE vocabulary from MNE itself where available, with a conservative fallback in
+both cases so importing this module never hard-fails in a stripped environment.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from .. import schema as schema_mod
+
+# Conservative fallbacks, used only if the live source cannot be read. Kept
+# small and obviously-correct; the live source is authoritative when present.
+_BIDS_FALLBACK: frozenset[str] = frozenset(
+    {
+        "EEG", "ECG", "EOG", "EMG", "ECOG", "SEEG", "DBS", "MEGMAG",
+        "MEGGRADAXIAL", "MEGGRADPLANAR", "MEGREFMAG", "MEGREFGRADAXIAL",
+        "MEGREFGRADPLANAR", "MEGOTHER", "TRIG", "AUDIO", "PD", "RESP", "GSR",
+        "TEMP", "PPG", "HEOG", "VEOG", "MISC", "OTHER", "REF",
+    }
+)
+
+# MNE channel-type strings accepted by ``raw.set_channel_types``. Used only if
+# MNE's own constant table cannot be read.
+_MNE_FALLBACK: frozenset[str] = frozenset(
+    {
+        "bio", "chpi", "dbs", "dipole", "ecg", "ecog", "emg", "eog", "exci",
+        "eyetrack", "fnirs", "gof", "gsr", "ias", "misc", "meg", "ref_meg",
+        "resp", "seeg", "stim", "syst", "temperature", "mag", "grad",
+    }
+)
+
+
+@functools.lru_cache(maxsize=1)
+def bids_channel_types() -> frozenset[str]:
+    """Allowed values for the ``type`` column of a BIDS ``channels.tsv``.
+
+    Read from the schema's ``columns.type__channels`` enum so the set tracks
+    whatever BIDS version the bundled schema pins.
+    """
+    try:
+        column = schema_mod.get_schema().objects.columns["type__channels"]
+        enum = column["enum"]
+        values = frozenset(str(v) for v in enum)
+        if values:
+            return values
+    except Exception:  # pragma: no cover - defensive only
+        pass
+    return _BIDS_FALLBACK
+
+
+@functools.lru_cache(maxsize=1)
+def mne_channel_types() -> frozenset[str]:
+    """Channel-type strings MNE's ``set_channel_types`` accepts."""
+    try:
+        from mne.io.pick import get_channel_type_constants
+
+        values = frozenset(str(k) for k in get_channel_type_constants().keys())
+        if values:
+            return values
+    except Exception:  # pragma: no cover - older/newer MNE or absent MNE
+        pass
+    return _MNE_FALLBACK
+
+
+__all__ = ["bids_channel_types", "mne_channel_types"]

--- a/bidsmgr/recording_meta/serialize.py
+++ b/bidsmgr/recording_meta/serialize.py
@@ -1,0 +1,57 @@
+"""Load and build :class:`RecordingMetaSpec` objects.
+
+The spec is a plain JSON document (our own layout, not tied to any external
+tool). The convert and metadata verbs read it via ``--recording-meta``; when no
+spec is supplied they fall back to :func:`default_spec`, which preserves the
+historical behaviour of writing ``PowerLineFrequency = 50`` by default while
+keeping that value visible and overridable instead of buried in a CLI flag.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .models import AcquisitionSpec, RecordingMetaSpec
+
+# Historical default written when nothing else specifies a power-line
+# frequency, preserved so removing the old --line-freq flag does not silently
+# change the default output.
+DEFAULT_POWER_LINE_FREQ = 50.0
+
+# Suffix for the scaffold the scan verb writes next to an inventory TSV
+# (``<inventory>.tsv.recording_meta.json``). The convert/metadata verbs
+# auto-discover it when ``--recording-meta`` is not given, mirroring the
+# ``files_by_uid`` sidecar convention.
+RECORDING_META_SIDECAR = ".recording_meta.json"
+
+
+def scaffold_sidecar_path(tsv_path) -> Path:
+    """Return the recording-metadata scaffold path beside an inventory TSV."""
+    p = Path(tsv_path)
+    return p.with_name(p.name + RECORDING_META_SIDECAR)
+
+
+def default_spec(power_line_freq: Optional[float] = DEFAULT_POWER_LINE_FREQ) -> RecordingMetaSpec:
+    """A spec with no enrichment beyond the default power-line frequency."""
+    return RecordingMetaSpec(defaults=AcquisitionSpec(power_line_freq=power_line_freq))
+
+
+def load_spec(path: Path) -> RecordingMetaSpec:
+    """Read and validate a recording-metadata JSON document.
+
+    Raises the underlying ``OSError`` / JSON / Pydantic error so the caller can
+    report a precise message; callers that want a forgiving load should catch.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    data = json.loads(text)
+    return RecordingMetaSpec.model_validate(data)
+
+
+def dump_spec(spec: RecordingMetaSpec) -> str:
+    """Serialise a spec to pretty JSON (drops unset leaves for readability)."""
+    return json.dumps(spec.model_dump(exclude_none=True), indent=2) + "\n"
+
+
+__all__ = ["DEFAULT_POWER_LINE_FREQ", "default_spec", "load_spec", "dump_spec"]

--- a/bidsmgr/schema/loader.py
+++ b/bidsmgr/schema/loader.py
@@ -28,7 +28,7 @@ def get_schema(version: Optional[str] = None) -> Namespace:
     Parameters
     ----------
     version
-        Schema version to load (e.g. ``"1.10.0"``). Currently ignored; we
+        Schema version to load (e.g. ``"1.11.1"``). Currently ignored; we
         always load the version that ships with the installed
         ``bidsschematools``. Will be honoured against ``bundled/`` once the
         per-project pinning policy lands.

--- a/bidsmgr/schema/validation.py
+++ b/bidsmgr/schema/validation.py
@@ -117,7 +117,15 @@ _BASENAME_TOKEN = re.compile(r"^([a-zA-Z]+)-([0-9a-zA-Z]+)$")
 def validate_basename(
     basename: str,
     datatype: Datatype,
-    extensions: tuple[str, ...] = (".nii.gz", ".nii", ".json", ".bval", ".bvec", ".tsv", ".edf", ".bdf", ".vhdr", ".set"),
+    # Longest / double extensions FIRST so e.g. ``.tsv.gz`` is stripped before
+    # ``.tsv`` (otherwise the suffix parses as ``physio.tsv.gz`` and is
+    # wrongly flagged "not valid"). Covers MRI, physio, and EEG/MEG/iEEG.
+    extensions: tuple[str, ...] = (
+        ".nii.gz", ".tsv.gz", ".fif.gz",
+        ".nii", ".tsv", ".json", ".bval", ".bvec",
+        ".edf", ".bdf", ".gdf", ".vhdr", ".vmrk", ".eeg", ".fdt",
+        ".set", ".fif", ".con", ".sqd", ".cnt", ".kdf", ".mef", ".nwb", ".egi",
+    ),
 ) -> list[ValidationVerdict]:
     """Parse + validate a BIDS basename. Strips extension; needs a known suffix."""
 

--- a/bidsmgr/util/cancel.py
+++ b/bidsmgr/util/cancel.py
@@ -1,0 +1,42 @@
+"""Cooperative cancellation for the long-running scan / convert verbs.
+
+The GUI workers expose a Stop button that flips a ``threading.Event``; the
+CLI verbs receive its ``is_set`` bound method as a ``cancel_check`` callable
+and poll it at unit-of-work boundaries (each batch of DICOM-read results,
+each convert subject / task). When it returns True they raise
+:class:`OperationCancelled`, which the worker catches and reports as a clean
+stop.
+
+This is cooperative, not pre-emptive: a dcm2niix subprocess or a single
+DICOM read already in flight runs to completion before the stop takes
+effect -- nothing is force-killed, so the BIDS tree is never left
+half-written. No partial output is committed: a cancelled scan writes no
+TSV, and a cancelled convert subject's staging is wiped by the existing
+per-subject ``finally`` (subjects committed before the stop remain, which
+is the desired "stop here" behaviour).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+# A zero-arg predicate that returns True when a stop has been requested.
+CancelCheck = Optional[Callable[[], bool]]
+
+
+class OperationCancelled(Exception):
+    """Raised inside ``run_scan`` / ``run_convert`` when a stop was requested."""
+
+
+def is_cancelled(cancel_check: CancelCheck) -> bool:
+    """True if ``cancel_check`` is provided and currently signals a stop."""
+    return bool(cancel_check is not None and cancel_check())
+
+
+def raise_if_cancelled(cancel_check: CancelCheck, message: str = "operation cancelled") -> None:
+    """Raise :class:`OperationCancelled` if a stop has been requested."""
+    if is_cancelled(cancel_check):
+        raise OperationCancelled(message)
+
+
+__all__ = ["CancelCheck", "OperationCancelled", "is_cancelled", "raise_if_cancelled"]

--- a/bidsmgr/util/system_info.py
+++ b/bidsmgr/util/system_info.py
@@ -1,0 +1,91 @@
+"""Cross-platform machine introspection: CPU thread/core count + RAM.
+
+Used by the Settings dialog to (a) show a read-only "System info" panel and
+(b) cap the parallel-workers spinboxes at the number of logical CPUs so a
+user cannot ask for more workers than the machine has threads.
+
+``psutil`` is the primary source (declared in ``pyproject.toml``); every
+field degrades gracefully to a stdlib fallback so a missing or broken
+``psutil`` never crashes the GUI -- the worst case is ``physical_cores`` /
+``total_ram_bytes`` coming back ``None`` and the panel showing "unknown".
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SystemInfo:
+    """A snapshot of the host's CPU + memory capacity."""
+
+    logical_threads: int                 # always >= 1 (the spinbox cap)
+    physical_cores: Optional[int] = None  # None when undetectable
+    total_ram_bytes: Optional[int] = None
+
+    @property
+    def total_ram_gib(self) -> Optional[float]:
+        if self.total_ram_bytes is None:
+            return None
+        return self.total_ram_bytes / (1024 ** 3)
+
+    def human(self) -> str:
+        """One-line human summary, e.g. ``10 threads (10 cores) - 32.0 GiB RAM``."""
+        if self.physical_cores and self.physical_cores != self.logical_threads:
+            cpu = f"{self.logical_threads} threads ({self.physical_cores} cores)"
+        else:
+            cpu = f"{self.logical_threads} threads"
+        if self.total_ram_gib is not None:
+            return f"{cpu} - {self.total_ram_gib:.1f} GiB RAM"
+        return f"{cpu} - RAM unknown"
+
+
+def _logical_threads() -> int:
+    # ``os.cpu_count()`` can return None on exotic platforms; ``sched_getaffinity``
+    # (Linux) reflects the threads this process may actually use under cgroups.
+    n: Optional[int] = None
+    getaffinity = getattr(os, "sched_getaffinity", None)
+    if getaffinity is not None:
+        try:
+            n = len(getaffinity(0))
+        except OSError:
+            n = None
+    if not n:
+        n = os.cpu_count()
+    return max(1, int(n or 1))
+
+
+def _physical_cores() -> Optional[int]:
+    try:
+        import psutil
+        cores = psutil.cpu_count(logical=False)
+        return int(cores) if cores else None
+    except Exception:
+        return None
+
+
+def _total_ram_bytes() -> Optional[int]:
+    try:
+        import psutil
+        return int(psutil.virtual_memory().total)
+    except Exception:
+        pass
+    # POSIX fallback (Linux + macOS); Windows has no SC_PHYS_PAGES.
+    try:
+        return int(os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES"))
+    except (AttributeError, ValueError, OSError):
+        return None
+
+
+def get_system_info() -> SystemInfo:
+    """Return a :class:`SystemInfo` snapshot of the host machine."""
+    return SystemInfo(
+        logical_threads=_logical_threads(),
+        physical_cores=_physical_cores(),
+        total_ram_bytes=_total_ram_bytes(),
+    )
+
+
+__all__ = ["SystemInfo", "get_system_info"]

--- a/bidsmgr/vendor/README.md
+++ b/bidsmgr/vendor/README.md
@@ -52,8 +52,19 @@ entirely.
    (`from bidsphysio.base.bidsphysio import ...`) to relative
    (`from ..base.bidsphysio import ...`) so the tree relocates
    cleanly under `bidsmgr.vendor`.
-3. No behavioural changes. Every function and class body is
-   verbatim. Original per-file MIT headers are preserved.
+3. One performance fix in `base/bidsphysio.py`:
+   `PhysioSignal.plug_missing_data` was rewritten from the upstream
+   one-insertion-at-a-time loop (each step a full `np.concatenate` plus
+   a re-scan from index 0, i.e. O(n^2)) to a vectorised single-pass
+   build. The upstream version hangs for minutes on large CMRR logs
+   (a real 22M-sample ECG with many gaps); the rewrite handles 1M
+   samples / ~1M gaps in well under a second. Output is identical to
+   the original for every input where the original actually fills gaps;
+   it additionally fixes an upstream `np.argmax` edge bug that left a
+   gap in the very first sampling interval unfilled. Covered by
+   `tests/unit/test_bidsphysio_plug_missing_data.py`.
+4. Otherwise no behavioural changes. Every other function and class
+   body is verbatim. Original per-file MIT headers are preserved.
 
 **What's in the tree:**
 

--- a/bidsmgr/vendor/bidsphysio/base/bidsphysio.py
+++ b/bidsmgr/vendor/bidsphysio/base/bidsphysio.py
@@ -149,30 +149,60 @@ class PhysioSignal(object):
         """
         Function to plug "missing_value" (NaN, by default) wherever the
         signal was not recorded.
+
+        bids-manager change (vendored): the upstream implementation inserted
+        one missing sample at a time, each insertion doing a full
+        ``np.concatenate`` (O(n) copy of the whole signal) followed by a
+        re-scan from the start -- O(n^2) overall, which hangs for minutes on
+        large CMRR logs (e.g. a 22M-sample ECG with many gaps). This is a
+        fully vectorised rewrite that produces the identical output in a
+        single pass / single allocation. See ``bidsmgr/vendor/README.md``.
         """
 
         # The time increment between samples:
-        dt = 1/self.samples_per_second
+        dt = 1 / self.samples_per_second
 
-        # The following finds the first index for which the difference between
-        #   consecutive elements is larger than dt (plus a small rounding error)
-        # (argmax stops at the first "True"; if it doesn't find any, it returns 0):
-        i = np.argmax( np.ediff1d(self.sampling_times) > dt*(1.001) )
-        while i != 0:
-            # new time array, which adds the missing timepoint:
-            self.sampling_times = np.concatenate(
-                # Note: np.concatenate takes a list as argument, so you need (...)
-                (self.sampling_times[:i+1], [self.sampling_times[i]+dt], self.sampling_times[i+1:])
-            )
-            # new signal array, which adds a "missing_value" at the missing timepoint:
-            self.signal = np.concatenate(
-                # Note: np.concatenate takes a list as argument, so you need (...)
-                (self.signal[:i+1], [missing_value], self.signal[i+1:])
-            )
-            # check to see if we are done:
-            i = np.argmax( np.ediff1d(self.sampling_times) > dt*(1.001) )
+        times = np.asarray(self.sampling_times, dtype=float)
+        signal = np.asarray(self.signal)
+        n = times.size
+        if n < 2:
+            self.samples_count = int(signal.size)
+            return
 
-        self.samples_count = len( self.signal )
+        diffs = np.diff(times)
+        gap_mask = diffs > dt * 1.001
+        # Number of missing samples to insert AFTER each original sample.
+        # ``ceil(diff/dt - 1.001)`` matches the upstream loop's count exactly:
+        # it inserts at ``t+dt, t+2dt, ...`` until the residual gap is <= dt.
+        inserts = np.zeros(n, dtype=np.int64)  # inserts[-1] stays 0 (no gap after last)
+        inserts[:-1][gap_mask] = np.ceil(
+            diffs[gap_mask] / dt - 1.001
+        ).astype(np.int64)
+
+        total = int(inserts.sum())
+        if total == 0:
+            self.samples_count = int(signal.size)
+            return
+
+        out_len = n + total
+        block = 1 + inserts                       # output slots each original sample owns
+        orig_pos = np.cumsum(block) - block       # output index of each original sample
+
+        out_times = np.empty(out_len, dtype=float)
+        out_signal = np.full(out_len, missing_value, dtype=signal.dtype)
+        out_times[orig_pos] = times
+        out_signal[orig_pos] = signal
+
+        # Inserted slots get times ``t_prev + dt * k`` (k = 1, 2, ...).
+        base = np.repeat(times, block)            # preceding original time per slot
+        within = np.arange(out_len) - np.repeat(orig_pos, block)  # 0 at original, 1.. at inserts
+        inserted = np.ones(out_len, dtype=bool)
+        inserted[orig_pos] = False
+        out_times[inserted] = (base + dt * within)[inserted]
+
+        self.sampling_times = out_times
+        self.signal = out_signal
+        self.samples_count = out_len
 
     @classmethod
     def matching_trigger_signal(cls, mysignal, trigger_s):

--- a/bidsmgr/workers/__init__.py
+++ b/bidsmgr/workers/__init__.py
@@ -20,8 +20,15 @@ from .convert import ConvertWorker
 from .file_report import FileReportWorker, FolderReportWorker
 from .metadata import MetadataWorker
 from .nifti_loader import NiftiLoaderWorker
+from .meeg_recording_loader import (
+    RecordingComputeWorker,
+    RecordingMetaWorker,
+    RecordingResampleWorker,
+    RecordingSignalWorker,
+)
 from .report import ReportWorker
 from .scan import ScanWorker
+from .tsv_loader import TsvLoaderWorker
 from .validate import ValidateWorker
 
 __all__ = [
@@ -30,7 +37,12 @@ __all__ = [
     "FolderReportWorker",
     "MetadataWorker",
     "NiftiLoaderWorker",
+    "RecordingComputeWorker",
+    "RecordingMetaWorker",
+    "RecordingResampleWorker",
+    "RecordingSignalWorker",
     "ReportWorker",
     "ScanWorker",
+    "TsvLoaderWorker",
     "ValidateWorker",
 ]

--- a/bidsmgr/workers/convert.py
+++ b/bidsmgr/workers/convert.py
@@ -23,6 +23,7 @@ long as series UIDs don't change.
 from __future__ import annotations
 
 import logging
+import threading
 import traceback
 from pathlib import Path
 from typing import Optional
@@ -66,6 +67,10 @@ class ConvertWorker(QThread):
     progress = pyqtSignal(str)
     finished_with_result = pyqtSignal(int, object)
     failed = pyqtSignal(str)
+    # Emitted when the run stopped because the user clicked Stop. Subjects
+    # committed before the stop remain on disk; the in-flight subject (if
+    # any) is wiped from staging and not committed.
+    stopped = pyqtSignal()
 
     def __init__(
         self,
@@ -79,6 +84,7 @@ class ConvertWorker(QThread):
         line_freq: Optional[float] = 50.0,
         montage: Optional[str] = None,
         raw_root: Optional[Path] = None,
+        skip_residuals: bool = True,
         parent=None,
     ) -> None:
         super().__init__(parent)
@@ -91,6 +97,16 @@ class ConvertWorker(QThread):
         self._line_freq = line_freq
         self._montage = montage
         self._raw_root = Path(raw_root) if raw_root is not None else None
+        self._skip_residuals = skip_residuals
+        # Cooperative stop flag, polled by ``run_convert`` between subjects
+        # and between per-subject tasks.
+        self._stop = threading.Event()
+
+    def request_stop(self) -> None:
+        """Ask the in-flight conversion to stop at the next subject / task
+        boundary. Thread-safe. Already-committed subjects stay; the
+        in-flight subject is not committed."""
+        self._stop.set()
 
     def run(self) -> None:
         from ..cli.convert import run_convert  # see scan worker comment
@@ -121,7 +137,14 @@ class ConvertWorker(QThread):
                 line_freq=self._line_freq,
                 montage=self._montage,
                 raw_root=self._raw_root,
+                skip_residuals=self._skip_residuals,
+                cancel_check=self._stop.is_set,
             )
+            if rc == 130 or self._stop.is_set():
+                # 130 = run_convert's "stopped before all subjects" code.
+                self.progress.emit("Conversion stopped by user")
+                self.stopped.emit()
+                return
             verdict = "completed" if rc == 0 else f"completed with {rc} subject failure(s)"
             self.progress.emit(f"Conversion {verdict}")
             self.finished_with_result.emit(rc, self._bids_parent)

--- a/bidsmgr/workers/convert.py
+++ b/bidsmgr/workers/convert.py
@@ -85,6 +85,7 @@ class ConvertWorker(QThread):
         recording_meta: Optional[Path] = None,
         raw_root: Optional[Path] = None,
         skip_residuals: bool = True,
+        force_edf: bool = False,
         parent=None,
     ) -> None:
         super().__init__(parent)
@@ -98,6 +99,7 @@ class ConvertWorker(QThread):
         self._recording_meta = Path(recording_meta) if recording_meta is not None else None
         self._raw_root = Path(raw_root) if raw_root is not None else None
         self._skip_residuals = skip_residuals
+        self._force_edf = force_edf
         # Cooperative stop flag, polled by ``run_convert`` between subjects
         # and between per-subject tasks.
         self._stop = threading.Event()
@@ -138,6 +140,7 @@ class ConvertWorker(QThread):
                 recording_meta=self._recording_meta,
                 raw_root=self._raw_root,
                 skip_residuals=self._skip_residuals,
+                force_edf=self._force_edf,
                 cancel_check=self._stop.is_set,
             )
             if rc == 130 or self._stop.is_set():

--- a/bidsmgr/workers/convert.py
+++ b/bidsmgr/workers/convert.py
@@ -60,7 +60,7 @@ class ConvertWorker(QThread):
     bids_parent
         Destination parent dir; ``run_convert`` creates one
         ``<bids_parent>/<dataset>/`` per dataset slug.
-    n_jobs, overwrite, dry_run, line_freq, montage
+    n_jobs, overwrite, dry_run, recording_meta
         Pass-through to the CLI verb's keyword args.
     """
 
@@ -81,8 +81,7 @@ class ConvertWorker(QThread):
         n_jobs: int = 1,
         overwrite: bool = False,
         dry_run: bool = False,
-        line_freq: Optional[float] = 50.0,
-        montage: Optional[str] = None,
+        recording_meta: Optional[Path] = None,
         raw_root: Optional[Path] = None,
         skip_residuals: bool = True,
         parent=None,
@@ -94,8 +93,7 @@ class ConvertWorker(QThread):
         self._n_jobs = n_jobs
         self._overwrite = overwrite
         self._dry_run = dry_run
-        self._line_freq = line_freq
-        self._montage = montage
+        self._recording_meta = Path(recording_meta) if recording_meta is not None else None
         self._raw_root = Path(raw_root) if raw_root is not None else None
         self._skip_residuals = skip_residuals
         # Cooperative stop flag, polled by ``run_convert`` between subjects
@@ -134,8 +132,7 @@ class ConvertWorker(QThread):
                 n_jobs=self._n_jobs,
                 overwrite=self._overwrite,
                 dry_run=self._dry_run,
-                line_freq=self._line_freq,
-                montage=self._montage,
+                recording_meta=self._recording_meta,
                 raw_root=self._raw_root,
                 skip_residuals=self._skip_residuals,
                 cancel_check=self._stop.is_set,

--- a/bidsmgr/workers/convert.py
+++ b/bidsmgr/workers/convert.py
@@ -80,6 +80,7 @@ class ConvertWorker(QThread):
         *,
         n_jobs: int = 1,
         overwrite: bool = False,
+        on_existing: Optional[str] = None,
         dry_run: bool = False,
         recording_meta: Optional[Path] = None,
         raw_root: Optional[Path] = None,
@@ -92,6 +93,7 @@ class ConvertWorker(QThread):
         self._bids_parent = Path(bids_parent)
         self._n_jobs = n_jobs
         self._overwrite = overwrite
+        self._on_existing = on_existing
         self._dry_run = dry_run
         self._recording_meta = Path(recording_meta) if recording_meta is not None else None
         self._raw_root = Path(raw_root) if raw_root is not None else None
@@ -131,6 +133,7 @@ class ConvertWorker(QThread):
                 self._bids_parent,
                 n_jobs=self._n_jobs,
                 overwrite=self._overwrite,
+                on_existing=self._on_existing,
                 dry_run=self._dry_run,
                 recording_meta=self._recording_meta,
                 raw_root=self._raw_root,

--- a/bidsmgr/workers/meeg_recording_loader.py
+++ b/bidsmgr/workers/meeg_recording_loader.py
@@ -1,0 +1,211 @@
+"""Background loaders for EEG / MEG / iEEG recordings (Editor viewer).
+
+The Editor's :class:`bidsmgr.gui.widgets.RecordingViewerPane` reads
+recordings with MNE-Python. Even a metadata read can touch a multi-GB
+file, and a full signal load (``preload=True``) can take several seconds
+and allocate gigabytes. Doing either on the GUI thread freezes the
+window, including the busy spinner that is supposed to say "loading".
+
+These workers push the work onto ``QThread``s, mirroring
+:class:`bidsmgr.workers.nifti_loader.NiftiLoaderWorker`.
+
+Cancellation
+------------
+The pane often issues a new load before the previous one has finished
+(the user clicks a different recording in the BIDS tree). The worker
+cannot interrupt MNE mid-read, so it flips a flag and suppresses the
+result emission; the pane additionally guards on the emitted ``path`` so
+a stale result never reaches the UI.
+
+CTF ``.ds`` + macOS note
+------------------------
+MNE's CTF reader uses lazy memory-mapping; the MEEGqc viewer reported
+SIGBUS crashes when reading ``.ds`` inside a ``QThread`` on macOS. We
+load with ``preload=True`` (the whole file is materialised into RAM
+during the call, leaving no lingering memory-map to fault later), and our
+datasets never use that path, so we thread uniformly. If a real
+CTF-on-macOS SIGBUS is ever observed, the fix is a deferred main-thread
+read guarded by ``sys.platform == "darwin" and ext == ".ds"`` in the
+pane's :meth:`set_file` / load handler.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from PyQt6.QtCore import QThread, pyqtSignal
+
+log = logging.getLogger(__name__)
+
+
+class RecordingMetaWorker(QThread):
+    """Read a recording's metadata (``preload=False``) on a background thread.
+
+    Signals
+    -------
+    finished_with_meta(dict, Path)
+        Emitted on success. ``dict`` is the plain summary produced by
+        :func:`bidsmgr.gui.widgets.recording_viewer_pane._summarize_raw`.
+        Always check ``path`` against the currently-bound file.
+    failed(Path, str)
+        Emitted on read failure. Args: ``(path, error_message)``.
+    """
+
+    finished_with_meta = pyqtSignal(dict, Path)
+    failed = pyqtSignal(Path, str)
+
+    def __init__(self, path: Path, parent=None) -> None:
+        super().__init__(parent)
+        self._path = path
+        self._cancelled = False
+
+    def path(self) -> Path:
+        return self._path
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        from bidsmgr.gui.widgets.recording_viewer_pane import (
+            _read_raw,
+            _summarize_raw,
+        )
+
+        try:
+            raw = _read_raw(self._path, preload=False)
+            meta = _summarize_raw(raw, self._path)
+        except Exception as exc:  # noqa: BLE001 - surfaced to UI
+            log.warning("RecordingMetaWorker failed on %s: %s", self._path, exc)
+            if not self._cancelled:
+                self.failed.emit(self._path, str(exc))
+            return
+        if self._cancelled:
+            return
+        self.finished_with_meta.emit(meta, self._path)
+
+
+class RecordingSignalWorker(QThread):
+    """Read a recording's full signal (``preload=True``) on a background thread.
+
+    Signals
+    -------
+    finished_with_raw(object, Path)
+        Emitted on success with the preloaded ``mne.io.Raw``.
+    failed(Path, str)
+        Emitted on read failure.
+    """
+
+    finished_with_raw = pyqtSignal(object, Path)
+    failed = pyqtSignal(Path, str)
+
+    def __init__(self, path: Path, parent=None) -> None:
+        super().__init__(parent)
+        self._path = path
+        self._cancelled = False
+
+    def path(self) -> Path:
+        return self._path
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        from bidsmgr.gui.widgets.recording_viewer_pane import _read_raw
+
+        try:
+            raw = _read_raw(self._path, preload=True)
+        except Exception as exc:  # noqa: BLE001 - surfaced to UI
+            log.warning(
+                "RecordingSignalWorker failed on %s: %s", self._path, exc
+            )
+            if not self._cancelled:
+                self.failed.emit(self._path, str(exc))
+            return
+        if self._cancelled:
+            return
+        self.finished_with_raw.emit(raw, self._path)
+
+
+class RecordingResampleWorker(QThread):
+    """Resample an in-memory ``mne.io.Raw`` on a background thread.
+
+    Signals
+    -------
+    finished_with_raw(object, float)
+        Emitted on success. Args: ``(resampled_raw, new_sfreq)``.
+    failed(str)
+        Emitted on failure with the error message.
+    """
+
+    finished_with_raw = pyqtSignal(object, float)
+    failed = pyqtSignal(str)
+
+    def __init__(self, raw, sfreq: float, parent=None) -> None:
+        super().__init__(parent)
+        self._raw = raw
+        self._sfreq = float(sfreq)
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        try:
+            resampled = self._raw.copy().resample(self._sfreq, verbose=False)
+        except Exception as exc:  # noqa: BLE001 - surfaced to UI
+            log.warning("RecordingResampleWorker failed: %s", exc)
+            if not self._cancelled:
+                self.failed.emit(str(exc))
+            return
+        if self._cancelled:
+            return
+        self.finished_with_raw.emit(resampled, self._sfreq)
+
+
+class RecordingComputeWorker(QThread):
+    """Run an arbitrary heavy callable on a background thread.
+
+    Used for the PSD computation (an FFT over the whole recording can take
+    a noticeable amount of time on long MEG files). The callable returns
+    an opaque result object emitted back to the GUI thread.
+
+    Signals
+    -------
+    finished_with_result(object)
+        Emitted on success with whatever the callable returned.
+    failed(str)
+        Emitted on failure with the error message.
+    """
+
+    finished_with_result = pyqtSignal(object)
+    failed = pyqtSignal(str)
+
+    def __init__(self, func: Callable[[], object], parent=None) -> None:
+        super().__init__(parent)
+        self._func = func
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        try:
+            result = self._func()
+        except Exception as exc:  # noqa: BLE001 - surfaced to UI
+            log.warning("RecordingComputeWorker failed: %s", exc)
+            if not self._cancelled:
+                self.failed.emit(str(exc))
+            return
+        if self._cancelled:
+            return
+        self.finished_with_result.emit(result)
+
+
+__all__ = [
+    "RecordingMetaWorker",
+    "RecordingSignalWorker",
+    "RecordingResampleWorker",
+    "RecordingComputeWorker",
+]

--- a/bidsmgr/workers/scan.py
+++ b/bidsmgr/workers/scan.py
@@ -89,6 +89,8 @@ class ScanWorker(QThread):
         n_jobs: int = 1,
         skip_bids_guess: bool = False,
         probe_convert: bool = False,
+        user_hints=None,
+        exclusions=None,
         parent=None,
     ) -> None:
         super().__init__(parent)
@@ -100,6 +102,10 @@ class ScanWorker(QThread):
         self._n_jobs = n_jobs
         self._skip_bids_guess = skip_bids_guess
         self._probe_convert = probe_convert
+        # User scan rules (classifier hints + exclusions), already converted
+        # to the engine's frozen dataclasses by the caller.
+        self._user_hints = user_hints
+        self._exclusions = exclusions
         # Cooperative stop flag. ``run_scan`` polls ``_stop.is_set`` at
         # DICOM-read boundaries and raises ``OperationCancelled`` when set.
         self._stop = threading.Event()
@@ -144,6 +150,8 @@ class ScanWorker(QThread):
                 line_freq=self._line_freq,
                 montage=self._montage,
                 cancel_check=self._stop.is_set,
+                user_hints=self._user_hints,
+                exclusions=self._exclusions,
             )
             self.progress.emit(
                 f"Scan complete: {len(df)} row(s) → {self._output_tsv}"

--- a/bidsmgr/workers/scan.py
+++ b/bidsmgr/workers/scan.py
@@ -26,6 +26,7 @@ Signals
 from __future__ import annotations
 
 import logging
+import threading
 import traceback
 from pathlib import Path
 from typing import Optional
@@ -73,6 +74,9 @@ class ScanWorker(QThread):
     progress = pyqtSignal(str)
     finished_with_result = pyqtSignal(object, object)
     failed = pyqtSignal(str)
+    # Emitted (instead of ``failed``) when the run stopped because the user
+    # clicked Stop. The GUI treats this as a clean, expected outcome.
+    stopped = pyqtSignal()
 
     def __init__(
         self,
@@ -96,6 +100,17 @@ class ScanWorker(QThread):
         self._n_jobs = n_jobs
         self._skip_bids_guess = skip_bids_guess
         self._probe_convert = probe_convert
+        # Cooperative stop flag. ``run_scan`` polls ``_stop.is_set`` at
+        # DICOM-read boundaries and raises ``OperationCancelled`` when set.
+        self._stop = threading.Event()
+
+    def request_stop(self) -> None:
+        """Ask the in-flight scan to stop at the next read boundary.
+
+        Thread-safe (just sets an Event). The scan finishes the read
+        already in flight, then aborts without writing a TSV.
+        """
+        self._stop.set()
 
     # ------------------------------------------------------------------
     def run(self) -> None:
@@ -106,6 +121,7 @@ class ScanWorker(QThread):
         # construction on the main thread. Also keeps the worker module
         # cheap to import in tests that don't actually start it.
         from ..cli.scan import run_scan
+        from ..util.cancel import OperationCancelled
 
         handler = _LogToSignal(self.progress.emit)
         handler.setLevel(logging.INFO)
@@ -127,11 +143,15 @@ class ScanWorker(QThread):
                 dataset=self._dataset,
                 line_freq=self._line_freq,
                 montage=self._montage,
+                cancel_check=self._stop.is_set,
             )
             self.progress.emit(
                 f"Scan complete: {len(df)} row(s) → {self._output_tsv}"
             )
             self.finished_with_result.emit(df, self._output_tsv)
+        except OperationCancelled:
+            self.progress.emit("Scan stopped by user")
+            self.stopped.emit()
         except Exception:
             self.failed.emit(traceback.format_exc())
         finally:

--- a/bidsmgr/workers/tsv_loader.py
+++ b/bidsmgr/workers/tsv_loader.py
@@ -1,0 +1,74 @@
+"""Background loader for TSV / TSV.GZ tables (Editor viewer).
+
+BIDS sidecar TSVs (events / channels / participants / scans) are usually
+small, but a phenotype table or a derivatives TSV can run to many
+thousands of rows, and decompressing a ``.tsv.gz`` blocks while the file
+is read. Doing that on the GUI thread freezes the window when the user
+clicks such a file in the BIDS tree.
+
+This worker pushes the parse onto a ``QThread`` and emits the parsed
+header / rows back to :class:`bidsmgr.gui.widgets.TsvViewerPane`,
+mirroring :class:`bidsmgr.workers.nifti_loader.NiftiLoaderWorker`.
+
+Cancellation
+------------
+The pane often issues a new load before the previous one finishes (the
+user clicks a different file). The worker can't interrupt the parse, so
+it flips a flag and suppresses the result; the pane also guards on the
+emitted ``path`` so a stale table never reaches the UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from PyQt6.QtCore import QThread, pyqtSignal
+
+log = logging.getLogger(__name__)
+
+
+class TsvLoaderWorker(QThread):
+    """Parse a ``.tsv`` / ``.tsv.gz`` on a background thread.
+
+    Signals
+    -------
+    finished_with_data(list, list, int, Path)
+        Emitted on success. Args: ``(header, rows, total_rows, path)``.
+        ``total_rows`` is the on-disk data-row count (so the footer can
+        report truncation). Always check ``path`` against the bound file.
+    failed(Path, str)
+        Emitted on read failure. Args: ``(path, error_message)``.
+    """
+
+    finished_with_data = pyqtSignal(list, list, int, Path)
+    failed = pyqtSignal(Path, str)
+
+    def __init__(self, path: Path, max_rows: int, parent=None) -> None:
+        super().__init__(parent)
+        self._path = path
+        self._max_rows = max_rows
+        self._cancelled = False
+
+    def path(self) -> Path:
+        return self._path
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:  # noqa: D401 - QThread entry point
+        from bidsmgr.gui.widgets.tsv_viewer_pane import _read_tsv
+
+        try:
+            header, rows, total = _read_tsv(self._path, max_rows=self._max_rows)
+        except Exception as exc:  # noqa: BLE001 - surfaced to UI
+            log.warning("TsvLoaderWorker failed on %s: %s", self._path, exc)
+            if not self._cancelled:
+                self.failed.emit(self._path, str(exc))
+            return
+        if self._cancelled:
+            return
+        self.finished_with_data.emit(header, rows, total, self._path)
+
+
+__all__ = ["TsvLoaderWorker"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.1.4"
+version = "1.2.0"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.2"
+version = "1.2.3"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ dependencies = [
     "numpy>=1.26,<3.0",
     "joblib>=1.3,<=1.5.3",
 
+    # System info (CPU thread count, total RAM) shown in Settings and used
+    # to cap the parallel-workers spinboxes. Already pulled in transitively
+    # by joblib/loky; declared explicitly so the cap never silently breaks.
+    "psutil>=5.9,<=7.0.0",
+
     # Editor viewer.
     "pyqtgraph>=0.13,<=0.14.0",
     "PyOpenGL>=3.1,<=3.1.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.1"
+version = "1.2.2"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"
@@ -78,7 +78,8 @@ dependencies = [
     # by joblib/loky; declared explicitly so the cap never silently breaks.
     "psutil>=5.9,<=7.0.0",
 
-    # Editor viewer.
+    # Editor viewer (NIfTI slices + MEG/EEG time-series + PSD, all
+    # rendered in-app with pyqtgraph - no matplotlib dependency).
     "pyqtgraph>=0.13,<=0.14.0",
     "PyOpenGL>=3.1,<=3.1.10",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ Tracker       = "https://github.com/ANCPLabOldenburg/BIDS-Manager/issues"
 # ``import sklearn``).
 [project.scripts]
 bidsmgr           = "bidsmgr.main:main"
+bidsmgr-create    = "bidsmgr.cli.create:main"
 bidsmgr-scan      = "bidsmgr.cli.scan:main"
 bidsmgr-convert   = "bidsmgr.cli.convert:main"
 bidsmgr-rebuild   = "bidsmgr.cli.rebuild:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.0"
+version = "1.2.1"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"
@@ -110,6 +110,7 @@ Tracker       = "https://github.com/ANCPLabOldenburg/BIDS-Manager/issues"
 [project.scripts]
 bidsmgr           = "bidsmgr.main:main"
 bidsmgr-create    = "bidsmgr.cli.create:main"
+bidsmgr-project   = "bidsmgr.cli.project:main"
 bidsmgr-scan      = "bidsmgr.cli.scan:main"
 bidsmgr-convert   = "bidsmgr.cli.convert:main"
 bidsmgr-rebuild   = "bidsmgr.cli.rebuild:main"

--- a/tests/gui/test_bulk_edit.py
+++ b/tests/gui/test_bulk_edit.py
@@ -83,12 +83,15 @@ def test_bulk_set_subject_updates_bids_name_and_basename() -> None:
         assert json.loads(ent)["subject"] == "099"
 
 
-def test_bulk_set_dataset_applies_to_every_row() -> None:
+def test_bulk_set_dataset_is_blocked() -> None:
+    # The dataset column is owned by the project / locked output folder and is
+    # read-only; bulk-editing it must be a no-op (nothing changed).
     df = make_df([_row(series_uid=str(i)) for i in range(3)])
     model = InventoryTableModel(df)
+    assert "dataset" not in model.BULK_EDITABLE_KEYS
     n = model.bulk_set([0, 1, 2], "dataset", "other_study")
-    assert n == 3
-    assert (model.dataframe()["dataset"] == "other_study").all()
+    assert n == 0
+    assert (model.dataframe()["dataset"] == "study").all()  # unchanged
 
 
 def test_bulk_set_task_rebuilds_basename() -> None:
@@ -146,16 +149,17 @@ def test_dialog_apply_writes_through_bulk_set(qtbot) -> None:
 
     dlg = BulkEditDialog(model, rows=[0, 1, 2])
     qtbot.addWidget(dlg)
-    # Pick the dataset column from the dropdown (find by user data).
+    # Pick the task column from the dropdown (find by user data). The dataset
+    # column is intentionally not offered (read-only / project-owned).
     for i in range(dlg._col_combo.count()):
-        if dlg._col_combo.itemData(i) == "dataset":
+        if dlg._col_combo.itemData(i) == "task":
             dlg._col_combo.setCurrentIndex(i)
             break
-    dlg._value_edit.setText("other_study")
+    dlg._value_edit.setText("memory")
     dlg._on_apply()
 
     assert dlg.changed_count() == 3
-    assert (model.dataframe()["dataset"] == "other_study").all()
+    assert (model.dataframe()["task"] == "memory").all()
 
 
 def test_dialog_blank_value_is_a_noop(qtbot) -> None:

--- a/tests/gui/test_bulk_edit.py
+++ b/tests/gui/test_bulk_edit.py
@@ -218,3 +218,59 @@ def test_bulk_btn_enables_with_multi_selection(qtbot, tmp_path) -> None:
         )
     assert sorted(panel._selected_rows()) == [0, 2]
     assert panel._bulk_btn.isEnabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Constrained-choice columns -> dropdown-only (never free-typed)
+# ---------------------------------------------------------------------------
+
+
+def _select_column(dlg, key) -> None:
+    for i in range(dlg._col_combo.count()):
+        if dlg._col_combo.itemData(i) == key:
+            dlg._col_combo.setCurrentIndex(i)
+            break
+    dlg._on_column_changed(dlg._col_combo.currentIndex())
+
+
+def test_dialog_line_freq_is_fixed_dropdown(qtbot) -> None:
+    df = make_df([_row(proposed_datatype="eeg", series_uid="", source_file="a.edf",
+                       line_freq="", proposed_basename="sub-001_task-rest_eeg")])
+    model = InventoryTableModel(df)
+    dlg = BulkEditDialog(model, rows=[0])
+    qtbot.addWidget(dlg)
+    _select_column(dlg, "line_freq")
+    assert dlg._value_is_combo is True
+    assert dlg._value_combo.isEditable() is False  # dropdown-only
+    items = [dlg._value_combo.itemText(i) for i in range(dlg._value_combo.count())]
+    assert items == ["50", "60"]
+
+
+def test_dialog_montage_is_dropdown(qtbot) -> None:
+    df = make_df([_row(proposed_datatype="eeg", series_uid="", source_file="a.edf",
+                       montage="", proposed_basename="sub-001_task-rest_eeg")])
+    model = InventoryTableModel(df)
+    dlg = BulkEditDialog(model, rows=[0])
+    qtbot.addWidget(dlg)
+    _select_column(dlg, "montage")
+    assert dlg._value_is_combo is True
+    assert dlg._value_combo.isEditable() is False
+    assert dlg._value_combo.count() > 0
+
+
+def test_dialog_apply_combo_value(qtbot) -> None:
+    df = make_df([
+        _row(proposed_datatype="eeg", series_uid="", source_file="a.edf",
+             line_freq="", proposed_basename="sub-001_task-rest_eeg"),
+        _row(BIDS_name="sub-002", proposed_datatype="eeg", series_uid="",
+             source_file="b.edf", line_freq="",
+             proposed_basename="sub-002_task-rest_eeg"),
+    ])
+    model = InventoryTableModel(df)
+    dlg = BulkEditDialog(model, rows=[0, 1])
+    qtbot.addWidget(dlg)
+    _select_column(dlg, "line_freq")
+    dlg._value_combo.setCurrentText("60")
+    dlg._on_apply()
+    assert dlg.changed_count() == 2
+    assert (model.dataframe()["line_freq"] == "60").all()

--- a/tests/gui/test_column_manager.py
+++ b/tests/gui/test_column_manager.py
@@ -76,6 +76,29 @@ def test_set_columns_visible_applies_and_forces_mandatory(qtbot, isolated_settin
     assert panel._table.columnWidth(idx_pid) > 0      # revealed with a width
 
 
+def test_studydescription_is_hidden_toggleable_column(qtbot, isolated_settings) -> None:
+    # Registered, read-only, hidden by default, and described - so it appears in
+    # Manage columns as an off-by-default toggle the user can switch on.
+    spec = next((c for c in COLUMNS if c.key == "StudyDescription"), None)
+    assert spec is not None
+    assert spec.default_visible is False
+    assert spec.editable is False
+    assert COLUMN_DESCRIPTIONS.get("StudyDescription")
+    assert "StudyDescription" not in MANDATORY_COLUMN_KEYS
+
+    # The user can reveal it from Manage columns, and it shows the value.
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    df = _df()
+    df["StudyDescription"] = "PPMI"
+    panel.load_inventory(df, None)
+    mapping = {c.key: c.default_visible for c in COLUMNS}
+    mapping["StudyDescription"] = True
+    panel.set_columns_visible(mapping)
+    idx = next(i for i, c in enumerate(COLUMNS) if c.key == "StudyDescription")
+    assert not panel._table.isColumnHidden(idx)
+
+
 def test_all_columns_are_user_resizable(qtbot) -> None:
     """Every column is Interactive (independently resizable); the table uses
     stretch-last-section + horizontal scroll instead of a greedy stretch

--- a/tests/gui/test_column_manager.py
+++ b/tests/gui/test_column_manager.py
@@ -1,0 +1,113 @@
+"""Tests for the Manage-columns dialog + column resize behaviour."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+from PyQt6.QtWidgets import QHeaderView
+
+from bidsmgr.gui.column_manager_dialog import ColumnManagerDialog
+from bidsmgr.gui.converter_panel import ConverterPanel
+from bidsmgr.gui.models import COLUMN_DESCRIPTIONS, COLUMNS, MANDATORY_COLUMN_KEYS
+
+pytestmark = pytest.mark.gui
+
+
+def test_every_column_has_a_description() -> None:
+    missing = [c.key for c in COLUMNS if not COLUMN_DESCRIPTIONS.get(c.key)]
+    assert missing == [], f"columns without a description: {missing}"
+
+
+def test_dialog_result_keeps_mandatory_visible(qtbot) -> None:
+    current = {c.key: c.default_visible for c in COLUMNS}
+    dlg = ColumnManagerDialog(current, None)
+    qtbot.addWidget(dlg)
+    # Try to hide everything; mandatory columns must stay on.
+    dlg._set_all(False)
+    res = dlg.result_visibility()
+    for key in MANDATORY_COLUMN_KEYS:
+        assert res[key] is True
+
+
+def test_dialog_select_all_and_defaults(qtbot) -> None:
+    current = {c.key: c.default_visible for c in COLUMNS}
+    dlg = ColumnManagerDialog(current, None)
+    qtbot.addWidget(dlg)
+    dlg._set_all(True)
+    res = dlg.result_visibility()
+    assert all(res[c.key] for c in COLUMNS)  # everything on
+    dlg._restore_defaults()
+    res = dlg.result_visibility()
+    for c in COLUMNS:
+        if c.key in MANDATORY_COLUMN_KEYS:
+            assert res[c.key] is True
+        else:
+            assert res[c.key] == c.default_visible
+
+
+def _df() -> pd.DataFrame:
+    return pd.DataFrame([{
+        "BIDS_name": "sub-001", "session": "", "include": 1, "modality": "mri",
+        "proposed_datatype": "anat", "proposed_basename": "sub-001_T1w",
+        "Proposed BIDS name": "sub-001_T1w", "bids_guess_suffix": "T1w",
+        "bids_guess_confidence": "0.9", "bids_guess_skip": False,
+        "proposed_issues": "", "entities": json.dumps({"subject": "001"}),
+        "task": "", "run": "", "series_uid": "1.1", "PatientID": "P1",
+        "n_files": "100", "dataset": "D",
+    }])
+
+
+def test_set_columns_visible_applies_and_forces_mandatory(qtbot, isolated_settings) -> None:
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    panel.load_inventory(_df(), None)
+
+    mapping = {c.key: c.default_visible for c in COLUMNS}
+    mapping["PatientID"] = True   # reveal a hidden column
+    mapping["id"] = False         # attempt to hide a mandatory column
+    panel.set_columns_visible(mapping)
+
+    idx_pid = next(i for i, c in enumerate(COLUMNS) if c.key == "PatientID")
+    idx_id = next(i for i, c in enumerate(COLUMNS) if c.key == "id")
+    assert not panel._table.isColumnHidden(idx_pid)   # revealed
+    assert not panel._table.isColumnHidden(idx_id)    # mandatory stayed visible
+    assert panel._table.columnWidth(idx_pid) > 0      # revealed with a width
+
+
+def test_all_columns_are_user_resizable(qtbot) -> None:
+    """Every column is Interactive (independently resizable); the table uses
+    stretch-last-section + horizontal scroll instead of a greedy stretch
+    column, so even the predicted-basename column can be shrunk / widened."""
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    panel.load_inventory(_df(), None)
+    header = panel._table.horizontalHeader()
+    for col in range(len(COLUMNS)):
+        assert header.sectionResizeMode(col) == QHeaderView.ResizeMode.Interactive
+    assert header.stretchLastSection() is True
+    assert header.sectionsMovable() is True
+
+
+def test_column_order_persists_and_restores(qtbot, isolated_settings) -> None:
+    """Dragging a header section persists the order; a fresh panel restores it."""
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    panel.load_inventory(_df(), None)
+    header = panel._table.horizontalHeader()
+    task_logical = next(i for i, c in enumerate(COLUMNS) if c.key == "task")
+    header.moveSection(header.visualIndex(task_logical), 3)
+
+    panel2 = ConverterPanel()
+    qtbot.addWidget(panel2)
+    panel2.load_inventory(_df(), None)
+    assert panel2._table.horizontalHeader().visualIndex(task_logical) == 3
+
+
+def test_double_click_autofit_does_not_crash(qtbot) -> None:
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    panel.load_inventory(_df(), None)
+    for col, spec in enumerate(COLUMNS):
+        panel._table_resize_column_to_contents(col)  # incl. the stretch col

--- a/tests/gui/test_converter_panel.py
+++ b/tests/gui/test_converter_panel.py
@@ -40,9 +40,12 @@ def test_panel_constructs_without_a_project(qtbot) -> None:
     qtbot.addWidget(panel)
     # No model until the first scan.
     assert panel.model() is None
-    # Scan button is enabled at start; Run-conversion is gated.
-    assert panel._scan_btn.isEnabled()
+    # Project-first gate: with no active project, Scan / Run / the raw + BIDS
+    # change buttons are all disabled until a dataset is opened on Home.
+    assert not panel._scan_btn.isEnabled()
     assert not panel._run_btn.isEnabled()
+    assert not panel._raw_pathbar.change_button.isEnabled()
+    assert not panel._bids_pathbar.change_button.isEnabled()
 
 
 def test_panel_renders_under_offscreen_qpa(qtbot) -> None:
@@ -204,11 +207,25 @@ def test_per_row_acq_override_persists_scaffold(qtbot, tmp_path: Path) -> None:
     assert data["overrides"]["sub-001/rec.edf"]["manufacturer"] == "BioSemi"
 
 
-def test_bids_pathbar_change_button_is_enabled(qtbot) -> None:
-    """The user must be able to pick the BIDS output before scanning."""
+def test_no_project_gate_blocks_then_set_project_ungates(qtbot, tmp_path) -> None:
+    """With no project the raw/BIDS/Scan controls are blocked; opening a project
+    un-gates raw input + Scan and locks the BIDS output to the project root."""
+    from bidsmgr.cli.create import open_or_create_workspace
     panel = ConverterPanel()
     qtbot.addWidget(panel)
-    assert panel._bids_pathbar.change_button.isEnabled()
+    # Gated before any project.
+    assert not panel._raw_pathbar.change_button.isEnabled()
+    assert not panel._bids_pathbar.change_button.isEnabled()
+    assert not panel._scan_btn.isEnabled()
+
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    panel.set_project(proj, root)
+    # Raw input + Scan enabled; BIDS output locked to the project (disabled).
+    assert panel._raw_pathbar.change_button.isEnabled()
+    assert panel._scan_btn.isEnabled()
+    assert not panel._bids_pathbar.change_button.isEnabled()
+    assert str(root) in panel._bids_pathbar.value()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_converter_panel.py
+++ b/tests/gui/test_converter_panel.py
@@ -140,6 +140,43 @@ def test_load_inventory_does_not_overwrite_user_set_bids_output(qtbot, tmp_path:
     assert str(chosen) in panel._bids_pathbar.value()
 
 
+def _eeg_row() -> dict:
+    return {
+        "BIDS_name": "sub-001", "session": "", "include": 1, "modality": "eeg",
+        "proposed_datatype": "eeg", "bids_guess_suffix": "eeg",
+        "proposed_basename": "sub-001_task-rest_eeg",
+        "entities": json.dumps({"subject": "001", "task": "rest"}, sort_keys=True),
+        "task": "rest", "run": "", "series_uid": "",
+        "source_file": "sub-001/rec.edf",
+        "montage": "", "line_freq": "", "eeg_reference": "", "eeg_ground": "",
+        "proposed_issues": "", "bids_guess_skip": False,
+    }
+
+
+def test_per_row_acq_override_persists_scaffold(qtbot, tmp_path: Path) -> None:
+    """A per-row device override is written to the scaffold beside the TSV so
+    the convert verb (which reloads it) sees the edit."""
+    import json as _json
+    from bidsmgr.recording_meta import (
+        AcquisitionSpec, RecordingMetaSpec, scaffold_sidecar_path,
+    )
+
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    out_tsv = tmp_path / "inv.tsv"
+    panel.load_inventory(pd.DataFrame([_eeg_row()]), output_tsv=out_tsv)
+
+    m = panel.model()
+    m.set_global_spec(RecordingMetaSpec(defaults=AcquisitionSpec(manufacturer="Brain Products")))
+    # Override the manufacturer for row 0 -> triggers recordingSpecChanged.
+    m.set_acq_override(0, "manufacturer", "BioSemi")
+
+    scaffold = scaffold_sidecar_path(out_tsv)
+    assert scaffold.exists()
+    data = _json.loads(scaffold.read_text())
+    assert data["overrides"]["sub-001/rec.edf"]["manufacturer"] == "BioSemi"
+
+
 def test_bids_pathbar_change_button_is_enabled(qtbot) -> None:
     """The user must be able to pick the BIDS output before scanning."""
     panel = ConverterPanel()
@@ -172,6 +209,28 @@ def test_start_scan_on_empty_dir_finishes_and_loads_empty_model(qtbot, tmp_path:
     assert panel.model().rowCount() == 0
     assert panel._scan_btn.isEnabled(), "Scan button should re-enable on completion"
     assert out_tsv.exists()
+
+
+def test_fresh_scan_resets_stale_recording_meta_scaffold(qtbot, tmp_path: Path) -> None:
+    """A new scan must not inherit the previous dataset's metadata: the stale
+    scaffold at the output path is removed so it re-seeds from the new data."""
+    from bidsmgr.recording_meta import scaffold_sidecar_path
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    out_tsv = tmp_path / "inv.tsv"
+    # Simulate a leftover scaffold from a PREVIOUS (different) dataset.
+    stale = scaffold_sidecar_path(out_tsv)
+    stale.write_text('{"schema_version": 1, "defaults": {"manufacturer": "OldVendor"}}',
+                     encoding="utf-8")
+    with qtbot.waitSignal(panel.scan_finished, timeout=60_000):
+        worker = panel.start_scan(raw, out_tsv, n_jobs=1)
+    worker.wait()
+    qtbot.wait(50)
+    # The empty scan detects nothing to seed, so the stale scaffold is simply
+    # gone (not carried over).
+    assert not stale.exists()
 
 
 def test_scan_button_becomes_stop_and_locks_run_while_scan_runs(qtbot, tmp_path: Path) -> None:

--- a/tests/gui/test_converter_panel.py
+++ b/tests/gui/test_converter_panel.py
@@ -174,7 +174,7 @@ def test_start_scan_on_empty_dir_finishes_and_loads_empty_model(qtbot, tmp_path:
     assert out_tsv.exists()
 
 
-def test_scan_button_disabled_while_scan_runs(qtbot, tmp_path: Path) -> None:
+def test_scan_button_becomes_stop_and_locks_run_while_scan_runs(qtbot, tmp_path: Path) -> None:
     panel = ConverterPanel()
     qtbot.addWidget(panel)
 
@@ -182,13 +182,19 @@ def test_scan_button_disabled_while_scan_runs(qtbot, tmp_path: Path) -> None:
     raw.mkdir()
 
     worker = panel.start_scan(raw, tmp_path / "inv.tsv", n_jobs=1)
-    # While the worker is alive the button is disabled.
-    assert not panel._scan_btn.isEnabled()
+    # While the worker is alive the Scan button stays enabled but reads
+    # "Stop scanning"; the Run button is locked out (mutual exclusion).
+    assert panel._scan_btn.isEnabled()
+    assert "Stop" in panel._scan_btn.text()
+    assert not panel._run_btn.isEnabled()
     with qtbot.waitSignal(panel.scan_finished, timeout=60_000):
         pass
     worker.wait()
     qtbot.wait(50)
+    # On completion it reverts to "Scan…".
     assert panel._scan_btn.isEnabled()
+    assert "Scan" in panel._scan_btn.text()
+    assert "Stop" not in panel._scan_btn.text()
 
 
 def test_log_messages_forwarded_to_panel_signal(qtbot, tmp_path: Path) -> None:
@@ -237,56 +243,35 @@ def test_panel_uses_attached_project_for_edits(qtbot, tmp_path: Path) -> None:
 
 
 def test_bottom_dock_split_layout(qtbot) -> None:
-    """Bottom dock is now a horizontal splitter with two QTabWidgets:
-    Log + Conflicts on the left, BIDS preview + Statistics on the right.
+    """Bottom dock is a horizontal splitter of two detach-only PanelFrames,
+    each wrapping a QTabWidget: Log on the left, BIDS preview + Statistics
+    on the right. The whole dock is wrapped in a collapse-to-bottom frame.
     """
-    from PyQt6.QtWidgets import QSplitter, QTabWidget
-
     panel = ConverterPanel()
     qtbot.addWidget(panel)
 
-    # The dock is now a QSplitter (not the original single QTabWidget).
-    # Locate it via the _log_view + _bids_preview children whose
-    # ancestors must include the dock.
-    def _ancestors(w):
-        cur = w
-        while cur is not None:
-            yield cur
-            cur = cur.parent()
-
-    log_ancestors = set(id(a) for a in _ancestors(panel._log_view))
-    preview_ancestors = set(id(a) for a in _ancestors(panel._bids_preview))
-
-    # Find the *common* QSplitter ancestor — that's the dock.
-    common = log_ancestors & preview_ancestors
-    splitters = [
-        w for w in panel.findChildren(QSplitter)
-        if id(w) in common
-    ]
-    # The vertical splitter (top half vs dock) is also a common ancestor;
-    # the horizontal one is the dock itself. Pick the horizontal one.
-    horizontal_splitters = [
-        s for s in splitters if s.orientation().name == "Horizontal"
-    ]
-    assert horizontal_splitters, "expected at least one horizontal splitter"
-    # The dock-level horizontal splitter holds exactly two QTabWidgets.
-    dock_candidates = [
-        s for s in horizontal_splitters
-        if s.count() == 2 and all(
-            isinstance(s.widget(i), QTabWidget) for i in range(2)
-        )
-    ]
-    assert dock_candidates, "expected the dock to be a QSplitter with 2 QTabWidgets"
-
-    dock = dock_candidates[0]
-    left_tabs = dock.widget(0)
-    right_tabs = dock.widget(1)
+    # The dock's two tab groups are wrapped in detach PanelFrames; read the
+    # tab titles directly off the (kept) QTabWidget references.
+    left_tabs = panel._left_tabs
+    right_tabs = panel._right_tabs
     left_titles = [left_tabs.tabText(i) for i in range(left_tabs.count())]
     right_titles = [right_tabs.tabText(i) for i in range(right_tabs.count())]
     assert any("Log" in t for t in left_titles)
-    assert any("Conflicts" in t for t in left_titles)
+    # The Conflicts tab was removed; Log is the only left-hand tab now.
+    assert not any("Conflicts" in t for t in left_titles)
     assert any("BIDS preview" in t for t in right_titles)
     assert any("Statistics" in t for t in right_titles)
+
+    # The Log + preview groups are each independently detachable, and the
+    # whole dock collapses toward the bottom.
+    assert panel._log_frame.is_detached() is False
+    assert panel._preview_frame.is_detached() is False
+    panel._log_frame.detach()
+    assert panel._log_frame.is_detached() is True
+    panel._log_frame.reattach()
+    assert panel._dock_frame.is_collapsed() is False
+    panel._dock_frame.set_collapsed(True)
+    assert panel._dock_frame.is_collapsed() is True
 
 
 def test_log_tab_appends_progress_messages(qtbot) -> None:

--- a/tests/gui/test_converter_panel.py
+++ b/tests/gui/test_converter_panel.py
@@ -120,6 +120,33 @@ def test_load_inventory_updates_status_chips(qtbot, tmp_path: Path) -> None:
     assert "1 skipped" in panel._chip_skip.text()
 
 
+def test_revalidate_button_enables_after_scan_and_refreshes_chips(
+    qtbot, tmp_path: Path,
+) -> None:
+    panel = ConverterPanel()
+    qtbot.addWidget(panel)
+    # Disabled before any scan.
+    assert not panel._revalidate_btn.isEnabled()
+
+    # A func/bold row missing its required task -> err.
+    row = _func_row()
+    row["entities"] = json.dumps({"subject": "001", "session": "pre"}, sort_keys=True)
+    row["task"] = ""
+    panel.load_inventory(pd.DataFrame([row]), output_tsv=tmp_path / "inv.tsv")
+    assert panel._revalidate_btn.isEnabled()  # available after scan
+    assert "1 error" in panel._chip_err.text()
+
+    # Simulate a fix that bypassed setData (edit elsewhere), then re-validate:
+    df = panel.model().dataframe()
+    df.at[0, "task"] = "rest"
+    df.at[0, "entities"] = json.dumps(
+        {"subject": "001", "session": "pre", "task": "rest"}, sort_keys=True,
+    )
+    panel._on_revalidate_clicked()
+    assert "0 error" in panel._chip_err.text()
+    assert "1 valid" in panel._chip_valid.text()
+
+
 def test_load_inventory_does_not_overwrite_user_set_bids_output(qtbot, tmp_path: Path) -> None:
     """BIDS output stays whatever the user set (or '(not set)' if unset).
 

--- a/tests/gui/test_editor_interactivity.py
+++ b/tests/gui/test_editor_interactivity.py
@@ -285,3 +285,32 @@ def test_fix_request_focuses_field_in_sidecar_form(
     # ``selectAll`` was called as part of focus_field — the editor
     # shows the existing value pre-selected for easy overwrite.
     assert editor.selectedText() == editor.text()
+
+
+def test_editor_undo_redo_buttons_follow_active_pane(qapp, tmp_path: Path) -> None:
+    """The Editor's Undo/Redo buttons delegate to the active editable pane and
+    sync their enabled-state with that pane's history."""
+    import json
+    panel = EditorPanel()
+    qapp.processEvents()
+
+    # No undoable pane yet (NIfTI placeholder / nothing).
+    assert not panel._undo_btn.isEnabled()
+    assert not panel._redo_btn.isEnabled()
+
+    # Point the sidecar pane at a JSON and make it the active center widget.
+    js = tmp_path / "sub-01_task-x_bold.json"
+    js.write_text(json.dumps({"TaskName": "rest"}), encoding="utf-8")
+    panel._sidecar_form.set_file(js, tmp_path, None)
+    panel._center_stack.setCurrentWidget(panel._sidecar_form)
+    qapp.processEvents()
+    assert not panel._undo_btn.isEnabled()  # no edits yet
+
+    panel._sidecar_form._on_field_committed("TaskName", "memory", "str")
+    qapp.processEvents()
+    assert panel._undo_btn.isEnabled()
+
+    panel._on_editor_undo()
+    qapp.processEvents()
+    assert panel._sidecar_form._json_cache["TaskName"] == "rest"
+    assert panel._redo_btn.isEnabled()

--- a/tests/gui/test_editor_tree.py
+++ b/tests/gui/test_editor_tree.py
@@ -202,6 +202,90 @@ def test_set_root_none_clears(qapp, bids_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Live refresh (parity with the Converter's output tree)
+# ---------------------------------------------------------------------------
+
+
+def _find_item(tree, label: str):
+    found = []
+
+    def visit(item) -> None:
+        if item.text(0) == label:
+            found.append(item)
+        for i in range(item.childCount()):
+            visit(item.child(i))
+
+    for i in range(tree.topLevelItemCount()):
+        visit(tree.topLevelItem(i))
+    return found[0] if found else None
+
+
+def test_refresh_picks_up_new_files(qapp, bids_root: Path) -> None:
+    pane = BidsTreePane()
+    pane.set_root(bids_root)
+    assert _find_item(pane._tree, "sub-01_ses-01_bold.nii.gz") is None
+
+    # A new file lands on disk (e.g. a conversion writing into the open root).
+    func = bids_root / "sub-01" / "ses-01" / "func"
+    func.mkdir(parents=True)
+    (func / "sub-01_ses-01_bold.nii.gz").write_bytes(b"")
+    pane.refresh()
+
+    assert _find_item(pane._tree, "sub-01_ses-01_bold.nii.gz") is not None
+
+
+def test_refresh_preserves_expansion_and_selection(qapp, bids_root: Path) -> None:
+    pane = BidsTreePane()
+    pane.set_root(bids_root)
+
+    # Collapse the root, then expand + select a deep row.
+    pane._tree.topLevelItem(0).setExpanded(False)
+    target = _find_item(pane._tree, "anat")
+    assert target is not None
+    target.setExpanded(True)
+    json_item = _find_item(pane._tree, "sub-01_ses-01_T1w.json")
+    pane._tree.setCurrentItem(json_item)
+
+    # A live refresh must not collapse the user's view or drop the selection.
+    pane.refresh()
+
+    assert not pane._tree.topLevelItem(0).isExpanded()  # root stays collapsed
+    assert _find_item(pane._tree, "anat").isExpanded()
+    cur = pane._tree.currentItem()
+    assert cur is not None and cur.text(0) == "sub-01_ses-01_T1w.json"
+
+
+def test_set_root_same_path_preserves_view(qapp, bids_root: Path) -> None:
+    """Re-setting the already-open root must not collapse the user's view
+    (it routes through refresh), mirroring the output tree."""
+    pane = BidsTreePane()
+    pane.set_root(bids_root)
+    # Collapse the root the user opened.
+    pane._tree.topLevelItem(0).setExpanded(False)
+    anat = _find_item(pane._tree, "anat")
+    anat.setExpanded(True)
+
+    pane.set_root(bids_root)  # same path -> preserve, not reset
+
+    assert not pane._tree.topLevelItem(0).isExpanded()
+    assert _find_item(pane._tree, "anat").isExpanded()
+
+
+def test_refresh_reapplies_badges(qapp, bids_root: Path) -> None:
+    from bidsmgr.gui.delegates.bids_tree import BADGE_ROLE
+
+    pane = BidsTreePane()
+    pane.set_root(bids_root)
+    json_path = bids_root / "sub-01" / "ses-01" / "anat" / "sub-01_ses-01_T1w.json"
+    pane.set_badges({json_path: "err"})
+    assert _find_item(pane._tree, "sub-01_ses-01_T1w.json").data(0, BADGE_ROLE) == "err"
+
+    # Live refresh rebuilds the items; the cached badge must survive.
+    pane.refresh()
+    assert _find_item(pane._tree, "sub-01_ses-01_T1w.json").data(0, BADGE_ROLE) == "err"
+
+
+# ---------------------------------------------------------------------------
 # EditorPanel
 # ---------------------------------------------------------------------------
 

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -262,6 +262,51 @@ def test_status_kind_ok_for_valid_mri_row() -> None:
     assert model.data(model.index(0, status_col), PAYLOAD_ROLE) == "ok"
 
 
+def test_row_state_noimg_for_nonimage_series() -> None:
+    """A DERIVED non-image series (flagged by the scanner with the
+    ``non-image series`` token) reads as ``noimg`` — taking priority over
+    the ``skip`` it would otherwise get for being excluded (include=0)."""
+    df = make_df([_ok_row(
+        include=0,
+        bids_guess_skip=True,
+        proposed_issues=(
+            "non-image series: the DICOM headers carry no pixel data "
+            "(Rows/Columns absent), so dcm2niix cannot convert it. "
+            "Excluded from conversion."
+        ),
+    )])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == "noimg"
+
+
+def test_status_kind_noimg_for_nonimage_series() -> None:
+    df = make_df([_ok_row(
+        include=0, bids_guess_skip=True,
+        proposed_issues="non-image series: no pixel data; excluded.",
+    )])
+    model = InventoryTableModel(df)
+    status_col = next(i for i, c in enumerate(COLUMNS) if c.key == "status")
+    assert model.data(model.index(0, status_col), PAYLOAD_ROLE) == "noimg"
+
+
+def test_tooltip_surfaces_proposed_issues() -> None:
+    """Hovering any cell of a flagged row shows the scanner's reason."""
+    df = make_df([_ok_row(
+        proposed_issues="non-image series: no pixel data | trivial: few files",
+    )])
+    model = InventoryTableModel(df)
+    tip = model.data(model.index(0, 1), Qt.ItemDataRole.ToolTipRole)
+    assert tip is not None and "non-image series" in tip
+    # `` | ``-joined notes are split onto separate lines for readability.
+    assert "\n" in tip
+
+
+def test_no_tooltip_when_no_issues() -> None:
+    df = make_df([_ok_row(proposed_issues="")])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 1), Qt.ItemDataRole.ToolTipRole) is None
+
+
 def test_include_payload_reads_dataframe() -> None:
     df = make_df([_ok_row(include=1), _ok_row(include=0)])
     model = InventoryTableModel(df)

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -548,3 +548,69 @@ def test_model_renders_in_real_qtableview(qtbot) -> None:
     # If we got here, the model + delegates rendered with no Qt errors.
     assert view.model() is model
     assert view.model().rowCount() == 5
+
+
+# ---------------------------------------------------------------------------
+# Recording-metadata inheritance (global default <- per-row override)
+# ---------------------------------------------------------------------------
+
+
+def _eeg_inherit_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"BIDS_name": "sub-001", "proposed_datatype": "eeg", "bids_guess_suffix": "eeg",
+         "source_file": "a.edf", "proposed_basename": "sub-001_task-rest_eeg",
+         "entities": json.dumps({"subject": "001", "task": "rest"}),
+         "line_freq": "", "montage": "", "eeg_reference": "", "eeg_ground": "", "include": 1},
+        {"BIDS_name": "sub-002", "proposed_datatype": "eeg", "bids_guess_suffix": "eeg",
+         "source_file": "b.edf", "proposed_basename": "sub-002_task-rest_eeg",
+         "entities": json.dumps({"subject": "002", "task": "rest"}),
+         "line_freq": "60", "montage": "", "eeg_reference": "", "eeg_ground": "", "include": 1},
+    ])
+
+
+def _col_index(key: str) -> int:
+    return next(i for i, c in enumerate(COLUMNS) if c.key == key)
+
+
+def _spec(line_freq):
+    from bidsmgr.recording_meta import AcquisitionSpec, RecordingMetaSpec
+    return RecordingMetaSpec(defaults=AcquisitionSpec(power_line_freq=line_freq))
+
+
+def test_inheritance_blank_cell_shows_global_default() -> None:
+    from bidsmgr.gui.delegates import INHERITED_ROLE
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_spec(50.0))
+    col = _col_index("line_freq")
+    idx0 = m.index(0, col)
+    assert m.data(idx0, Qt.ItemDataRole.DisplayRole) == "50"  # inherited from global
+    assert m.data(idx0, INHERITED_ROLE) is True
+    # Row 1 has an explicit override -> shown as-is, not inherited.
+    idx1 = m.index(1, col)
+    assert m.data(idx1, Qt.ItemDataRole.DisplayRole) == "60"
+    assert m.data(idx1, INHERITED_ROLE) is False
+
+
+def test_inheritance_set_equal_global_clears_override() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_spec(50.0))
+    col = _col_index("line_freq")
+    # Setting the global value clears the cell back to inherited.
+    m.setData(m.index(0, col), "50")
+    assert m.dataframe().at[0, "line_freq"] == ""
+    assert m.is_inherited(0, "line_freq") is True
+    # A differing value is stored as a real override.
+    m.setData(m.index(0, col), "60")
+    assert m.dataframe().at[0, "line_freq"] == "60"
+    assert m.is_inherited(0, "line_freq") is False
+
+
+def test_inheritance_global_change_reflows_inherited_rows() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_spec(50.0))
+    assert m.effective_value(0, "line_freq") == "50"
+    m.set_global_spec(_spec(60.0))
+    assert m.effective_value(0, "line_freq") == "60"  # inherited row re-flowed
+    # Inert without a spec.
+    m2 = InventoryTableModel(_eeg_inherit_df())
+    assert m2.effective_value(0, "line_freq") == ""

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -200,7 +200,14 @@ def test_id_strips_sub_prefix() -> None:
 
 
 def test_session_strips_ses_prefix_and_dashes_empty() -> None:
-    df = make_df([_ok_row(session="ses-pre"), _ok_row(session="")])
+    # Row 1 has no session at all (entities lacks it) -> empty mirror cell.
+    # The model mirrors entities -> cells on load, so a row whose entities
+    # carry a session always shows it; only a genuinely session-less row
+    # renders "—".
+    df = make_df([
+        _ok_row(session="ses-pre"),
+        _ok_row(session="", entities=json.dumps({"subject": "001"}, sort_keys=True)),
+    ])
     model = InventoryTableModel(df)
     col = next(i for i, c in enumerate(COLUMNS) if c.key == "ses")
     assert model.data(model.index(0, col), Qt.ItemDataRole.DisplayRole) == "pre"
@@ -345,6 +352,68 @@ def test_setdata_same_value_is_noop() -> None:
     model = InventoryTableModel(df)
     task_col = next(i for i, c in enumerate(COLUMNS) if c.key == "task")
     assert model.setData(model.index(0, task_col), "rest") is False
+
+
+def test_editing_task_preserves_run_entity() -> None:
+    """Regression: a fresh scan TSV carries entities in JSON but leaves the
+    mirror cells (task / run / session) blank. Editing one mirror cell must
+    not delete the others. Previously, changing ``task`` ran
+    ``rebuild_from_columns`` which saw the blank ``run`` cell and dropped
+    ``run`` from the entities, so ``sub-001_task-X_run-1_bold`` lost its run.
+    """
+    # Mirror cells deliberately blank, entities holds run+task (real scan shape).
+    row = _ok_row(
+        proposed_datatype="func",
+        bids_guess_datatype="func",
+        bids_guess_suffix="bold",
+        proposed_basename="sub-001_task-dmaging_run-1_bold",
+        task="",   # blank mirror cell, as a fresh scan TSV leaves it
+        run="",
+        session="",
+        entities=json.dumps(
+            {"subject": "001", "task": "dmaging", "run": "1"},
+            sort_keys=True,
+        ),
+    )
+    model = InventoryTableModel(make_df([row]))
+
+    # The load pass should have mirrored entities → cells.
+    assert model.entities(0).get("run") == "1"
+
+    task_col = next(i for i, c in enumerate(COLUMNS) if c.key == "task")
+    bn_col = next(i for i, c in enumerate(COLUMNS) if c.key == "basename")
+    assert model.setData(model.index(0, task_col), "newtask") is True
+
+    new_bn = model.data(model.index(0, bn_col), Qt.ItemDataRole.DisplayRole)
+    assert "task-newtask" in new_bn
+    assert "run-1" in new_bn          # run entity survived the task edit
+    assert model.entities(0).get("run") == "1"
+
+
+def test_bulk_edit_task_preserves_run_across_rows() -> None:
+    """The same guarantee via the bulk-edit path (``bulk_set``)."""
+    rows = [
+        _ok_row(
+            proposed_datatype="func",
+            bids_guess_datatype="func",
+            bids_guess_suffix="bold",
+            proposed_basename=f"sub-001_task-dmaging_run-{n}_bold",
+            task="", run="", session="", series_uid=f"uid-{n}",
+            entities=json.dumps(
+                {"subject": "001", "task": "dmaging", "run": str(n)},
+                sort_keys=True,
+            ),
+        )
+        for n in (1, 2, 3)
+    ]
+    model = InventoryTableModel(make_df(rows))
+    changed = model.bulk_set([0, 1, 2], "task", "memory")
+    assert changed == 3
+    bn_col = next(i for i, c in enumerate(COLUMNS) if c.key == "basename")
+    for r, n in zip((0, 1, 2), (1, 2, 3)):
+        bn = model.data(model.index(r, bn_col), Qt.ItemDataRole.DisplayRole)
+        assert "task-memory" in bn
+        assert f"run-{n}" in bn
 
 
 def test_toggling_include_changes_row_state_to_skip() -> None:

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -107,6 +107,13 @@ def _physio_row(**overrides) -> dict:
         BIDS_name="sub-002",
         session="ses-post",
         task="mb",
+        # func/physio requires a task entity; keep the entities JSON in sync
+        # with the mirror cells so live validation reads the row as valid
+        # (status "phys") rather than flagging a missing task.
+        entities=json.dumps(
+            {"subject": "002", "session": "post", "task": "mb"},
+            sort_keys=True,
+        ),
         **overrides,
     )
 
@@ -294,6 +301,83 @@ def test_status_kind_noimg_for_nonimage_series() -> None:
     model = InventoryTableModel(df)
     status_col = next(i for i, c in enumerate(COLUMNS) if c.key == "status")
     assert model.data(model.index(0, status_col), PAYLOAD_ROLE) == "noimg"
+
+
+# ---------------------------------------------------------------------------
+# Live entity-validation (recomputed on every edit)
+# ---------------------------------------------------------------------------
+
+
+def _task_col() -> int:
+    return next(i for i, c in enumerate(COLUMNS) if c.key == "task")
+
+
+def _func_row_missing_task(**overrides) -> dict:
+    """A func/bold row whose entities lack the required task entity."""
+    row = _func_row(**overrides)
+    row["entities"] = json.dumps({"subject": "001", "session": "pre"}, sort_keys=True)
+    row["task"] = ""
+    return row
+
+
+def test_live_validation_flags_func_bold_missing_task() -> None:
+    """A func/bold row whose entities lack the required task reads as err
+    at load (live validation runs on construction, not just on edit)."""
+    df = make_df([_func_row_missing_task()])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == "err"
+
+
+def test_live_validation_clears_error_when_user_supplies_task() -> None:
+    """Editing the missing task to a real value re-validates the row to
+    valid (the chips track the fix)."""
+    df = make_df([_func_row_missing_task()])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == "err"
+    assert model.setData(model.index(0, _task_col()), "rest") is True
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == ""
+
+
+def test_live_validation_introduces_error_when_user_clears_task() -> None:
+    """Clearing a required task on a valid row flips it back to err."""
+    df = make_df([_func_row()])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == ""
+    assert model.setData(model.index(0, _task_col()), "") is True
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == "err"
+
+
+def test_revalidate_all_recomputes_states_after_external_change() -> None:
+    """``revalidate_all`` picks up a change made directly to the DataFrame
+    (an edit path that bypassed setData) -- the Re-validate button's engine."""
+    df = make_df([_func_row()])
+    model = InventoryTableModel(df)
+    assert model.row_state(0) == ""
+    # Mutate the underlying frame directly (no setData / refresh_row).
+    model.dataframe().at[0, "task"] = ""
+    model.dataframe().at[0, "entities"] = json.dumps(
+        {"subject": "001", "session": "pre"}, sort_keys=True,
+    )
+    assert model.row_state(0) == ""  # still stale (no recompute yet)
+    model.revalidate_all()
+    assert model.row_state(0) == "err"  # now reflects the missing task
+
+
+def test_live_validation_preserves_static_scan_notes() -> None:
+    """Recomputing the validation segment must not drop static scan notes
+    (suspected_abort, B0 reroute, collision hints, ...)."""
+    note = "rerouted to fmap/epi: SeriesDescription contains a B0 marker"
+    row = _func_row_missing_task()
+    row["proposed_issues"] = note
+    df = make_df([row])
+    model = InventoryTableModel(df)
+    # Loaded: static note + fresh "task required" error coexist.
+    issues = model.dataframe().at[0, "proposed_issues"]
+    assert note in issues and "required" in issues.lower()
+    # After the user supplies the task, only the static note remains.
+    model.setData(model.index(0, _task_col()), "rest")
+    issues = model.dataframe().at[0, "proposed_issues"]
+    assert issues == note
 
 
 def test_tooltip_surfaces_proposed_issues() -> None:

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -614,3 +614,86 @@ def test_inheritance_global_change_reflows_inherited_rows() -> None:
     # Inert without a spec.
     m2 = InventoryTableModel(_eeg_inherit_df())
     assert m2.effective_value(0, "line_freq") == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-row acquisition overrides (scaffold overrides[row_id]; not TSV columns)
+# ---------------------------------------------------------------------------
+
+
+def _device_spec(**defaults):
+    from bidsmgr.recording_meta import AcquisitionSpec, RecordingMetaSpec
+    return RecordingMetaSpec(defaults=AcquisitionSpec(**defaults))
+
+
+def test_acq_override_inherits_dataset_default() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products", amplifier_model="actiCHamp"))
+    # No per-row override yet -> effective is the dataset default, flagged inherited.
+    assert m.acq_effective(0, "manufacturer") == "Brain Products"
+    assert m.acq_override(0, "manufacturer") == ""
+    assert m.acq_is_inherited(0, "manufacturer") is True
+    assert m.acq_effective(0, "amplifier_model") == "actiCHamp"
+
+
+def test_acq_override_set_stores_in_spec_and_emits(qtbot) -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    with qtbot.waitSignal(m.recordingSpecChanged, timeout=500):
+        assert m.set_acq_override(0, "manufacturer", "BioSemi") is True
+    assert m.acq_override(0, "manufacturer") == "BioSemi"
+    assert m.acq_is_inherited(0, "manufacturer") is False
+    # Stored under the row_id (the EEG source path), not a TSV column.
+    assert m.global_spec().overrides["a.edf"].manufacturer == "BioSemi"
+    assert "manufacturer" not in m.dataframe().columns
+
+
+def test_acq_override_equal_default_clears_to_inherited() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    m.set_acq_override(0, "manufacturer", "BioSemi")
+    # Re-set to the dataset default -> override cleared, row inherits again.
+    assert m.set_acq_override(0, "manufacturer", "Brain Products") is True
+    assert m.acq_override(0, "manufacturer") == ""
+    assert m.acq_is_inherited(0, "manufacturer") is True
+    assert "a.edf" not in m.global_spec().overrides  # empty override dropped
+
+
+def test_acq_override_blank_clears_and_keeps_other_fields() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec())
+    m.set_acq_override(0, "manufacturer", "BioSemi")
+    m.set_acq_override(0, "amplifier_model", "actiCHamp")
+    # Clearing one field keeps the override entry alive for the other.
+    assert m.set_acq_override(0, "manufacturer", "") is True
+    over = m.global_spec().overrides["a.edf"]
+    assert over.manufacturer is None
+    assert over.amplifier_model == "actiCHamp"
+
+
+def test_acq_override_keyed_per_row() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    m.set_acq_override(0, "manufacturer", "BioSemi")
+    # Row 1 (source b.edf) is untouched -> still inherits the default.
+    assert m.acq_effective(1, "manufacturer") == "Brain Products"
+    assert m.acq_override(1, "manufacturer") == ""
+
+
+def test_acq_override_noop_returns_false() -> None:
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    # Setting the inherited value again is a no-op.
+    assert m.set_acq_override(0, "manufacturer", "Brain Products") is False
+
+
+def test_acq_override_meg_string_field() -> None:
+    """MEG manual fields (dewar position) round-trip through the override path."""
+    m = InventoryTableModel(_eeg_inherit_df())
+    m.set_global_spec(_device_spec())
+    m.set_acq_override(0, "dewar_position", "supine")
+    assert m.global_spec().overrides["a.edf"].dewar_position == "supine"
+    assert m.acq_effective(0, "dewar_position") == "supine"
+    # Clear -> override dropped (back to unset).
+    assert m.set_acq_override(0, "dewar_position", "") is True
+    assert "a.edf" not in m.global_spec().overrides

--- a/tests/gui/test_issue_visibility.py
+++ b/tests/gui/test_issue_visibility.py
@@ -269,3 +269,45 @@ def test_jump_to_row_selects_the_table_row(qtbot, tmp_path) -> None:
 
     panel._jump_to_row(1)
     assert panel._table.currentIndex().row() == 1
+
+
+# ---------------------------------------------------------------------------
+# Mixed-StudyDescription heads-up flows through the existing warn system
+# ---------------------------------------------------------------------------
+
+
+def _mixed_study_note() -> str:
+    from bidsmgr.cli.scan import MIXED_STUDY_ISSUE_TOKEN
+    return (
+        f"{MIXED_STUDY_ISSUE_TOKEN}: this series is 'PPMI'; "
+        f"scan also contains '1-MR'"
+    )
+
+
+def test_mixed_study_note_reads_as_warn_in_model(qtbot) -> None:
+    df = make_df([_func_row(proposed_issues=_mixed_study_note())])
+    model = InventoryTableModel(df)
+    # The scan's mixed-study note must classify as a warning (not err/skip),
+    # so it counts toward the warnings chip.
+    assert model.row_state(0) == "warn"
+
+
+def test_mixed_study_row_lists_in_warn_issues_dialog(qtbot) -> None:
+    from bidsmgr.cli.scan import MIXED_STUDY_ISSUE_TOKEN
+    from bidsmgr.gui.issues_dialog import _RowCard
+    from PyQt6.QtWidgets import QLabel
+
+    df = make_df([_func_row(proposed_issues=_mixed_study_note())])
+    model = InventoryTableModel(df)
+    dlg = IssuesDialog(model, severity="warn")
+    qtbot.addWidget(dlg)
+
+    cards = dlg.findChildren(_RowCard)
+    assert len(cards) == 1
+    bodies = [
+        lbl.text()
+        for card in cards
+        for vm in card.findChildren(ValMessage)
+        for lbl in vm.findChildren(QLabel)
+    ]
+    assert any(MIXED_STUDY_ISSUE_TOKEN in t for t in bodies)

--- a/tests/gui/test_panel_frame.py
+++ b/tests/gui/test_panel_frame.py
@@ -1,0 +1,85 @@
+"""Tests for the collapsible / detachable ``PanelFrame`` wrapper."""
+
+from __future__ import annotations
+
+import pytest
+from PyQt6.QtWidgets import QLabel, QWidget
+
+from bidsmgr.gui.widgets import PanelFrame
+from bidsmgr.gui.widgets.primitives import PaneHeader
+
+pytestmark = pytest.mark.gui
+
+
+def _pane_with_header() -> QWidget:
+    from PyQt6.QtWidgets import QVBoxLayout
+    w = QWidget()
+    lay = QVBoxLayout(w)
+    lay.addWidget(PaneHeader("Inner title"))
+    lay.addWidget(QLabel("body"))
+    return w
+
+
+def test_collapse_toggles_body_visibility(qtbot) -> None:
+    inner = QLabel("content")
+    frame = PanelFrame(inner, "Demo", edge="top")
+    qtbot.addWidget(frame)
+    frame.show()
+    assert not frame.is_collapsed()
+    assert inner.isVisible()
+
+    frame.toggle_collapsed()
+    assert frame.is_collapsed()
+    assert not inner.isVisible()
+
+    frame.toggle_collapsed()
+    assert not frame.is_collapsed()
+    assert inner.isVisible()
+
+
+def test_non_collapsible_frame_ignores_collapse(qtbot) -> None:
+    frame = PanelFrame(QLabel("x"), "Inspection", collapsible=False)
+    qtbot.addWidget(frame)
+    frame.set_collapsed(True)
+    assert not frame.is_collapsed()  # no-op
+
+
+def test_inner_pane_header_is_hidden(qtbot) -> None:
+    pane = _pane_with_header()
+    frame = PanelFrame(pane, "Outer title")
+    qtbot.addWidget(frame)
+    hdr = pane.findChild(PaneHeader)
+    assert hdr is not None
+    assert not hdr.isVisible()  # PanelFrame shows the single title instead
+
+
+def test_detach_then_reattach_restores_parent(qtbot) -> None:
+    inner = QLabel("content")
+    frame = PanelFrame(inner, "Demo")
+    qtbot.addWidget(frame)
+    frame.show()
+
+    assert inner.parent() is frame
+    frame.detach()
+    assert frame.is_detached()
+    # Body moved into the floating window, not the frame.
+    assert inner.parent() is not frame
+
+    frame.reattach()
+    assert not frame.is_detached()
+    assert inner.parent() is frame
+    assert inner.isVisible()
+
+
+def test_detach_expands_a_collapsed_frame(qtbot) -> None:
+    inner = QLabel("content")
+    frame = PanelFrame(inner, "Demo", edge="left")
+    qtbot.addWidget(frame)
+    frame.show()
+    frame.set_collapsed(True)
+    assert frame.is_collapsed()
+    frame.detach()
+    # Detaching a collapsed frame expands it first so the body is usable.
+    assert not frame.is_collapsed()
+    assert frame.is_detached()
+    frame.reattach()

--- a/tests/gui/test_properties_panel.py
+++ b/tests/gui/test_properties_panel.py
@@ -435,3 +435,58 @@ def test_nirs_row_has_no_reference_montage_section(qtbot) -> None:
     assert any("ACQUISITION" in t for t in texts)         # device/institution block
     assert not any("REFERENCE & MONTAGE" in t for t in texts)
     assert not any("montage match" in t for t in texts)   # no montage hint
+
+
+# ---------------------------------------------------------------------------
+# Per-row Compute-PSD button (threaded, mirrors the Editor recording viewer)
+# ---------------------------------------------------------------------------
+
+
+def _psd_buttons(panel):
+    from PyQt6.QtWidgets import QPushButton
+    return [
+        b for b in panel._body.findChildren(QPushButton)
+        if "Compute PSD" in b.text()
+    ]
+
+
+def test_eeg_row_has_compute_psd_button(qtbot) -> None:
+    """An EEG row exposes a Compute-PSD action under the line-frequency field;
+    it is disabled until the recording can be located on disk."""
+    panel, _m = _build_panel_with_model(qtbot, _eeg_row())
+    btns = _psd_buttons(panel)
+    assert len(btns) == 1
+    # No raw root set and the relative source_file does not exist -> disabled.
+    assert not btns[0].isEnabled()
+
+
+def test_compute_psd_button_enabled_when_source_resolvable(qtbot, tmp_path) -> None:
+    rec = tmp_path / "sub-001" / "rec.edf"
+    rec.parent.mkdir(parents=True)
+    rec.write_bytes(b"\x00")
+    panel, _m = _build_panel_with_model(qtbot, _eeg_row())
+    panel.set_raw_root(tmp_path)
+    btns = _psd_buttons(panel)
+    assert len(btns) == 1 and btns[0].isEnabled()
+    assert panel._resolve_source_path(0) == rec
+
+
+def test_meg_and_ieeg_rows_have_psd_button(qtbot) -> None:
+    for dt in ("meg", "ieeg"):
+        row = _eeg_row(
+            proposed_datatype=dt, bids_guess_suffix=dt, modality=dt,
+            proposed_basename=f"sub-001_task-rest_{dt}",
+        )
+        panel, _m = _build_panel_with_model(qtbot, row)
+        assert len(_psd_buttons(panel)) == 1, dt
+
+
+def test_mri_row_has_no_psd_button(qtbot) -> None:
+    """The PSD action only appears for the electrophysiology recording section."""
+    panel, _m = _build_panel_with_model(qtbot)  # default func/bold MRI row
+    assert _psd_buttons(panel) == []
+
+
+def test_resolve_source_path_none_for_dicom_row(qtbot) -> None:
+    panel, _m = _build_panel_with_model(qtbot)  # MRI row has blank source_file
+    assert panel._resolve_source_path(0) is None

--- a/tests/gui/test_properties_panel.py
+++ b/tests/gui/test_properties_panel.py
@@ -283,3 +283,155 @@ def test_companion_link_writeback(qtbot) -> None:
     assert stored == [{"suffix": "events", "path": "/data/sub-001_events.tsv"}]
     # Round-trips back through the reader.
     assert panel._companions(0) == [("events", "/data/sub-001_events.tsv")]
+
+
+# ---------------------------------------------------------------------------
+# Per-row device / institution overrides (scaffold-backed, not TSV columns)
+# ---------------------------------------------------------------------------
+
+
+def _device_spec(**defaults):
+    from bidsmgr.recording_meta import AcquisitionSpec, RecordingMetaSpec
+    return RecordingMetaSpec(defaults=AcquisitionSpec(**defaults))
+
+
+def test_per_row_device_override_writeback(qtbot) -> None:
+    """The device fields write into the scaffold's per-row override. Institution
+    is agnostic (dataset-level only) and NOT a per-row override."""
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    panel.set_selected_row(0)
+    panel._on_acq_field_changed("manufacturer", "BioSemi")
+    panel._on_acq_field_changed("amplifier_model", "actiCHamp")
+    over = m.global_spec().overrides["sub-001/rec.edf"]
+    assert over.manufacturer == "BioSemi"
+    assert over.amplifier_model == "actiCHamp"
+    # Not a TSV column.
+    assert "manufacturer" not in m.dataframe().columns
+
+
+def test_per_row_device_field_shows_effective_value(qtbot) -> None:
+    """A blank override surfaces the inherited dataset default in the panel."""
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    m.set_global_spec(_device_spec(manufacturer="Brain Products"))
+    panel.set_selected_row(0)
+    assert panel._acq_eff(0, "manufacturer") == "Brain Products"
+
+
+def test_section_headers_color_code_agnostic_vs_modality(qtbot) -> None:
+    """Agnostic sections render in a different colour than modality-specific,
+    and the modality-specific tag names the recording's actual modality."""
+    from bidsmgr.gui.theme_manager import CUR
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    pal = CUR()
+    agnostic = panel._section_header(
+        "PARTICIPANT", "participants.tsv", agnostic=True, tag="any modality")
+    modality = panel._section_header(
+        "ACQUISITION", "sub-..._eeg.json", agnostic=False, tag="EEG")
+    assert pal["teal"] in agnostic.text() and "any modality" in agnostic.text()
+    assert pal["purple"] in modality.text() and "EEG" in modality.text()
+
+
+def test_region_labels_split_agnostic_and_specific(qtbot) -> None:
+    """An EEG row shows both region dividers (agnostic + modality-specific);
+    an MRI row shows only the agnostic region (no recording sidecar)."""
+    from PyQt6.QtWidgets import QLabel
+
+    def region_texts(panel):
+        return [
+            w.text() for w in panel._body.findChildren(QLabel)
+            if "MODALITY-AGNOSTIC" in w.text() or "MODALITY-SPECIFIC" in w.text()
+        ]
+
+    panel, _m = _build_panel_with_model(qtbot, _eeg_row())
+    texts = region_texts(panel)
+    assert any("MODALITY-AGNOSTIC" in t for t in texts)
+    assert any("MODALITY-SPECIFIC" in t for t in texts)
+
+    panel2, _m2 = _build_panel_with_model(qtbot, _func_row())  # MRI
+    texts2 = region_texts(panel2)
+    assert any("MODALITY-AGNOSTIC" in t for t in texts2)
+    assert not any("MODALITY-SPECIFIC" in t for t in texts2)
+
+
+def test_montage_match_rate_shown_for_eeg(qtbot) -> None:
+    """The scan's montage suggestion (match rate) is surfaced as a read-only
+    hint next to the per-row montage field."""
+    from PyQt6.QtWidgets import QLabel
+    row = _eeg_row(montage_suggestion="standard_1005 (64/64)")
+    panel, _m = _build_panel_with_model(qtbot, row)
+    hints = [
+        w.text() for w in panel._body.findChildren(QLabel)
+        if "montage match" in w.text() and "standard_1005 (64/64)" in w.text()
+    ]
+    assert hints, "montage match-rate hint should be shown"
+
+
+def test_meg_row_has_meg_acquisition_section(qtbot) -> None:
+    """A MEG row shows a MEG ACQUISITION sub-section (and no scalp montage)."""
+    from PyQt6.QtWidgets import QLabel
+    row = _eeg_row(proposed_datatype="meg", bids_guess_suffix="meg", modality="meg",
+                   proposed_basename="sub-001_task-rest_meg", montage_suggestion="")
+    panel, m = _build_panel_with_model(qtbot, row)
+    from bidsmgr.recording_meta import default_spec
+    m.set_global_spec(default_spec()); panel.set_selected_row(0)
+    texts = [w.text() for w in panel._body.findChildren(QLabel)]
+    assert any("MEG ACQUISITION" in t for t in texts)
+    assert not any("REFERENCE & MONTAGE" in t for t in texts)
+    # The MEG manual field (dewar position) writes through the override path.
+    panel._on_acq_field_changed("dewar_position", "supine")
+    assert m.global_spec().overrides["sub-001/rec.edf"].dewar_position == "supine"
+
+
+def test_minimal_metadata_title_present(qtbot) -> None:
+    from PyQt6.QtWidgets import QLabel
+    panel, _m = _build_panel_with_model(qtbot, _eeg_row())
+    texts = [w.text() for w in panel._body.findChildren(QLabel)]
+    assert any("MINIMAL METADATA" in t for t in texts)
+
+
+def test_manufacturer_suggestion_hint_shown(qtbot) -> None:
+    """The scan-detected/inferred manufacturer shows as a read-only hint
+    next to the manufacturer field (like the montage match)."""
+    from PyQt6.QtWidgets import QLabel
+    row = _eeg_row(manufacturer_suggestion="Brain Products")
+    panel, _m = _build_panel_with_model(qtbot, row)
+    hints = [w.text() for w in panel._body.findChildren(QLabel)
+             if "scan detected" in w.text() and "Brain Products" in w.text()]
+    assert hints
+
+
+def test_per_row_has_no_institution_field(qtbot) -> None:
+    """Institution is agnostic (dataset-level); it must NOT appear per-row."""
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    from bidsmgr.recording_meta import default_spec
+    m.set_global_spec(default_spec()); panel.set_selected_row(0)
+    # institution is not a per-row override field.
+    from bidsmgr.gui.models.inventory import _ACQ_OVERRIDE_FIELDS
+    assert "institution_name" not in _ACQ_OVERRIDE_FIELDS
+    assert "institution_dept" not in _ACQ_OVERRIDE_FIELDS
+
+
+def test_per_row_fields_have_tooltips(qtbot) -> None:
+    """Every metadata input row carries an on-hover explanation."""
+    from PyQt6.QtWidgets import QComboBox, QLineEdit
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    from bidsmgr.recording_meta import default_spec
+    m.set_global_spec(default_spec()); panel.set_selected_row(0)
+    tipped = sum(1 for w in panel._body.findChildren((QComboBox, QLineEdit)) if w.toolTip())
+    assert tipped >= 8  # sex/hand/line_freq/manufacturer/ref/ground/montage/...
+
+
+def test_nirs_row_has_no_reference_montage_section(qtbot) -> None:
+    """NIRS gets the modality-specific ACQUISITION block but NOT the EEG/iEEG
+    REFERENCE & MONTAGE block (montage/reference/ground are scalp-EEG concepts,
+    matching the global dialog + the enrichment fixup)."""
+    from PyQt6.QtWidgets import QLabel
+    row = _eeg_row(proposed_datatype="nirs", bids_guess_suffix="nirs", modality="nirs",
+                   proposed_basename="sub-001_task-rest_nirs")
+    panel, _m = _build_panel_with_model(qtbot, row)
+    texts = [w.text() for w in panel._body.findChildren(QLabel)]
+    assert any("MODALITY-SPECIFIC" in t for t in texts)   # still modality-specific
+    assert any("ACQUISITION" in t for t in texts)         # device/institution block
+    assert not any("REFERENCE & MONTAGE" in t for t in texts)
+    assert not any("montage match" in t for t in texts)   # no montage hint

--- a/tests/gui/test_properties_panel.py
+++ b/tests/gui/test_properties_panel.py
@@ -201,3 +201,85 @@ def test_panel_project_integration(qtbot, tmp_path: Path) -> None:
     panel._on_entity_committed("acquisition", "mprage")
     events = [e for e in project.log if isinstance(e, UserSetEntity)]
     assert any(e.entity == "acquisition" and e.value == "mprage" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Per-row recording-metadata section (EEG/MEG)
+# ---------------------------------------------------------------------------
+
+
+def _eeg_row(**overrides) -> dict:
+    base = {
+        "BIDS_name": "sub-001",
+        "session": "",
+        "include": 1,
+        "modality": "eeg",
+        "proposed_datatype": "eeg",
+        "proposed_basename": "sub-001_task-rest_eeg",
+        "Proposed BIDS name": "sub-001_task-rest_eeg",
+        "bids_guess_suffix": "eeg",
+        "bids_guess_confidence": "1.00",
+        "bids_guess_skip": False,
+        "proposed_issues": "",
+        "entities": json.dumps({"subject": "001", "task": "rest"}, sort_keys=True),
+        "task": "rest",
+        "run": "",
+        "source_file": "sub-001/rec.edf",
+        "series_uid": "",
+        "montage": "",
+        "line_freq": "",
+        "eeg_reference": "",
+        "eeg_ground": "",
+        "PatientSex": "",
+        "PatientAge": "",
+        "Handedness": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_per_row_meta_writeback_updates_model(qtbot) -> None:
+    """The Properties panel's per-recording fields write back to the model."""
+    panel, m = _build_panel_with_model(qtbot, _eeg_row())
+    panel._on_meta_field_changed("eeg_reference", "Cz")
+    panel._on_meta_field_changed("montage", "standard_1005")
+    panel._on_meta_field_changed("Handedness", "R")
+    panel._on_meta_field_changed("PatientSex", "F")
+    df = m.dataframe()
+    assert df.at[0, "eeg_reference"] == "Cz"
+    assert df.at[0, "montage"] == "standard_1005"
+    assert df.at[0, "Handedness"] == "R"
+    assert df.at[0, "PatientSex"] == "F"
+
+
+def test_per_row_meta_section_renders_for_eeg(qtbot) -> None:
+    """Selecting an EEG row renders without error (the meta section shows)."""
+    panel, _m = _build_panel_with_model(qtbot, _eeg_row())
+    # The entity rows still render; the meta section is appended below them.
+    names = [r.entity_name for r in panel._entity_rows]
+    assert "subject" in names and "task" in names
+
+
+def test_participant_section_writeback_for_mri(qtbot) -> None:
+    """MRI (func) rows now get a per-row Participant section -> participants.tsv."""
+    row = _func_row(PatientSex="", PatientAge="", Handedness="")
+    panel, m = _build_panel_with_model(qtbot, row)
+    panel._on_meta_field_changed("PatientSex", "F")
+    panel._on_meta_field_changed("Handedness", "L")
+    panel._on_meta_field_changed("PatientAge", "41")
+    df = m.dataframe()
+    assert df.at[0, "PatientSex"] == "F"
+    assert df.at[0, "Handedness"] == "L"
+    assert df.at[0, "PatientAge"] == "41"
+
+
+def test_companion_link_writeback(qtbot) -> None:
+    """Linking a companion file writes a JSON list into the row's cell."""
+    import json as _json
+    row = _eeg_row(companion_files="")
+    panel, m = _build_panel_with_model(qtbot, row)
+    panel._write_companions(0, [("events", "/data/sub-001_events.tsv")])
+    stored = _json.loads(m.dataframe().at[0, "companion_files"])
+    assert stored == [{"suffix": "events", "path": "/data/sub-001_events.tsv"}]
+    # Round-trips back through the reader.
+    assert panel._companions(0) == [("events", "/data/sub-001_events.tsv")]

--- a/tests/gui/test_recording_loader_worker.py
+++ b/tests/gui/test_recording_loader_worker.py
@@ -1,0 +1,108 @@
+"""Tests for the recording + TSV background loader workers."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mne = pytest.importorskip("mne")
+
+from bidsmgr.workers import (  # noqa: E402
+    RecordingComputeWorker,
+    RecordingMetaWorker,
+    RecordingResampleWorker,
+    RecordingSignalWorker,
+    TsvLoaderWorker,
+)
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture
+def fif_path(tmp_path: Path) -> Path:
+    sfreq = 200.0
+    n = int(sfreq * 4)
+    data = np.random.default_rng(1).standard_normal((4, n)) * 1e-5
+    info = mne.create_info(
+        ["A", "B", "C", "STI"], sfreq, ["eeg", "eeg", "eeg", "stim"]
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        raw = mne.io.RawArray(data, info, verbose=False)
+        path = tmp_path / "sub-01_task-x_eeg.fif"
+        raw.save(path, overwrite=True, verbose=False)
+    return path
+
+
+def test_meta_worker_emits(qtbot, fif_path: Path) -> None:
+    w = RecordingMetaWorker(fif_path)
+    with qtbot.waitSignal(w.finished_with_meta, timeout=15000) as blocker:
+        w.start()
+    meta, path = blocker.args
+    assert path == fif_path
+    assert meta["n_channels"] == 4
+    assert meta["sfreq"] == 200.0
+    w.wait()
+
+
+def test_meta_worker_failed_on_bad_path(qtbot, tmp_path: Path) -> None:
+    w = RecordingMetaWorker(tmp_path / "missing_eeg.fif")
+    with qtbot.waitSignal(w.failed, timeout=15000):
+        w.start()
+    w.wait()
+
+
+def test_signal_worker_preloads(qtbot, fif_path: Path) -> None:
+    w = RecordingSignalWorker(fif_path)
+    with qtbot.waitSignal(w.finished_with_raw, timeout=15000) as blocker:
+        w.start()
+    raw, path = blocker.args
+    assert path == fif_path
+    assert raw.preload is True
+    assert raw.n_times > 0
+    w.wait()
+
+
+def test_resample_worker(qtbot, fif_path: Path) -> None:
+    raw = mne.io.read_raw(str(fif_path), preload=True, verbose=False)
+    w = RecordingResampleWorker(raw, 100.0)
+    with qtbot.waitSignal(w.finished_with_raw, timeout=15000) as blocker:
+        w.start()
+    out, freq = blocker.args
+    assert freq == 100.0
+    assert out.info["sfreq"] == 100.0
+    w.wait()
+
+
+def test_compute_worker_returns_result(qtbot) -> None:
+    w = RecordingComputeWorker(lambda: 6 * 7)
+    with qtbot.waitSignal(w.finished_with_result, timeout=5000) as blocker:
+        w.start()
+    assert blocker.args[0] == 42
+    w.wait()
+
+
+def test_compute_worker_failed(qtbot) -> None:
+    def boom():
+        raise ValueError("nope")
+
+    w = RecordingComputeWorker(boom)
+    with qtbot.waitSignal(w.failed, timeout=5000):
+        w.start()
+    w.wait()
+
+
+def test_tsv_loader_worker(qtbot, tmp_path: Path) -> None:
+    p = tmp_path / "big.tsv"
+    p.write_text("a\tb\n1\t2\n3\t4\n")
+    w = TsvLoaderWorker(p, 5000)
+    with qtbot.waitSignal(w.finished_with_data, timeout=5000) as blocker:
+        w.start()
+    header, rows, total, path = blocker.args
+    assert header == ["a", "b"]
+    assert total == 2
+    assert path == p
+    w.wait()

--- a/tests/gui/test_recording_meta_dialog.py
+++ b/tests/gui/test_recording_meta_dialog.py
@@ -165,11 +165,170 @@ def test_hidden_section_values_preserved_on_save(qtbot, tmp_path):
 
 
 def test_dialog_whole_is_scrollable(qtbot, tmp_path):
-    """The whole dialog scrolls (not just the inner table/list)."""
+    """Structural invariant: exactly ONE scroll area wraps the whole body, and
+    the intro label + button box live OUTSIDE it (so the scroll surface is the
+    whole metadata body, not an inner widget)."""
     from PyQt6.QtWidgets import QScrollArea
     dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json")
     qtbot.addWidget(dlg)
-    assert dlg.findChildren(QScrollArea), "body should be wrapped in a scroll area"
-    # Inner widgets are bounded so the OUTER scroll engages for the overall layout.
-    assert 0 < dlg._events.maximumHeight() <= 200
+    areas = dlg.findChildren(QScrollArea)
+    assert len(areas) == 1, "the whole body should be one scroll surface"
+    # Inner widgets are bounded so they cannot stretch greedily to fill.
+    assert 0 < dlg._events.maximumHeight() <= 160
     assert 0 < dlg._phenotype.maximumHeight() <= 110
+
+
+@pytest.mark.parametrize(
+    "datatypes, expect_scroll",
+    [
+        ({"eeg"}, True),    # all sections stacked -> body taller than viewport
+        ({"meg"}, True),    # device + meg + agnostic sections overflow
+        ({"mri"}, True),    # institution + events + phenotype overflow too
+    ],
+)
+def test_dialog_whole_body_scrolls_not_inner_tables(qtbot, tmp_path, datatypes, expect_scroll):
+    """The OUTER scroll area moves the whole body; inner tables keep a natural
+    bounded height (they do not stretch to fill).
+
+    The user asked for a scrollable window rather than one that resizes to its
+    content or whose inner tables expand. Scroll engagement at the fixed default
+    size is deterministic per modality combination.
+    """
+    from PyQt6.QtWidgets import QScrollArea
+    dlg = RecordingMetaDialog(
+        tmp_path / "inv.tsv.recording_meta.json", present_datatypes=datatypes)
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    sa = dlg.findChild(QScrollArea)
+    overflows = sa.widget().sizeHint().height() > sa.viewport().height()
+    assert overflows is expect_scroll
+    # Tables keep a bounded natural height regardless of modality.
+    assert dlg._events.height() <= dlg._events.maximumHeight()
+    assert dlg._phenotype.height() <= dlg._phenotype.maximumHeight()
+
+
+def test_dialog_uses_shared_manufacturer_vocab(qtbot, tmp_path):
+    """The dialog's manufacturer dropdown is the one shared list (no duplicate)."""
+    from bidsmgr.recording_meta import COMMON_MANUFACTURERS
+    dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json")
+    qtbot.addWidget(dlg)
+    items = [dlg._manufacturer.itemText(i) for i in range(dlg._manufacturer.count())]
+    assert items[0] == ""  # blank first entry
+    assert items[1:] == list(COMMON_MANUFACTURERS)
+
+
+def test_dialog_combined_modality_label(qtbot, tmp_path):
+    """A field shared by several present modalities is labelled with all of
+    them (e.g. 'EEG and MEG'); the device block names every electrophysiology
+    modality, the reference block only EEG/iEEG."""
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"eeg", "meg"})
+    qtbot.addWidget(dlg)
+    assert "EEG and MEG" in dlg._device_box.title()
+    # MEG has no scalp reference/montage -> that block is EEG-only here.
+    assert "EEG" in dlg._eeg_box.title() and "MEG" not in dlg._eeg_box.title()
+
+
+def test_dialog_region_header_hidden_for_mri_only(qtbot, tmp_path):
+    """An MRI-only dataset shows no modality-specific region (only agnostic)."""
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"mri"})
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    assert not dlg._specific_region.isVisible()
+    assert not dlg._device_box.isVisible()
+    assert not dlg._eeg_box.isVisible()
+    assert not dlg._meg_box.isVisible()
+
+
+def test_dialog_meg_group_visibility_and_roundtrip(qtbot, tmp_path):
+    """The MEG group shows only for MEG datasets and round-trips its manual
+    fields. Channel-derived MEG fields are NOT exposed (mne-bids fills them)."""
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"meg"})
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    assert dlg._meg_box.isVisible()
+    assert not dlg._eeg_box.isVisible()      # MEG has no scalp reference/montage
+    assert not hasattr(dlg, "_continuous_head_localization")  # auto -> not exposed
+    dlg._dewar_position.setCurrentText("supine")
+    dlg._associated_empty_room.setText("bids::sub-emptyroom")
+    acq = dlg.build_spec().defaults
+    assert acq.dewar_position == "supine"
+    assert acq.associated_empty_room == "bids::sub-emptyroom"
+
+
+def test_dialog_cap_is_editable_dropdown(qtbot, tmp_path):
+    from PyQt6.QtWidgets import QComboBox
+    from bidsmgr.recording_meta import COMMON_CAP_MANUFACTURERS
+    dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json",
+                              present_datatypes={"eeg"})
+    qtbot.addWidget(dlg)
+    assert isinstance(dlg._cap_manufacturer, QComboBox)
+    assert dlg._cap_manufacturer.isEditable()
+    items = [dlg._cap_manufacturer.itemText(i) for i in range(dlg._cap_manufacturer.count())]
+    assert "EasyCap" in items
+    # A typed custom value flows through.
+    dlg._cap_manufacturer.setCurrentText("Custom Cap Co")
+    assert dlg.build_spec().defaults.cap_manufacturer == "Custom Cap Co"
+
+
+def test_dialog_fields_have_schema_tooltips(qtbot, tmp_path):
+    """Every metadata field carries an on-hover explanation from the schema."""
+    dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json",
+                              present_datatypes={"eeg", "meg"})
+    qtbot.addWidget(dlg)
+    assert "Manufacturer" in dlg._manufacturer.toolTip()
+    assert dlg._line_freq.toolTip()           # PowerLineFrequency description
+    assert dlg._eeg_reference.toolTip()
+    assert dlg._dewar_position.toolTip()
+    assert dlg._cap_manufacturer.toolTip()
+
+
+def test_dialog_montage_suggestion_summary(qtbot, tmp_path):
+    """The scan montage suggestions surface in the global dialog as a summary."""
+    from PyQt6.QtWidgets import QLabel
+    dlg = RecordingMetaDialog(
+        tmp_path / "inv.tsv.recording_meta.json", present_datatypes={"eeg"},
+        montage_suggestions=["standard_1005 (64/64)", "standard_1020 (19/19)"],
+    )
+    qtbot.addWidget(dlg)
+    hints = [w.text() for w in dlg.findChildren(QLabel)
+             if "scan suggests" in w.text() and "standard_1005 (64/64)" in w.text()]
+    assert hints
+
+
+def test_dialog_manufacturer_suggestion_summary(qtbot, tmp_path):
+    """The scan manufacturer suggestions surface in the global dialog too."""
+    from PyQt6.QtWidgets import QLabel
+    dlg = RecordingMetaDialog(
+        tmp_path / "inv.tsv.recording_meta.json", present_datatypes={"meg"},
+        manufacturer_suggestions=["MEGIN / Elekta / Neuromag"],
+    )
+    qtbot.addWidget(dlg)
+    hints = [w.text() for w in dlg.findChildren(QLabel)
+             if "scan suggests" in w.text() and "MEGIN" in w.text()]
+    assert hints
+
+
+def test_dialog_institution_is_agnostic_not_in_device_group(qtbot, tmp_path):
+    """Institution is agnostic: it has its own group and shows even for an
+    MRI-only dataset (where the device/EEG/MEG groups are hidden)."""
+    from PyQt6.QtWidgets import QGroupBox
+    dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json",
+                              present_datatypes={"mri"})
+    qtbot.addWidget(dlg)
+    dlg.show()
+    qtbot.waitExposed(dlg)
+    titles = [g.title() for g in dlg.findChildren(QGroupBox)]
+    inst = [t for t in titles if "Institution" in t]
+    assert inst and "any modality" in inst[0]
+    # The device group does NOT mention institution any more.
+    device = [t for t in titles if t.startswith("Acquisition system")]
+    assert device and "institution" not in device[0].lower()
+    # Institution fields are editable even on an MRI-only dataset.
+    dlg._institution_name.setText("Uni Oldenburg")
+    assert dlg.build_spec().defaults.institution_name == "Uni Oldenburg"

--- a/tests/gui/test_recording_meta_dialog.py
+++ b/tests/gui/test_recording_meta_dialog.py
@@ -117,6 +117,16 @@ def test_dialog_phenotype_round_trip(qtbot, tmp_path):
     assert load_spec(scaffold).phenotype_files == ["/data/edinburgh.tsv", "/data/bdi.csv"]
 
 
+def test_dialog_participants_file_round_trip(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold)
+    qtbot.addWidget(dlg)
+    dlg._participants_file.setText("/data/subjects.csv")
+    assert dlg.build_spec().participants_file == "/data/subjects.csv"
+    dlg._on_save()
+    assert load_spec(scaffold).participants_file == "/data/subjects.csv"
+
+
 def test_dialog_acquisition_hidden_for_mri_only(qtbot, tmp_path):
     scaffold = tmp_path / "inv.tsv.recording_meta.json"
     dlg = RecordingMetaDialog(scaffold, present_datatypes={"anat", "func"})

--- a/tests/gui/test_recording_meta_dialog.py
+++ b/tests/gui/test_recording_meta_dialog.py
@@ -1,0 +1,175 @@
+"""GUI smoke tests for the Phase 4 recording-metadata surface:
+
+* the constrained ``montage`` / ``line_freq`` dropdown delegate,
+* the new editable per-row columns (reference / ground / demographics),
+* the dataset-level :class:`RecordingMetaDialog` scaffold round-trip.
+
+Marked ``gui`` so they run under ``QT_QPA_PLATFORM=offscreen``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QStandardItemModel
+from PyQt6.QtWidgets import QComboBox, QTableWidgetItem
+
+from bidsmgr.gui.delegates import ChoiceDelegate, builtin_montages
+from bidsmgr.gui.models import COLUMNS
+from bidsmgr.gui.recording_meta_dialog import RecordingMetaDialog
+from bidsmgr.recording_meta import load_spec
+
+pytestmark = pytest.mark.gui
+
+
+def _spec(key: str):
+    return next(c for c in COLUMNS if c.key == key)
+
+
+def test_new_columns_registered_and_editable():
+    for key in ("eeg_reference", "eeg_ground", "Handedness", "montage", "line_freq"):
+        assert _spec(key).editable is True
+    # Demographics are now editable so EEG/MEG subjects can be filled in-table.
+    assert _spec("PatientSex").editable is True
+    assert _spec("PatientAge").editable is True
+
+
+def test_builtin_montages_nonempty():
+    assert len(builtin_montages()) > 0
+
+
+def test_choice_delegate_is_dropdown_only(qtbot):
+    d = ChoiceDelegate(["50", "60"], blank_label="(blank)")
+    editor = d.createEditor(None, None, None)
+    assert isinstance(editor, QComboBox)
+    assert editor.isEditable() is False  # never hand-typed
+    assert [editor.itemText(i) for i in range(editor.count())] == ["(blank)", "50", "60"]
+
+
+def test_choice_delegate_blank_maps_to_empty(qtbot):
+    d = ChoiceDelegate(["50", "60"], blank_label="(blank)")
+    model = QStandardItemModel(1, 1)
+    idx = model.index(0, 0)
+    model.setData(idx, "60", Qt.ItemDataRole.EditRole)
+
+    editor = QComboBox()
+    editor.addItems(["(blank)", "50", "60"])
+    editor.setCurrentText("(blank)")
+    d.setModelData(editor, model, idx)
+    assert model.data(idx, Qt.ItemDataRole.EditRole) == ""  # blank -> empty string
+
+    editor.setCurrentText("50")
+    d.setModelData(editor, model, idx)
+    assert model.data(idx, Qt.ItemDataRole.EditRole) == "50"
+
+
+def test_dialog_round_trip(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold)
+    qtbot.addWidget(dlg)
+
+    dlg._manufacturer.setCurrentText("Brain Products")
+    dlg._eeg_reference.setText("Cz")
+    dlg._line_freq.setCurrentText("60")
+    dlg._montage.setCurrentText("(none)")
+    dlg._events.insertRow(0)
+    dlg._events.setItem(0, 0, QTableWidgetItem("S 20"))
+    dlg._events.setItem(0, 1, QTableWidgetItem("eyes_open"))
+
+    spec = dlg.build_spec()
+    assert spec.defaults.manufacturer == "Brain Products"
+    assert spec.defaults.eeg_reference == "Cz"
+    assert spec.defaults.power_line_freq == 60.0
+    assert spec.defaults.montage is None  # "(none)" -> unset
+    assert spec.event_maps["*"]["S 20"] == "eyes_open"
+
+    dlg._on_save()
+    assert scaffold.exists()
+    reloaded = load_spec(scaffold)
+    assert reloaded.defaults.manufacturer == "Brain Products"
+    assert reloaded.event_maps["*"]["S 20"] == "eyes_open"
+
+
+def test_dialog_loads_existing_scaffold(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    scaffold.write_text(
+        '{"schema_version": 1, "defaults": {"manufacturer": "Elekta"}, '
+        '"event_maps": {"*": {"T0": "rest"}}}',
+        encoding="utf-8",
+    )
+    dlg = RecordingMetaDialog(scaffold)
+    qtbot.addWidget(dlg)
+    assert dlg._manufacturer.currentText() == "Elekta"
+    assert dlg._events.rowCount() == 1
+    assert dlg._events.item(0, 0).text() == "T0"
+
+
+def test_dialog_phenotype_round_trip(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold)
+    qtbot.addWidget(dlg)
+    dlg._phenotype.addItem("/data/edinburgh.tsv")
+    dlg._phenotype.addItem("/data/bdi.csv")
+    assert dlg.build_spec().phenotype_files == ["/data/edinburgh.tsv", "/data/bdi.csv"]
+    dlg._on_save()
+    assert load_spec(scaffold).phenotype_files == ["/data/edinburgh.tsv", "/data/bdi.csv"]
+
+
+def test_dialog_acquisition_hidden_for_mri_only(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"anat", "func"})
+    qtbot.addWidget(dlg)
+    # The modality-specific sections are hidden for an MRI-only set...
+    assert dlg._device_box.isVisibleTo(dlg) is False
+    assert dlg._eeg_box.isVisibleTo(dlg) is False
+    # ...but the agnostic event + phenotype sections still exist.
+    assert dlg._events is not None and dlg._phenotype is not None
+
+
+def test_dialog_acquisition_shown_for_eeg(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"eeg"})
+    qtbot.addWidget(dlg)
+    assert dlg._device_box.isVisibleTo(dlg) is True
+    assert dlg._eeg_box.isVisibleTo(dlg) is True
+    assert dlg._eeg_reference.isEnabled() is True
+
+
+def test_manufacturer_is_editable_dropdown_with_defaults(qtbot, tmp_path):
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    dlg = RecordingMetaDialog(scaffold)
+    qtbot.addWidget(dlg)
+    assert dlg._manufacturer.isEditable() is True  # pick a default OR type another
+    items = [dlg._manufacturer.itemText(i) for i in range(dlg._manufacturer.count())]
+    assert "Brain Products" in items
+    assert "MEGIN / Elekta / Neuromag" in items
+    # A typed custom value flows through.
+    dlg._manufacturer.setCurrentText("Custom Amp Co")
+    assert dlg.build_spec().defaults.manufacturer == "Custom Amp Co"
+
+
+def test_hidden_section_values_preserved_on_save(qtbot, tmp_path):
+    """Editing on an MRI-only dataset must not wipe EEG fields a scaffold holds."""
+    scaffold = tmp_path / "inv.tsv.recording_meta.json"
+    scaffold.write_text(
+        '{"schema_version": 1, "defaults": {"eeg_reference": "Cz", "montage": "standard_1005"}}',
+        encoding="utf-8",
+    )
+    dlg = RecordingMetaDialog(scaffold, present_datatypes={"anat", "func"})
+    qtbot.addWidget(dlg)
+    spec = dlg.build_spec()
+    assert spec.defaults.eeg_reference == "Cz"          # preserved, not wiped
+    assert spec.defaults.montage == "standard_1005"
+
+
+def test_dialog_whole_is_scrollable(qtbot, tmp_path):
+    """The whole dialog scrolls (not just the inner table/list)."""
+    from PyQt6.QtWidgets import QScrollArea
+    dlg = RecordingMetaDialog(tmp_path / "inv.tsv.recording_meta.json")
+    qtbot.addWidget(dlg)
+    assert dlg.findChildren(QScrollArea), "body should be wrapped in a scroll area"
+    # Inner widgets are bounded so the OUTER scroll engages for the overall layout.
+    assert 0 < dlg._events.maximumHeight() <= 200
+    assert 0 < dlg._phenotype.maximumHeight() <= 110

--- a/tests/gui/test_recording_viewer.py
+++ b/tests/gui/test_recording_viewer.py
@@ -1,0 +1,166 @@
+"""GUI tests for the EEG/MEG recording viewer pane + Editor routing."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mne = pytest.importorskip("mne")
+
+from bidsmgr.gui.editor_panel import EditorPanel  # noqa: E402
+from bidsmgr.gui.theme_manager import DARK, LIGHT  # noqa: E402
+from bidsmgr.gui.widgets import RecordingViewerPane  # noqa: E402
+
+pytestmark = pytest.mark.gui
+
+
+@pytest.fixture
+def rec(tmp_path: Path) -> Path:
+    sfreq = 200.0
+    n = int(sfreq * 5)
+    data = np.random.default_rng(3).standard_normal((6, n)) * 1e-5
+    data[5, :] = 0
+    data[5, [40, 120, 300]] = 1  # stim pulses
+    info = mne.create_info(
+        ["Fp1", "Fp2", "Cz", "Pz", "EOG", "STI"],
+        sfreq,
+        ["eeg", "eeg", "eeg", "eeg", "eog", "stim"],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        raw = mne.io.RawArray(data, info, verbose=False)
+        path = tmp_path / "sub-01_task-rest_eeg.fif"
+        raw.save(path, overwrite=True, verbose=False)
+    (tmp_path / "sub-01_task-rest_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n0.5\t0\tgo\n2.5\t0\tstop\n"
+    )
+    return path
+
+
+def test_pane_starts_with_hint(qapp) -> None:
+    pane = RecordingViewerPane()
+    assert pane._stack.currentWidget() is pane._hint
+
+
+def test_recording_tree_icons(qapp) -> None:
+    """File and directory-shaped recordings get the brain+signal icon;
+    plain folders keep the folder icon."""
+    from bidsmgr.gui import icons
+
+    assert not icons.icon_for_path("sub-01_task-x_eeg.edf").isNull()
+    assert not icons.icon_for_path("sub-01_task-x_eeg.vhdr").isNull()
+    ds = icons.icon_for_path("sub-01_task-x_meg.ds", is_dir=True)
+    mff = icons.icon_for_path("sub-01_eeg.mff", is_dir=True)
+    folder = icons.icon_for_path("anat", is_dir=True)
+    assert not ds.isNull() and not mff.isNull()
+    # CTF .ds / EGI .mff dirs must NOT use the plain folder icon.
+    assert ds.cacheKey() != folder.cacheKey()
+    assert mff.cacheKey() != folder.cacheKey()
+
+
+def test_metadata_loads_then_signal(qapp, qtbot, rec: Path) -> None:
+    pane = RecordingViewerPane()
+    qtbot.addWidget(pane)
+    pane.set_file(rec, rec.parent)
+    qtbot.waitUntil(
+        lambda: pane._stack.currentWidget() is pane._meta_page, timeout=20000
+    )
+    assert pane._meta is not None
+    assert pane._meta["n_channels"] == 6
+
+    pane._load_signal()
+    qtbot.waitUntil(
+        lambda: pane._stack.currentWidget() is pane._view, timeout=20000
+    )
+    view = pane._view
+    assert view._raw is not None
+    items = [view.cmb_ch_type.itemText(i) for i in range(view.cmb_ch_type.count())]
+    assert "all" in items and "eeg" in items
+    # Events from the sibling events.tsv + stim channel -> control enabled.
+    assert view.chk_events.isEnabled()
+
+    # Exercise the controls (must not raise).
+    view.chk_events.setChecked(True)
+    view._on_ch_type_changed("eeg")
+    view._on_n_changed(3)
+    view._on_scale_changed(2.0)
+    view._on_window_changed(3.0)
+    view._navigate("next")
+    view._navigate("end")
+    view._navigate("start")
+    view._on_norm_toggled(True)
+    view._on_norm_toggled(False)
+    view._on_dark_toggled(True)
+    view._on_dark_toggled(False)
+    view.spn_hp.setValue(1.0)
+    view.spn_lp.setValue(40.0)
+    view._apply_filters()
+    view._reset_filters()
+    view._reset_view()
+
+    # Theme swap + unload.
+    pane.repaint_for_palette(LIGHT)
+    pane.repaint_for_palette(DARK)
+    view.unload()
+    assert view._raw is None
+
+
+def test_set_file_none_unloads(qapp, qtbot, rec: Path) -> None:
+    pane = RecordingViewerPane()
+    qtbot.addWidget(pane)
+    pane.set_file(rec, rec.parent)
+    qtbot.waitUntil(
+        lambda: pane._stack.currentWidget() is pane._meta_page, timeout=20000
+    )
+    pane.set_file(None, None)
+    assert pane._stack.currentWidget() is pane._hint
+
+
+def test_event_jump_to_first_when_outside_window(qapp) -> None:
+    """Enabling events when none fall in the current window scrolls the
+    view to the first event (the MEG sample's first trigger is ~102 s in)."""
+    from bidsmgr.gui.widgets.recording_viewer_pane import _TimeSeriesView
+
+    v = _TimeSeriesView()
+    v._duration = 100.0
+    v._time_window = 5.0
+    v._time_start = 0.0
+    v._tsv_events = [(50.0, "x")]
+    v._event_source = "auto"
+    v._jump_to_first_event_if_needed()
+    assert 44.0 < v._time_start < 50.0
+    v.unload()
+
+
+def test_psd_dialog_handles_channel_subset(qapp) -> None:
+    """The PSD dialog must not crash when the caller passes more channel
+    names/types than PSD data rows (compute_psd drops non-data channels)."""
+    from bidsmgr.gui.widgets.recording_viewer_pane import _PsdDialog
+
+    res = {
+        "freqs": np.linspace(1.0, 40.0, 40),
+        "data": np.random.default_rng(0).random((3, 40)) * 1e-10,
+        "ch_names": ["a", "b", "c", "d", "e"],  # longer than data on purpose
+        "ch_types": ["eeg", "eeg", "eeg", "mag", "mag"],
+    }
+    dlg = _PsdDialog(res)
+    assert dlg._tabs.count() == 2
+    dlg._on_db_toggled(False)
+    dlg._on_db_toggled(True)
+    dlg._on_type_changed()
+
+
+def test_editor_routes_recording_to_pane(qapp, qtbot, rec: Path) -> None:
+    ep = EditorPanel()
+    qtbot.addWidget(ep)
+    ep._set_root(rec.parent, persist=False)
+    ep._on_file_selected(rec)
+    assert ep._center_stack.currentWidget() is ep._recording_viewer
+    qtbot.waitUntil(
+        lambda: ep._recording_viewer._stack.currentWidget()
+        is ep._recording_viewer._meta_page,
+        timeout=20000,
+    )

--- a/tests/gui/test_resume.py
+++ b/tests/gui/test_resume.py
@@ -221,6 +221,80 @@ def test_relocate_source_persists_to_version_meta(
     assert workspace.read_version_meta(vdir)["raw_root"] == str(new_raw)
 
 
+def test_fresh_scan_flags_rows_whose_subject_already_exists(
+    qtbot, isolated_settings, tmp_path,
+):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    (root / "sub-001").mkdir()  # already converted on disk
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    df = pd.DataFrame([
+        {"BIDS_name": "sub-001", "proposed_issues": ""},  # collides with on-disk
+        {"BIDS_name": "sub-002", "proposed_issues": ""},  # new
+    ])
+    panel._flag_existing_subject_rows(df)
+    # No participants.tsv identity -> generic heads-up, tagged with the token.
+    assert "already in the dataset" in df.iloc[0]["proposed_issues"]
+    assert "existing-subject" in df.iloc[0]["proposed_issues"]
+    assert df.iloc[1]["proposed_issues"] == ""  # new subject not flagged
+
+
+def test_flag_existing_subject_rows_is_idempotent_after_rename(
+    qtbot, isolated_settings, tmp_path,
+):
+    # Renaming a clashing subject must clear the stale collision note (it bakes
+    # in the old id); re-flagging the same frame is the engine behind Re-validate.
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    (root / "sub-001").mkdir()
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    df = pd.DataFrame([{"BIDS_name": "sub-001", "proposed_issues": ""}])
+    panel._flag_existing_subject_rows(df)
+    assert "existing-subject" in df.iloc[0]["proposed_issues"]
+
+    # User renames to a free id, then re-flags: the warning is gone (no double).
+    df.at[0, "BIDS_name"] = "sub-002"
+    panel._flag_existing_subject_rows(df)
+    assert df.iloc[0]["proposed_issues"] == ""
+
+
+def test_revalidate_clears_collision_after_bulk_rename(
+    qtbot, isolated_settings, tmp_path,
+):
+    # Full flow the user hit: convert sub-001, scan a second source that also
+    # lands on sub-001 (warn), rename to sub-002, click Re-validate -> warning
+    # clears (no lingering "sub-001 ... DIFFERENT subject" note).
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    (root / "sub-001").mkdir()  # subject already on disk
+    _add_version(root, "raw", _inventory_df(subject="001", uid="X1"), str(tmp_path / "raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    # Flag collisions as the scan-complete path would.
+    panel._flag_existing_subject_rows(panel._model.dataframe())
+    panel._model.revalidate_all()
+    assert panel._model.row_state(0) == "warn"  # collides with on-disk sub-001
+
+    # Rename via the bulk-edit code path (id -> subject entity + BIDS_name).
+    panel._model.bulk_set([0], "id", "002")
+    # Live edit alone leaves the stale note (manual revalidation is by design).
+    assert panel._model.row_state(0) == "warn"
+
+    # Re-validate recomputes the collision against the new id + disk -> cleared.
+    panel._on_revalidate_clicked()
+    assert panel._model.row_state(0) == ""
+    issues = panel._model.dataframe().at[0, "proposed_issues"]
+    assert "existing-subject" not in issues and "sub-001" not in issues
+
+
 def test_set_project_without_scan_is_noop(qtbot, isolated_settings, tmp_path):
     root = tmp_path / "fresh"
     proj = open_or_create_workspace(root)
@@ -229,3 +303,44 @@ def test_set_project_without_scan_is_noop(qtbot, isolated_settings, tmp_path):
     panel.set_project(proj, root)
     assert panel._model is None
     assert panel._scans_combo.isHidden()  # no versions -> picker hidden
+
+
+def test_binding_new_empty_project_clears_previous(qtbot, isolated_settings, tmp_path):
+    # Project A with a scan -> the converter shows its rows.
+    root_a = tmp_path / "A"
+    proj_a = open_or_create_workspace(root_a)
+    _add_version(root_a, "raw", _inventory_df(), str(tmp_path / "rawA"))
+    panel = ConverterPanel(project=proj_a)
+    qtbot.addWidget(panel)
+    panel.set_project(proj_a, root_a)
+    assert panel._model is not None
+
+    # Switching to a fresh, empty project B must reset the converter so A's rows
+    # / raw input / active version never leak across datasets.
+    root_b = tmp_path / "B"
+    proj_b = open_or_create_workspace(root_b)
+    panel.set_project(proj_b, root_b)
+    assert panel._model is None
+    assert panel._raw_root is None
+    assert panel._active_version_dir is None
+    assert panel._scans_combo.isHidden()
+    assert panel._bids_root == root_b
+
+
+def test_open_existing_syncs_dataset_column_to_folder(
+    qtbot, isolated_settings, tmp_path,
+):
+    # The dataset folder was renamed on disk, so the stored inventory's dataset
+    # column is stale. Opening the project must re-sync it to the folder name so
+    # conversion writes into the (renamed) locked root.
+    root = tmp_path / "renamed_ds"
+    proj = open_or_create_workspace(root)
+    df = _inventory_df()
+    df["dataset"] = "old_folder_name"
+    _add_version(root, "raw", df, str(tmp_path / "raw"))
+
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    assert (panel._model.dataframe()["dataset"] == "renamed_ds").all()

--- a/tests/gui/test_resume.py
+++ b/tests/gui/test_resume.py
@@ -1,0 +1,231 @@
+"""Resume curation + versioned scans (Phase E-1 + E-2).
+
+Each scan of a source folder is its own version under
+``.bidsmgr/project/scans/<version>/`` with an isolated curation bundle. Reopening
+a project resumes the latest version (replaying its cell / include / entity
+edits); a second scan creates a new version without overwriting the first; the
+toolbar picker switches between versions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bidsmgr.cli.create import open_or_create_workspace
+from bidsmgr.gui.converter_panel import ConverterPanel
+from bidsmgr.project import (
+    Project,
+    ScanImported,
+    UserSetCell,
+    UserSetEntity,
+    UserToggleInclude,
+    workspace,
+)
+
+pytestmark = pytest.mark.gui
+
+
+def _inventory_df(subject: str = "001", task: str = "rest", uid: str = "UID1") -> pd.DataFrame:
+    return pd.DataFrame([
+        {
+            "BIDS_name": f"sub-{subject}", "session": "", "include": 1,
+            "modality": "mri", "proposed_datatype": "func",
+            "proposed_basename": f"sub-{subject}_task-{task}_bold",
+            "bids_guess_suffix": "bold", "bids_guess_confidence": "0.9",
+            "bids_guess_skip": False, "proposed_issues": "",
+            "entities": json.dumps({"subject": subject, "task": task}, sort_keys=True),
+            "task": task, "run": "", "series_uid": uid, "dataset": "ds",
+            "source_file": "",
+        },
+    ])
+
+
+def _add_version(bids_root: Path, source_label: str, df: pd.DataFrame, raw_root: str):
+    """Create a scan version (its own bundle + inventory) and return its Project."""
+    vdir = workspace.allocate_version_dir(bids_root, source_label)
+    proj = Project.create(vdir, name=bids_root.name)
+    df.to_csv(workspace.version_inventory(vdir), sep="\t", index=False)
+    workspace.write_version_meta(
+        vdir, source_label=source_label, raw_root=raw_root, status="curating",
+    )
+    rids = tuple(df["series_uid"].tolist())
+    proj.append(ScanImported(
+        inventory_tsv=str(workspace.version_inventory(vdir)),
+        row_ids=rids, raw_root=raw_root,
+    ))
+    return vdir, proj
+
+
+def test_resume_loads_latest_version_and_paths(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    vdir, _ = _add_version(root, "raw_eeg", _inventory_df(), str(tmp_path / "raw"))
+
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    assert panel._model is not None
+    assert panel._active_version_dir == vdir
+    assert panel._raw_root == tmp_path / "raw"
+
+
+def test_resume_replays_cell_include_and_entity_edits(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    vdir, vproj = _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    vproj.append(UserSetCell(row_id="UID1", column="task", value="memory", previous="rest"))
+    vproj.append(UserToggleInclude(row_id="UID1", include=False))
+
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    df = panel._model.dataframe()
+    assert df.iloc[0]["task"] == "memory"
+    assert panel._model.row_state(0) == "skip"
+
+
+def test_resume_replays_subject_rename(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    vdir, vproj = _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    vproj.append(UserSetEntity(row_id="UID1", entity="subject", value="042", previous="001"))
+
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    assert panel._model.dataframe().iloc[0]["BIDS_name"] == "sub-042"
+
+
+def test_two_versions_coexist_and_picker_switches(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    v1, _ = _add_version(root, "source_a", _inventory_df(subject="001", uid="A1"), str(tmp_path / "a"))
+    v2, _ = _add_version(root, "source_b", _inventory_df(subject="002", uid="B1"), str(tmp_path / "b"))
+
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    # Both versions exist; resume lands on the latest (v2 / source_b).
+    assert len(workspace.list_versions(root)) == 2
+    assert panel._active_version_dir == v2
+    assert panel._model.dataframe().iloc[0]["BIDS_name"] == "sub-002"
+    # isHidden() reflects the explicit setVisible flag without needing the whole
+    # window shown (offscreen). The picker lists both versions.
+    assert not panel._scans_combo.isHidden() and panel._scans_combo.count() == 2
+
+    # Switch back to the first version via the picker.
+    idx_v1 = next(i for i in range(panel._scans_combo.count())
+                  if Path(panel._scans_combo.itemData(i)) == v1)
+    panel._scans_combo.setCurrentIndex(idx_v1)
+    panel._on_scans_combo_activated(idx_v1)
+    assert panel._active_version_dir == v1
+    assert panel._model.dataframe().iloc[0]["BIDS_name"] == "sub-001"
+
+
+def test_undo_reverts_last_edit(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    # An edit on the active version, then reload so the model shows it.
+    panel._project.append(UserSetCell(row_id="UID1", column="task", value="memory", previous="rest"))
+    panel._reload_active_version()
+    assert panel._model.dataframe().iloc[0]["task"] == "memory"
+
+    panel._on_undo()  # reverts the edit
+    assert panel._model.dataframe().iloc[0]["task"] == "rest"
+
+
+def test_redo_reapplies_undone_edit(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    panel._project.append(UserSetCell(row_id="UID1", column="task", value="memory", previous="rest"))
+    panel._reload_active_version()
+    assert panel._model.dataframe().iloc[0]["task"] == "memory"
+
+    panel._on_undo()
+    assert panel._model.dataframe().iloc[0]["task"] == "rest"
+    assert panel._redo_btn.isEnabled()
+
+    panel._on_redo()
+    assert panel._model.dataframe().iloc[0]["task"] == "memory"  # redone
+    assert not panel._redo_btn.isEnabled()  # stack drained
+
+
+def test_new_edit_clears_redo_stack(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    panel._project.append(UserSetCell(row_id="UID1", column="task", value="x", previous="rest"))
+    panel._reload_active_version()
+    panel._on_undo()
+    assert panel._redo_stack  # something is redoable
+
+    panel._on_user_edited()  # a fresh edit diverges the timeline
+    assert not panel._redo_stack
+
+
+def test_undo_is_noop_when_last_event_is_structural(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    _add_version(root, "raw", _inventory_df(), str(tmp_path / "raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    # Last event is ScanImported (structural) -> undo must not pop it.
+    panel._on_undo()
+    assert panel._model.dataframe().iloc[0]["task"] == "rest"  # unchanged
+
+
+def test_relocate_source_persists_to_version_meta(
+    qtbot, isolated_settings, tmp_path, monkeypatch,
+):
+    from bidsmgr.gui import converter_panel as cp
+
+    root = tmp_path / "ds"
+    proj = open_or_create_workspace(root)
+    vdir, _ = _add_version(root, "raw", _inventory_df(), str(tmp_path / "old_raw"))
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+
+    new_raw = tmp_path / "new_raw"
+    new_raw.mkdir()
+    monkeypatch.setattr(
+        cp.QFileDialog, "getExistingDirectory", lambda *a, **k: str(new_raw),
+    )
+    panel._on_pick_raw_dir()
+
+    assert panel._raw_root == new_raw
+    assert workspace.read_version_meta(vdir)["raw_root"] == str(new_raw)
+
+
+def test_set_project_without_scan_is_noop(qtbot, isolated_settings, tmp_path):
+    root = tmp_path / "fresh"
+    proj = open_or_create_workspace(root)
+    panel = ConverterPanel(project=proj)
+    qtbot.addWidget(panel)
+    panel.set_project(proj, root)
+    assert panel._model is None
+    assert panel._scans_combo.isHidden()  # no versions -> picker hidden

--- a/tests/gui/test_scan_rules.py
+++ b/tests/gui/test_scan_rules.py
@@ -1,0 +1,96 @@
+"""GUI smoke tests for the Settings 'Scan rules' tab + rules persistence."""
+
+from __future__ import annotations
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QAbstractItemView, QTableWidget, QTabWidget
+
+from bidsmgr.gui.app_settings import AppSettings
+from bidsmgr.gui.settings_dialog import SettingsDialog
+
+pytestmark = pytest.mark.gui
+
+
+def test_dialog_has_scan_rules_tab(qtbot) -> None:
+    dlg = SettingsDialog(AppSettings(), None)
+    qtbot.addWidget(dlg)
+    tabs = dlg.findChild(QTabWidget)
+    titles = [tabs.tabText(i) for i in range(tabs.count())]
+    assert "Scan rules" in titles
+    # Editable tables present.
+    assert isinstance(dlg._excl_table, QTableWidget)
+    assert isinstance(dlg._hint_table, QTableWidget)
+
+
+def test_builtin_criteria_table_populated_and_readonly(qtbot) -> None:
+    dlg = SettingsDialog(AppSettings(), None)
+    qtbot.addWidget(dlg)
+    t = QTableWidget(0, 4)
+    SettingsDialog._populate_builtin_criteria(t)
+    assert t.rowCount() > 10           # SEQUENCE_HINTS + DWI + task patterns
+    # Read-only: items lack the editable flag.
+    it = t.item(0, 0)
+    assert not (it.flags() & Qt.ItemFlag.ItemIsEditable)
+
+
+def test_read_scan_rules_valid(qtbot) -> None:
+    dlg = SettingsDialog(AppSettings(), None)
+    qtbot.addWidget(dlg)
+    dlg._add_exclusion_row("calibration", "sequence", "substring")
+    dlg._add_hint_row("lab_t1, my_mprage", "anat", "T1w", "", "substring", True)
+    hints, excl, err = dlg._read_scan_rules()
+    assert err is None
+    assert excl == [{"pattern": "calibration", "target": "sequence", "match_mode": "substring"}]
+    assert hints[0]["datatype"] == "anat" and hints[0]["suffix"] == "T1w" and hints[0]["force"] is True
+    assert hints[0]["patterns"] == ["lab_t1", "my_mprage"]
+
+
+def test_hint_datatype_suffix_are_constrained_dropdowns(qtbot) -> None:
+    """Datatype + suffix are dropdowns of valid BIDS labels (no free text);
+    suffix re-fills when the datatype changes, and 'derivatives' is absent."""
+    from PyQt6.QtWidgets import QComboBox
+    dlg = SettingsDialog(AppSettings(), None)
+    qtbot.addWidget(dlg)
+    dlg._add_hint_row("seq", "anat", "T1w", "", "substring", False)
+    dt_cb = dlg._hint_table.cellWidget(0, 1)
+    sfx_cb = dlg._hint_table.cellWidget(0, 2)
+    assert isinstance(dt_cb, QComboBox) and isinstance(sfx_cb, QComboBox)
+    dt_items = [dt_cb.itemText(i) for i in range(dt_cb.count())]
+    assert "derivatives" not in dt_items
+    assert "anat" in dt_items and "func" in dt_items
+    # anat suffixes include T1w, not bold.
+    anat_suffixes = [sfx_cb.itemText(i) for i in range(sfx_cb.count())]
+    assert "T1w" in anat_suffixes and "bold" not in anat_suffixes
+    # Switching the datatype re-fills the suffix list.
+    dt_cb.setCurrentText("func")
+    func_suffixes = [sfx_cb.itemText(i) for i in range(sfx_cb.count())]
+    assert "bold" in func_suffixes and "T1w" not in func_suffixes
+
+
+def test_persistence_round_trip(qtbot, isolated_settings) -> None:
+    s = AppSettings.load()
+    s.user_hints = [{"patterns": ["lab_t1"], "datatype": "anat", "suffix": "T1w", "force": True}]
+    s.scan_exclusions = [{"pattern": "calib", "target": "sequence", "match_mode": "substring"}]
+    s.save()
+    s2 = AppSettings.load()
+    assert s2.user_hints == s.user_hints
+    assert s2.scan_exclusions == s.scan_exclusions
+    # Boundary converters produce the engine dataclasses.
+    hints = s2.to_user_hints()
+    assert hints[0].force is True and hints[0].datatype == "anat"
+    # Defaults are empty (Restore-defaults path).
+    assert AppSettings().user_hints == [] and AppSettings().scan_exclusions == []
+
+
+def test_load_into_widgets_then_restore_defaults(qtbot, isolated_settings) -> None:
+    s = AppSettings.load()
+    s.user_hints = [{"patterns": ["a"], "datatype": "anat", "suffix": "T1w"}]
+    s.scan_exclusions = [{"pattern": "x", "target": "path", "match_mode": "substring"}]
+    dlg = SettingsDialog(s, None)
+    qtbot.addWidget(dlg)
+    assert dlg._hint_table.rowCount() == 1
+    assert dlg._excl_table.rowCount() == 1
+    dlg._on_restore_defaults()
+    assert dlg._hint_table.rowCount() == 0
+    assert dlg._excl_table.rowCount() == 0

--- a/tests/gui/test_settings_and_workers.py
+++ b/tests/gui/test_settings_and_workers.py
@@ -61,14 +61,12 @@ def test_app_settings_save_and_reload(isolated_settings) -> None:
     s.theme = "light"
     s.scan_n_jobs = 8
     s.scan_probe_convert = True
-    s.scan_montage = "standard_1005"
     s.post_run_validate = False
     s.save()
     reloaded = AppSettings.load()
     assert reloaded.theme == "light"
     assert reloaded.scan_n_jobs == 8
     assert reloaded.scan_probe_convert is True
-    assert reloaded.scan_montage == "standard_1005"
     assert reloaded.post_run_validate is False
 
 

--- a/tests/gui/test_settings_and_workers.py
+++ b/tests/gui/test_settings_and_workers.py
@@ -149,12 +149,14 @@ def test_mandatory_columns_cannot_be_hidden(isolated_settings, qtbot) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_dataset_column_is_editable_in_inspector() -> None:
-    """The ``dataset`` column partitions the convert queue per-row, so it
-    must be user-editable from the table without needing a global toolbar
-    input."""
+def test_dataset_column_is_read_only_in_inspector() -> None:
+    """The ``dataset`` column is owned by the project / locked output folder
+    (it determines the conversion target dir), so it is read-only and excluded
+    from bulk edits to prevent accidental misrouting."""
+    from bidsmgr.gui.models.inventory import InventoryTableModel
     dataset = next(c for c in COLUMNS if c.key == "dataset")
-    assert dataset.editable is True
+    assert dataset.editable is False
+    assert "dataset" not in InventoryTableModel.BULK_EDITABLE_KEYS
 
 
 def test_tsv_filename_input_seeded_from_settings(isolated_settings, qtbot) -> None:

--- a/tests/gui/test_settings_and_workers.py
+++ b/tests/gui/test_settings_and_workers.py
@@ -52,8 +52,14 @@ def test_app_settings_load_defaults(isolated_settings) -> None:
     s = AppSettings.load()
     assert s.theme == "dark"
     assert s.scan_n_jobs == 1
-    assert s.scan_probe_convert is False
+    # Default-on: probe-convert, skip-residuals, and the whole post-convert chain.
+    assert s.scan_probe_convert is True
+    assert s.convert_skip_residuals is True
     assert s.post_run_metadata is True
+    assert s.post_metadata_fill_todos is True
+    assert s.post_run_validate is True
+    assert s.post_validate_strict is True
+    assert s.post_validate_html is True
 
 
 def test_app_settings_save_and_reload(isolated_settings) -> None:
@@ -73,13 +79,11 @@ def test_app_settings_save_and_reload(isolated_settings) -> None:
 def test_remember_helpers_persist_individually(isolated_settings, tmp_path) -> None:
     AppSettings.remember_raw_root(tmp_path / "a")
     AppSettings.remember_bids_parent(tmp_path / "b")
-    AppSettings.remember_dataset_slug("study42")
     AppSettings.remember_theme("light")
 
     s = AppSettings.load()
     assert s.raw_root == str(tmp_path / "a")
     assert s.bids_parent == str(tmp_path / "b")
-    assert s.dataset_slug == "study42"
     assert s.theme == "light"
 
 
@@ -205,11 +209,6 @@ def test_scan_click_writes_tsv_under_bids_parent(isolated_settings, qtbot, tmp_p
     assert (out / "inv.tsv").exists()
     # The old behaviour wrote into the raw folder — make sure that's gone.
     assert not (raw / ".bidsmgr_scan.tsv").exists()
-
-
-def test_default_dataset_slug_helper() -> None:
-    assert ConverterPanel._default_dataset_slug(Path("/x/My Study v2")) == "my-study-v2"
-    assert ConverterPanel._default_dataset_slug(Path("/tmp/abc__def")) == "abc__def"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gui/test_side_panes.py
+++ b/tests/gui/test_side_panes.py
@@ -246,7 +246,13 @@ def test_filter_pane_per_sequence_leaves_show_basenames(qtbot) -> None:
     ``proposed_basename`` (or fallback)."""
     df = make_df([
         _func_row(proposed_basename="sub-001_ses-pre_task-rest_bold", series_uid="1.1"),
-        _func_row(proposed_basename="sub-001_ses-pre_task-mb_bold",   series_uid="2.2"),
+        _func_row(
+            proposed_basename="sub-001_ses-pre_task-mb_bold", series_uid="2.2",
+            task="mb",
+            entities=json.dumps(
+                {"subject": "001", "session": "pre", "task": "mb"}, sort_keys=True,
+            ),
+        ),
     ])
     model = InventoryTableModel(df)
     pane = FilterPane()
@@ -270,7 +276,11 @@ def test_filter_pane_unchecking_one_sequence_only_toggles_that_row(qtbot) -> Non
         _func_row(proposed_basename="sub-001_ses-pre_task-rest_bold",
                   series_uid="1.1"),
         _func_row(proposed_basename="sub-001_ses-pre_task-mb_bold",
-                  series_uid="2.2"),
+                  series_uid="2.2", task="mb",
+                  entities=json.dumps(
+                      {"subject": "001", "session": "pre", "task": "mb"},
+                      sort_keys=True,
+                  )),
     ])
     model = InventoryTableModel(df)
     pane = FilterPane()

--- a/tests/gui/test_sidecar_edit.py
+++ b/tests/gui/test_sidecar_edit.py
@@ -488,3 +488,37 @@ def test_binary_file_does_not_crash_set_file(
     # Belt + suspenders: pointing the helper at the same binary file
     # also returns None instead of raising.
     assert _load_json_ordered(nii_path) is None
+
+
+def test_sidecar_undo_redo(qapp, tmp_path: Path) -> None:
+    from bidsmgr.gui.widgets.sidecar_form_pane import SidecarFormPane
+    js = tmp_path / "sub-01_task-x_bold.json"
+    js.write_text(json.dumps({"TaskName": "rest", "RepetitionTime": 2.0}), encoding="utf-8")
+    pane = SidecarFormPane()
+    pane.set_file(js, tmp_path, None)
+    assert not pane.can_undo()  # nothing to undo at load
+
+    pane._on_field_committed("TaskName", "memory", "str")
+    assert pane.can_undo()
+    assert pane._json_cache["TaskName"] == "memory"
+
+    pane.undo()
+    assert pane._json_cache["TaskName"] == "rest"
+    assert pane.can_redo()
+
+    pane.redo()
+    assert pane._json_cache["TaskName"] == "memory"
+    assert not pane.can_redo()
+
+
+def test_sidecar_revert_clears_history(qapp, tmp_path: Path) -> None:
+    from bidsmgr.gui.widgets.sidecar_form_pane import SidecarFormPane
+    js = tmp_path / "s.json"
+    js.write_text(json.dumps({"TaskName": "rest"}), encoding="utf-8")
+    pane = SidecarFormPane()
+    pane.set_file(js, tmp_path, None)
+    pane._on_field_committed("TaskName", "memory", "str")
+    assert pane.can_undo()
+    pane.revert()
+    assert pane._json_cache["TaskName"] == "rest"
+    assert not pane.can_undo() and not pane.can_redo()  # history reset on revert

--- a/tests/gui/test_theme_refresh.py
+++ b/tests/gui/test_theme_refresh.py
@@ -117,8 +117,8 @@ def test_placeholder_labels_use_pane_hint_object_name(qapp) -> None:
         lbl for lbl in win.findChildren(QLabel)
         if lbl.objectName() == "pane-hint"
     ]
-    # At least one hint per: raw FS pane, filter pane, conflicts tab,
-    # stats tab, inspection-stack empty, plus the "(coming in a later
-    # milestone)" placeholders. We don't pin an exact count — just that
-    # the namespace is in use.
+    # At least one hint per: raw FS pane, filter pane, stats tab,
+    # inspection-stack empty, plus the "(coming in a later milestone)"
+    # placeholders. We don't pin an exact count — just that the namespace
+    # is in use.
     assert len(hints) >= 3

--- a/tests/gui/test_tsv_viewer.py
+++ b/tests/gui/test_tsv_viewer.py
@@ -549,3 +549,36 @@ def test_root_swap_clears_tsv_viewer(
     panel._set_root(other, persist=False)
     assert panel._tsv_viewer.current_file() is None
     assert panel._center_stack.currentWidget() is panel._sidecar_form
+
+
+def test_tsv_undo_redo(qapp, bids_root: Path) -> None:
+    pane = TsvViewerPane()
+    events = bids_root / "sub-01" / "ses-01" / "func" / "sub-01_ses-01_task-x_events.tsv"
+    events.parent.mkdir(parents=True, exist_ok=True)
+    events.write_text("onset\tduration\n0\t1\n", encoding="utf-8")
+    pane.set_file(events, bids_root)
+    assert not pane.can_undo()  # nothing to undo at load
+
+    pane._model.item(0, 0).setText("5")  # edit a cell
+    assert pane.can_undo() and pane.is_dirty()
+    assert pane._model.item(0, 0).text() == "5"
+
+    pane.undo()
+    assert pane._model.item(0, 0).text() == "0"
+    assert not pane.is_dirty() and pane.can_redo()
+
+    pane.redo()
+    assert pane._model.item(0, 0).text() == "5"
+    assert pane.is_dirty()
+
+
+def test_tsv_new_edit_clears_redo(qapp, bids_root: Path) -> None:
+    pane = TsvViewerPane()
+    events = bids_root / "e.tsv"
+    events.write_text("a\tb\n1\t2\n", encoding="utf-8")
+    pane.set_file(events, bids_root)
+    pane._model.item(0, 0).setText("x")
+    pane.undo()
+    assert pane.can_redo()
+    pane._model.item(0, 1).setText("y")  # a fresh edit diverges the timeline
+    assert not pane.can_redo()

--- a/tests/gui/test_tsv_viewer.py
+++ b/tests/gui/test_tsv_viewer.py
@@ -16,12 +16,30 @@ import io
 from pathlib import Path
 
 import pytest
+from PyQt6.QtCore import Qt
 
 from bidsmgr.gui.editor_panel import EditorPanel
 from bidsmgr.gui.widgets.tsv_viewer_pane import TsvViewerPane, _read_tsv
 
 
 pytestmark = pytest.mark.gui
+
+
+# ---------------------------------------------------------------------------
+# Model helpers (the table model is a lazy QAbstractTableModel now, not a
+# QStandardItemModel, so cells are read/written via the model index API).
+# ---------------------------------------------------------------------------
+def _cell(pane, r, c):
+    return pane._model.data(pane._model.index(r, c))
+
+
+def _set_cell(pane, r, c, value):
+    pane._model.setData(pane._model.index(r, c), value)
+
+
+def _hdr(pane, i):
+    return pane._model.headerData(i, Qt.Orientation.Horizontal)
+
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +74,32 @@ def bids_root(tmp_path: Path) -> Path:
         "participant_id\tage\nsub-01\t27\n"
     )
     return root
+
+
+# ---------------------------------------------------------------------------
+# Helpers - TSV loading is threaded (NIfTI pattern), so tests must let the
+# worker finish before asserting on the populated model. Polling on the
+# pane's ``_loader`` is race-free (set to None in the load callbacks).
+# ---------------------------------------------------------------------------
+def _load(pane, path, root, qapp, timeout_ms: int = 10000) -> None:
+    from PyQt6.QtCore import QElapsedTimer
+
+    pane.set_file(path, root)
+    t = QElapsedTimer()
+    t.start()
+    while pane._loader is not None and t.elapsed() < timeout_ms:
+        qapp.processEvents()
+    qapp.processEvents()
+
+
+def _wait_loaded(viewer, qapp, timeout_ms: int = 10000) -> None:
+    from PyQt6.QtCore import QElapsedTimer
+
+    t = QElapsedTimer()
+    t.start()
+    while viewer._loader is not None and t.elapsed() < timeout_ms:
+        qapp.processEvents()
+    qapp.processEvents()
 
 
 # ---------------------------------------------------------------------------
@@ -127,29 +171,32 @@ def test_set_file_populates_table(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     assert pane.current_file() == events
     assert pane._stack.currentIndex() == 1  # table visible
     assert pane._model.columnCount() == 3
     assert pane._model.rowCount() == 3
     # Column headers come from the first line of the file.
     headers = [
-        pane._model.horizontalHeaderItem(i).text()
+        _hdr(pane, i)
         for i in range(pane._model.columnCount())
     ]
     assert headers == ["onset", "duration", "trial_type"]
     # First data row.
-    assert pane._model.item(0, 0).text() == "0"
-    assert pane._model.item(0, 2).text() == "cue"
+    assert _cell(pane, 0, 0) == "0"
+    assert _cell(pane, 0, 2) == "cue"
 
 
-def test_set_file_handles_tsv_gz(qapp, bids_root: Path) -> None:
+def test_set_file_handles_tsv_gz(qapp, qtbot, bids_root: Path) -> None:
     pane = TsvViewerPane()
     gz = (
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_physio.tsv.gz"
     )
-    pane.set_file(gz, bids_root)
+    # .gz tables always load on a background thread (uncompressed size is
+    # opaque), so wait for the parse to land before asserting.
+    with qtbot.waitSignal(pane.loaded, timeout=10000):
+        pane.set_file(gz, bids_root)
     assert pane._model.columnCount() == 2
     assert pane._model.rowCount() == 2
 
@@ -160,7 +207,7 @@ def test_set_file_none_clears(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     pane.set_file(None, None)
     assert pane.current_file() is None
     assert pane._stack.currentIndex() == 0
@@ -173,7 +220,7 @@ def test_footer_summary_reports_dimensions(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     text = pane._footer_summary.text()
     assert "3 rows" in text and "3 columns" in text
 
@@ -185,7 +232,7 @@ def test_table_cells_are_editable(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     triggers = pane._table.editTriggers()
     # Cells respond to double-click and F2.
     assert bool(triggers & QAbstractItemView.EditTrigger.DoubleClicked)
@@ -202,11 +249,11 @@ def test_edit_cell_marks_pane_dirty(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     assert not pane.is_dirty()
     assert not pane._save_btn.isEnabled()
 
-    pane._model.item(0, 2).setText("custom_trial")
+    _set_cell(pane, 0, 2, "custom_trial")
     qapp.processEvents()
 
     assert pane.is_dirty()
@@ -225,8 +272,8 @@ def test_save_flushes_cells_to_disk(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
-    pane._model.item(0, 2).setText("custom_trial")
+    _load(pane, events, bids_root, qapp)
+    _set_cell(pane, 0, 2, "custom_trial")
     qapp.processEvents()
 
     with qtbot.waitSignal(pane.file_saved, timeout=500):
@@ -249,13 +296,13 @@ def test_add_row_appends_blank_row(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     before = pane._model.rowCount()
     pane._on_add_row()
     assert pane._model.rowCount() == before + 1
     # Newest row has the same column count and is empty.
     last = before
-    assert pane._model.item(last, 0).text() == ""
+    assert _cell(pane, last, 0) == ""
     assert pane.is_dirty()
 
 
@@ -265,7 +312,7 @@ def test_delete_row_removes_selected_row(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     before = pane._model.rowCount()
     # Select the first row.
     pane._table.setCurrentIndex(pane._model.index(0, 0))
@@ -292,17 +339,16 @@ def test_add_column_appends_with_user_name(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     before_cols = pane._model.columnCount()
     pane._on_add_column()
 
     assert pane._model.columnCount() == before_cols + 1
     new_idx = before_cols
-    header_item = pane._model.horizontalHeaderItem(new_idx)
-    assert header_item.text() == "extra"
+    assert _hdr(pane, new_idx) == "extra"
     # Every existing row got a blank cell in the new column.
     for r in range(pane._model.rowCount()):
-        assert pane._model.item(r, new_idx).text() == ""
+        assert _cell(pane, r, new_idx) == ""
     assert pane.is_dirty()
 
 
@@ -322,7 +368,7 @@ def test_add_column_cancel_is_noop(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     before = pane._model.columnCount()
     pane._on_add_column()
     assert pane._model.columnCount() == before
@@ -335,14 +381,14 @@ def test_delete_column_removes_selected_column(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     before = pane._model.columnCount()
     pane._table.setCurrentIndex(pane._model.index(0, 1))  # duration column
     pane._on_delete_column()
     assert pane._model.columnCount() == before - 1
     # The remaining headers no longer include "duration".
     remaining = [
-        pane._model.horizontalHeaderItem(i).text()
+        _hdr(pane, i)
         for i in range(pane._model.columnCount())
     ]
     assert "duration" not in remaining
@@ -355,14 +401,14 @@ def test_revert_reloads_from_disk(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     pane._on_add_row()
-    pane._model.item(pane._model.rowCount() - 1, 0).setText("99")
+    _set_cell(pane, pane._model.rowCount() - 1, 0, "99")
     qapp.processEvents()
     assert pane.is_dirty()
 
-    pane.revert()
-    qapp.processEvents()
+    pane.revert()  # revert re-reads from disk on the worker thread
+    _wait_loaded(pane, qapp)
 
     assert not pane.is_dirty()
     # Disk unchanged (we never saved), and the in-memory row count
@@ -378,8 +424,9 @@ def test_save_handles_tsv_gz(qapp, qtbot, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_physio.tsv.gz"
     )
-    pane.set_file(gz, bids_root)
-    pane._model.item(0, 0).setText("99")
+    with qtbot.waitSignal(pane.loaded, timeout=10000):
+        pane.set_file(gz, bids_root)
+    _set_cell(pane, 0, 0, "99")
     qapp.processEvents()
 
     with qtbot.waitSignal(pane.file_saved, timeout=500):
@@ -398,8 +445,8 @@ def test_save_failed_signal_on_io_error(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
-    pane._model.item(0, 0).setText("X")
+    _load(pane, events, bids_root, qapp)
+    _set_cell(pane, 0, 0, "X")
     qapp.processEvents()
 
     def _explode(self_, path):
@@ -421,7 +468,7 @@ def test_save_with_no_dirty_state_is_noop(qapp, bids_root: Path) -> None:
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     mtime_before = events.stat().st_mtime_ns
     assert pane.save() is True
     assert events.stat().st_mtime_ns == mtime_before
@@ -435,29 +482,46 @@ def test_switching_files_discards_unsaved_edits(
         bids_root / "sub-01" / "ses-01" / "func"
         / "sub-01_ses-01_task-rest_events.tsv"
     )
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     pane._on_add_row()
     assert pane.is_dirty()
 
     participants = bids_root / "participants.tsv"
-    pane.set_file(participants, bids_root)
+    _load(pane, participants, bids_root, qapp)
     # Loading a different file resets dirty state.
     assert not pane.is_dirty()
     # Original file unchanged on disk.
     assert "99" not in events.read_text()
 
 
+def test_large_tsv_reports_total_and_caps(qapp, tmp_path: Path) -> None:
+    """A big TSV reads its real total but caps the preview - and (with the
+    pandas C parser) loads on the worker without freezing the GUI."""
+    from bidsmgr.gui.widgets.tsv_viewer_pane import _MAX_PREVIEW_ROWS
+
+    p = tmp_path / "big.tsv"
+    extra = 2500
+    with open(p, "w") as f:
+        f.write("a\tb\n")
+        for i in range(_MAX_PREVIEW_ROWS + extra):
+            f.write(f"{i}\t{i * 2}\n")
+    pane = TsvViewerPane()
+    _load(pane, p, tmp_path, qapp)
+    assert pane._model.rowCount() == _MAX_PREVIEW_ROWS
+    assert str(_MAX_PREVIEW_ROWS + extra) in pane._footer_summary.text()
+
+
 def test_ragged_row_is_padded_to_header_width(qapp, tmp_path: Path) -> None:
     p = tmp_path / "ragged.tsv"
     p.write_text("a\tb\tc\n1\t2\n3\t4\t5\n")
     pane = TsvViewerPane()
-    pane.set_file(p, tmp_path)
+    _load(pane, p, tmp_path, qapp)
     # Header has 3 columns; first data row has 2 cells but is padded.
     assert pane._model.columnCount() == 3
     assert pane._model.rowCount() == 2
-    assert pane._model.item(0, 0).text() == "1"
-    assert pane._model.item(0, 1).text() == "2"
-    assert pane._model.item(0, 2).text() == ""
+    assert _cell(pane, 0, 0) == "1"
+    assert _cell(pane, 0, 1) == "2"
+    assert _cell(pane, 0, 2) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -476,7 +540,7 @@ def test_clicking_tsv_swaps_center_pane_to_table(
         / "sub-01_ses-01_task-rest_events.tsv"
     )
     panel._on_file_selected(events)
-    qapp.processEvents()
+    _wait_loaded(panel._tsv_viewer, qapp)
 
     # Center stack now shows the TSV viewer.
     assert panel._center_stack.currentWidget() is panel._tsv_viewer
@@ -496,7 +560,7 @@ def test_clicking_json_swaps_back_to_sidecar(
         / "sub-01_ses-01_task-rest_events.tsv"
     )
     panel._on_file_selected(events)
-    qapp.processEvents()
+    _wait_loaded(panel._tsv_viewer, qapp)
     assert panel._center_stack.currentWidget() is panel._tsv_viewer
 
     json_path = (
@@ -521,7 +585,7 @@ def test_clicking_directory_returns_to_sidecar_view(
         / "sub-01_ses-01_task-rest_events.tsv"
     )
     panel._on_file_selected(events)
-    qapp.processEvents()
+    _wait_loaded(panel._tsv_viewer, qapp)
     assert panel._center_stack.currentWidget() is panel._tsv_viewer
 
     anat = bids_root / "sub-01" / "ses-01" / "anat"
@@ -541,7 +605,7 @@ def test_root_swap_clears_tsv_viewer(
         / "sub-01_ses-01_task-rest_events.tsv"
     )
     panel._on_file_selected(events)
-    qapp.processEvents()
+    _wait_loaded(panel._tsv_viewer, qapp)
     assert panel._tsv_viewer.current_file() == events
 
     other = tmp_path / "Other"
@@ -556,19 +620,19 @@ def test_tsv_undo_redo(qapp, bids_root: Path) -> None:
     events = bids_root / "sub-01" / "ses-01" / "func" / "sub-01_ses-01_task-x_events.tsv"
     events.parent.mkdir(parents=True, exist_ok=True)
     events.write_text("onset\tduration\n0\t1\n", encoding="utf-8")
-    pane.set_file(events, bids_root)
+    _load(pane, events, bids_root, qapp)
     assert not pane.can_undo()  # nothing to undo at load
 
-    pane._model.item(0, 0).setText("5")  # edit a cell
+    _set_cell(pane, 0, 0, "5")  # edit a cell
     assert pane.can_undo() and pane.is_dirty()
-    assert pane._model.item(0, 0).text() == "5"
+    assert _cell(pane, 0, 0) == "5"
 
     pane.undo()
-    assert pane._model.item(0, 0).text() == "0"
+    assert _cell(pane, 0, 0) == "0"
     assert not pane.is_dirty() and pane.can_redo()
 
     pane.redo()
-    assert pane._model.item(0, 0).text() == "5"
+    assert _cell(pane, 0, 0) == "5"
     assert pane.is_dirty()
 
 
@@ -576,9 +640,9 @@ def test_tsv_new_edit_clears_redo(qapp, bids_root: Path) -> None:
     pane = TsvViewerPane()
     events = bids_root / "e.tsv"
     events.write_text("a\tb\n1\t2\n", encoding="utf-8")
-    pane.set_file(events, bids_root)
-    pane._model.item(0, 0).setText("x")
+    _load(pane, events, bids_root, qapp)
+    _set_cell(pane, 0, 0, "x")
     pane.undo()
     assert pane.can_redo()
-    pane._model.item(0, 1).setText("y")  # a fresh edit diverges the timeline
+    _set_cell(pane, 0, 1, "y")  # a fresh edit diverges the timeline
     assert not pane.can_redo()

--- a/tests/gui/test_validation_pane.py
+++ b/tests/gui/test_validation_pane.py
@@ -26,10 +26,11 @@ from bidsmgr.editor.types import (
     ValidationReport,
 )
 from bidsmgr.gui.editor_panel import EditorPanel
+from bidsmgr.gui.widgets import Chip
 from bidsmgr.gui.widgets.val_message import ValMessage
 from bidsmgr.gui.widgets.validation_pane import (
     ValidationPane,
-    _count_chip_object_name,
+    _count_chip_kind,
     _folder_key_for,
 )
 
@@ -101,14 +102,14 @@ def _report_with_three_levels(bids_root: Path) -> ValidationReport:
 
 
 def test_count_chip_picks_worst_severity() -> None:
-    assert _count_chip_object_name([]) == "val-count-ok"
-    assert _count_chip_object_name(
+    assert _count_chip_kind([]) == ""  # neutral / default Chip
+    assert _count_chip_kind(
         [_make_issue(Severity.WARN, "r", "m")]
-    ) == "val-count-warn"
-    assert _count_chip_object_name([
+    ) == "warn"
+    assert _count_chip_kind([
         _make_issue(Severity.WARN, "r", "m"),
         _make_issue(Severity.ERR, "r", "m"),
-    ]) == "val-count-err"
+    ]) == "err"
 
 
 def test_folder_key_relative_to_root(tmp_path: Path) -> None:
@@ -237,20 +238,15 @@ def test_count_chip_object_names_match_severity(
     target = bids_root / "sub-01" / "ses-01" / "anat" / "sub-01_ses-01_T1w.json"
     pane.set_current_file(target, bids_root)
 
-    chips = [
-        lbl for lbl in pane._body.findChildren(QLabel)
-        if lbl.objectName() in (
-            "val-count-ok", "val-count-warn", "val-count-err",
-        )
-    ]
+    chips = pane._body.findChildren(Chip)
     assert len(chips) == 3
-    object_names = [c.objectName() for c in chips]
+    kinds = [c.property("chipKind") for c in chips]
     # Dataset section has one ERR → err chip.
-    assert object_names[0] == "val-count-err"
+    assert kinds[0] == "err"
     # Folder section has one WARN → warn chip.
-    assert object_names[1] == "val-count-warn"
+    assert kinds[1] == "warn"
     # File section has one ERR → err chip.
-    assert object_names[2] == "val-count-err"
+    assert kinds[2] == "err"
 
 
 def test_repaint_for_palette_forces_qss_re_evaluation(
@@ -436,12 +432,9 @@ def test_schema_audit_section_appears_for_json_with_fields(
     ]
     assert "Schema audit" in titles
     # Required-missing rolls the chip up to err.
-    chips = [
-        lbl for lbl in pane._body.findChildren(QLabel)
-        if lbl.objectName() in ("val-count-ok", "val-count-warn", "val-count-err")
-    ]
+    chips = pane._body.findChildren(Chip)
     audit_chip = chips[-1]
-    assert audit_chip.objectName() == "val-count-err"
+    assert audit_chip.property("chipKind") == "err"
     assert "missing required" in audit_chip.text()
     # Missing field name surfaces in the audit body.
     miss_labels = [
@@ -477,12 +470,9 @@ def test_schema_audit_chip_is_ok_when_nothing_missing(
     )
     pane.set_report(report)
     pane.set_current_file(bids_root / rel, bids_root)
-    chips = [
-        lbl for lbl in pane._body.findChildren(QLabel)
-        if lbl.objectName() in ("val-count-ok", "val-count-warn", "val-count-err")
-    ]
+    chips = pane._body.findChildren(Chip)
     audit_chip = chips[-1]
-    assert audit_chip.objectName() == "val-count-ok"
+    assert audit_chip.property("chipKind") == "default"
 
 
 def test_schema_audit_section_omitted_when_no_fields(

--- a/tests/gui/test_view_switcher.py
+++ b/tests/gui/test_view_switcher.py
@@ -15,23 +15,27 @@ from bidsmgr.gui.converter_panel import ConverterPanel
 from bidsmgr.gui.editor_panel import EditorPanel
 from bidsmgr.gui.main_window import MainWindow
 from bidsmgr.gui.theme_manager import ThemeManager
+from bidsmgr.gui.welcome_panel import WelcomePanel
 
 
 pytestmark = pytest.mark.gui
 
 
-def test_stack_hosts_both_panels(qapp, isolated_settings) -> None:
+def test_stack_hosts_three_panels(qapp, isolated_settings) -> None:
     theme = ThemeManager(qapp)
     theme.apply("dark")
     win = MainWindow(theme)
     qapp.processEvents()
 
-    assert win.stack.count() == 2
+    assert win.stack.count() == 3
     assert isinstance(win.stack.widget(0), ConverterPanel)
     assert isinstance(win.stack.widget(1), EditorPanel)
-    # Default is Converter when no setting persisted.
-    assert win.stack.currentIndex() == 0
-    assert win._header._converter_btn.isChecked()
+    assert isinstance(win.stack.widget(2), WelcomePanel)
+    # Project-first: with no project bound the window lands on the Welcome
+    # (Home) tab; Converter/Editor stay reachable via their pills.
+    assert win.stack.currentIndex() == 2
+    assert win._header._welcome_btn.isChecked()
+    assert not win._header._converter_btn.isChecked()
     assert not win._header._editor_btn.isChecked()
 
 
@@ -60,14 +64,20 @@ def test_view_change_signal_swaps_stack_and_persists(
     assert AppSettings.load().active_view == "converter"
 
 
-def test_persisted_active_view_restores_on_construction(
-    qapp, isolated_settings,
+def test_persisted_active_view_restores_with_project(
+    qapp, isolated_settings, tmp_path,
 ) -> None:
+    # The persisted Converter/Editor view is restored only when a project is
+    # bound at construction (the ``--project`` path). With no project the window
+    # lands on Welcome regardless (see test_stack_hosts_three_panels).
+    from bidsmgr.cli.create import open_or_create_workspace
+
     AppSettings.remember_active_view("editor")
+    proj = open_or_create_workspace(tmp_path / "ds")
 
     theme = ThemeManager(qapp)
     theme.apply("dark")
-    win = MainWindow(theme)
+    win = MainWindow(theme, project=proj)
     qapp.processEvents()
 
     assert win.stack.currentIndex() == 1

--- a/tests/gui/test_welcome.py
+++ b/tests/gui/test_welcome.py
@@ -139,6 +139,94 @@ def test_theme_swap_repaints_welcome(qapp, isolated_settings, monkeypatch) -> No
     assert len(calls) == 2
 
 
+def test_resources_card_lists_links(qtbot, isolated_settings) -> None:
+    from PyQt6.QtWidgets import QLabel
+
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    links = [
+        l for l in panel.findChildren(QLabel) if l.objectName() == "welcome-link"
+    ]
+    # 3 resource links + 4 sample datasets = 7 clickable links, all external.
+    assert len(links) == 7
+    assert all(l.openExternalLinks() for l in links)
+    hrefs = " ".join(l.text() for l in links)
+    assert "bids_manager_documentation" in hrefs       # docs site
+    assert "github.com/ANCPLabOldenburg" in hrefs       # source
+    assert "cloud.uol.de" in hrefs                       # sample data
+    # Raw URLs never show as the visible text — friendly labels only.
+    assert ">Documentation website<" in hrefs
+    assert ">MEG Elekta sample dataset<" in hrefs
+
+
+def test_recent_rows_carry_name_and_path(qtbot, isolated_settings, tmp_path) -> None:
+    from bidsmgr.gui.welcome_panel import (
+        _RECENT_MISSING_ROLE,
+        _RECENT_NAME_ROLE,
+        _RECENT_PATH_ROLE,
+    )
+
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    # A real project (named) plus a now-missing one.
+    root = panel.create_project(tmp_path, "Fancy Name")
+    AppSettings.remember_recent_project(tmp_path / "gone")
+    panel.refresh_recent()
+
+    by_path = {
+        panel._recent.item(i).data(_RECENT_PATH_ROLE): panel._recent.item(i)
+        for i in range(panel._recent.count())
+    }
+    real = by_path[str(root)]
+    assert real.data(_RECENT_NAME_ROLE) == "Fancy Name"      # dataset Name, not slug
+    assert real.data(_RECENT_MISSING_ROLE) is False
+    missing = by_path[str(tmp_path / "gone")]
+    assert missing.data(_RECENT_MISSING_ROLE) is True
+
+
+def test_open_button_is_accent_styled(qtbot, isolated_settings) -> None:
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    # The blue-font open button keeps its dedicated object name (styled in QSS).
+    assert panel._open_btn.objectName() == "welcome-open-btn"
+
+
+def test_create_blocks_spaces_and_suggests_underscores(
+    qtbot, isolated_settings, tmp_path, monkeypatch,
+) -> None:
+    from PyQt6.QtWidgets import QMessageBox
+
+    shown: list = []
+    monkeypatch.setattr(
+        QMessageBox, "information", lambda *a, **k: shown.append(a),
+    )
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    created: list = []
+    panel.project_opened.connect(lambda p, r: created.append(r))
+
+    panel._location_edit.setText(str(tmp_path))
+    panel._name_edit.setText("My Study")
+    panel._on_inline_create()
+
+    # Nothing created; user was warned; the field is pre-filled with underscores.
+    assert created == []
+    assert shown, "expected an information dialog about spaces"
+    assert panel._name_edit.text() == "My_Study"
+    assert not (tmp_path / "My Study").exists()
+
+
+def test_parse_qcolor_handles_rgba_and_hex() -> None:
+    from bidsmgr.gui.welcome_panel import _parse_qcolor
+
+    c = _parse_qcolor("rgba(88,166,255,0.12)")
+    assert c.isValid()
+    assert (c.red(), c.green(), c.blue()) == (88, 166, 255)
+    assert c.alpha() == int(round(0.12 * 255))  # not 0/black
+    h = _parse_qcolor("#11161d")
+    assert (h.red(), h.green(), h.blue()) == (0x11, 0x16, 0x1d)
+
+
 def test_home_pill_returns_to_welcome(qapp, isolated_settings) -> None:
     theme = ThemeManager(qapp)
     theme.apply("dark")

--- a/tests/gui/test_welcome.py
+++ b/tests/gui/test_welcome.py
@@ -227,6 +227,36 @@ def test_parse_qcolor_handles_rgba_and_hex() -> None:
     assert (h.red(), h.green(), h.blue()) == (0x11, 0x16, 0x1d)
 
 
+def test_project_switcher_shows_and_switches(qapp, isolated_settings, tmp_path) -> None:
+    theme = ThemeManager(qapp)
+    theme.apply("dark")
+    win = MainWindow(theme)
+    qapp.processEvents()
+
+    # Hidden until a project is open.
+    assert win._header._project_btn.isHidden()
+
+    a = open_or_create_workspace(tmp_path / "StudyA", name="Study A")
+    AppSettings.remember_recent_project(tmp_path / "StudyA")
+    b = open_or_create_workspace(tmp_path / "StudyB", name="Study B")
+    AppSettings.remember_recent_project(tmp_path / "StudyB")
+
+    win._on_project_opened(a, tmp_path / "StudyA")
+    qapp.processEvents()
+    assert not win._header._project_btn.isHidden()
+    assert "Study A" in win._header._project_btn.text()
+
+    # The dropdown lists the current project header + the other recent.
+    win._header._rebuild_project_menu()
+    assert len(win._header._project_menu.actions()) >= 3
+
+    # Switching to a recent rebinds both views + relabels the switcher.
+    win._on_switch_project(tmp_path / "StudyB")
+    qapp.processEvents()
+    assert "Study B" in win._header._project_btn.text()
+    assert win.converter._bids_root == tmp_path / "StudyB"
+
+
 def test_home_pill_returns_to_welcome(qapp, isolated_settings) -> None:
     theme = ThemeManager(qapp)
     theme.apply("dark")

--- a/tests/gui/test_welcome.py
+++ b/tests/gui/test_welcome.py
@@ -1,0 +1,157 @@
+"""Tests for the project-first Welcome tab + lifecycle wiring (Phase D)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bidsmgr.cli._scaffold import project_bundle_dir
+from bidsmgr.cli.create import open_or_create_workspace
+from bidsmgr.gui.app_settings import AppSettings
+from bidsmgr.gui.main_window import MainWindow
+from bidsmgr.gui.theme_manager import ThemeManager
+from bidsmgr.gui.welcome_panel import WelcomePanel
+from bidsmgr.project import Project
+
+pytestmark = pytest.mark.gui
+
+
+def test_create_project_scaffolds_and_emits(qtbot, isolated_settings, tmp_path) -> None:
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    captured: list = []
+    panel.project_opened.connect(lambda proj, root: captured.append((proj, root)))
+
+    root = panel.create_project(tmp_path, "My Study")
+
+    # Slugified folder under the chosen parent.
+    assert root == tmp_path / "My-Study"
+    assert (root / "dataset_description.json").exists()
+    assert project_bundle_dir(root).exists()
+    dd = json.loads((root / "dataset_description.json").read_text())
+    assert dd["Name"] == "My Study"  # human name preserved
+    # Signal fired with a Project + the dataset root; recent list updated.
+    assert len(captured) == 1 and isinstance(captured[0][0], Project)
+    assert str(root) in AppSettings.load().recent_projects
+
+
+def test_open_project_adopts_existing(qtbot, isolated_settings, tmp_path) -> None:
+    # A dataset created out of band, no .bidsmgr bundle yet.
+    root = tmp_path / "external"
+    root.mkdir()
+    (root / "dataset_description.json").write_text(
+        json.dumps({"Name": "External", "BIDSVersion": "1.11.1"})
+    )
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    captured: list = []
+    panel.project_opened.connect(lambda proj, r: captured.append((proj, r)))
+
+    panel.open_project(root)
+
+    assert project_bundle_dir(root).exists()  # adopted: bundle added
+    assert json.loads((root / "dataset_description.json").read_text())["Name"] == "External"
+    assert len(captured) == 1
+
+
+def test_delete_project_from_disk(qtbot, isolated_settings, tmp_path) -> None:
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    root = panel.create_project(tmp_path, "Doomed")  # also adds to recent
+    assert root.exists() and str(root) in AppSettings.load().recent_projects
+
+    ok = panel.delete_project(root, from_disk=True)
+    assert ok
+    assert not root.exists()                                   # folder gone
+    assert str(root) not in AppSettings.load().recent_projects  # forgotten
+
+
+def test_remove_from_list_keeps_folder(qtbot, isolated_settings, tmp_path) -> None:
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    root = panel.create_project(tmp_path, "Keep")
+
+    panel.delete_project(root, from_disk=False)
+    assert root.exists()                                        # folder kept
+    assert str(root) not in AppSettings.load().recent_projects  # just forgotten
+
+
+def test_delete_refuses_non_dataset_folder(qtbot, isolated_settings, tmp_path) -> None:
+    # A plain folder (not a BIDS dataset / BM project) must never be rmtree'd.
+    plain = tmp_path / "not_a_dataset"
+    plain.mkdir()
+    (plain / "important.txt").write_text("keep me")
+    AppSettings.remember_recent_project(plain)
+
+    panel = WelcomePanel()
+    qtbot.addWidget(panel)
+    ok = panel.delete_project(plain, from_disk=True)
+    assert ok is False
+    assert plain.exists() and (plain / "important.txt").exists()  # untouched
+
+
+def test_mainwindow_lands_on_welcome_and_binds_on_open(
+    qapp, isolated_settings, tmp_path,
+) -> None:
+    theme = ThemeManager(qapp)
+    theme.apply("dark")
+    win = MainWindow(theme)
+    qapp.processEvents()
+
+    # Lands on Welcome (index 2) with no project.
+    assert win.stack.currentIndex() == 2
+
+    # Simulate the user creating a project from the Welcome tab.
+    root = tmp_path / "study"
+    proj = open_or_create_workspace(root, name="Study")
+    win._on_project_opened(proj, root)
+    qapp.processEvents()
+
+    # Switches to the Converter, binds the project, and soft-locks the output.
+    assert win.stack.currentIndex() == 0
+    assert win.converter._project is proj
+    assert win.converter._bids_root == root
+    assert win.converter._bids_pathbar.change_button.isEnabled() is False
+
+
+def test_theme_swap_repaints_welcome(qapp, isolated_settings, monkeypatch) -> None:
+    theme = ThemeManager(qapp)
+    theme.apply("dark")
+    win = MainWindow(theme)
+    qapp.processEvents()
+
+    calls: list = []
+    original = win.welcome.repaint_for_palette
+
+    def _spy(pal: dict) -> None:
+        calls.append(pal)
+        return original(pal)
+
+    monkeypatch.setattr(win.welcome, "repaint_for_palette", _spy)
+
+    theme.toggle()  # dark -> light
+    theme.toggle()  # light -> dark
+
+    # The Welcome panel is in the palette cascade (runs the unpolish/polish
+    # dance) so it never keeps stale white/black surfaces.
+    assert len(calls) == 2
+
+
+def test_home_pill_returns_to_welcome(qapp, isolated_settings) -> None:
+    theme = ThemeManager(qapp)
+    theme.apply("dark")
+    win = MainWindow(theme)
+    qapp.processEvents()
+
+    # Go to Converter, then Home pill back to Welcome.
+    win._header._converter_btn.setChecked(True)
+    win._header._pill_group.idClicked.emit(0)
+    qapp.processEvents()
+    assert win.stack.currentIndex() == 0
+
+    win._header._welcome_btn.setChecked(True)
+    win._header._pill_group.idClicked.emit(2)
+    qapp.processEvents()
+    assert win.stack.currentIndex() == 2

--- a/tests/unit/test_bidsphysio_plug_missing_data.py
+++ b/tests/unit/test_bidsphysio_plug_missing_data.py
@@ -1,0 +1,104 @@
+"""Tests for the vendored bidsphysio ``PhysioSignal.plug_missing_data`` fix.
+
+The upstream implementation inserted one missing sample at a time, each
+insertion doing a full ``np.concatenate`` plus a re-scan from index 0 --
+O(n^2), which hangs for minutes on large CMRR logs (a real 22M-sample ECG
+with many gaps). bids-manager replaced it with a vectorised single-pass
+rewrite. These tests lock in:
+
+* identical output to the original algorithm whenever the original works
+  (i.e. the first interval is not itself a gap -- see note below),
+* a regular time grid with the original samples preserved and gaps filled
+  with NaN, for arbitrary inputs, and
+* that the pathological many-gap case completes quickly (no O(n^2) hang).
+
+Note on the upstream edge bug: the original used
+``np.argmax(diffs > dt*1.001)`` whose result is ``0`` both for "no gap" and
+"first gap at index 0", and its ``while i != 0`` loop then treated index-0
+gaps as "done" -- so a gap in the very first interval was silently left
+unfilled. The vectorised rewrite fills those too (correct behaviour); the
+identical-output test therefore only compares on inputs whose first interval
+is not a gap, which is the case for real recordings.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from bidsmgr.vendor.bidsphysio.base.bidsphysio import PhysioSignal
+
+
+def _naive_plug(times, signal, sps, missing=np.nan):
+    """The original O(n^2) algorithm, verbatim, as a reference oracle."""
+    dt = 1 / sps
+    t = np.array(times, dtype=float)
+    arr = np.array(signal, dtype=float)
+    i = np.argmax(np.ediff1d(t) > dt * 1.001)
+    while i != 0:
+        t = np.concatenate((t[: i + 1], [t[i] + dt], t[i + 1:]))
+        arr = np.concatenate((arr[: i + 1], [missing], arr[i + 1:]))
+        i = np.argmax(np.ediff1d(t) > dt * 1.001)
+    return t, arr
+
+
+def _plug(times, signal, sps=1.0):
+    ps = PhysioSignal(
+        label="x", signal=np.array(signal, dtype=float),
+        samples_per_second=sps, sampling_times=np.array(times, dtype=float),
+    )
+    ps.plug_missing_data()
+    return ps
+
+
+def test_identical_to_original_when_first_interval_is_not_a_gap() -> None:
+    rng = np.random.default_rng(1)
+    for _ in range(300):
+        n = rng.integers(4, 50)
+        rest = np.sort(rng.choice(np.arange(2, n * 2), size=n - 2, replace=False)).astype(float)
+        times = np.concatenate(([0.0, 1.0], rest))  # first interval = 1 (no leading gap)
+        signal = rng.normal(size=len(times))
+        ref_t, ref_s = _naive_plug(times, signal, 1.0)
+        ps = _plug(times, signal)
+        assert np.allclose(ps.sampling_times, ref_t)
+        assert np.array_equal(np.isnan(ps.signal), np.isnan(ref_s))
+        assert np.allclose(ps.signal[~np.isnan(ps.signal)], ref_s[~np.isnan(ref_s)])
+
+
+def test_always_regular_grid_with_originals_preserved() -> None:
+    rng = np.random.default_rng(2)
+    for _ in range(300):
+        n = rng.integers(3, 50)
+        times = np.sort(rng.choice(np.arange(0, n * 2), size=n, replace=False)).astype(float)
+        signal = rng.normal(size=n)
+        ps = _plug(times, signal)
+        assert np.allclose(np.diff(ps.sampling_times), 1.0)  # regular grid
+        assert np.allclose(ps.signal[~np.isnan(ps.signal)], signal)  # originals kept
+
+
+def test_no_op_when_already_regular() -> None:
+    ps = _plug([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
+    assert np.array_equal(ps.sampling_times, [0, 1, 2, 3])
+    assert np.array_equal(ps.signal, [10, 11, 12, 13])
+    assert ps.samples_count == 4
+
+
+def test_fills_single_and_multi_sample_gaps() -> None:
+    # gap of 1 missing (1->3) and a wide gap of 3 missing (3->7)
+    ps = _plug([0.0, 1.0, 3.0, 7.0], [0.0, 1.0, 3.0, 7.0])
+    assert np.allclose(ps.sampling_times, [0, 1, 2, 3, 4, 5, 6, 7])
+    nan_positions = np.isnan(ps.signal)
+    assert list(np.nonzero(nan_positions)[0]) == [2, 4, 5, 6]
+
+
+def test_large_many_gap_input_does_not_hang() -> None:
+    """1M samples with ~1M gaps: the old O(n^2) loop would hang for minutes."""
+    rng = np.random.default_rng(3)
+    times = np.sort(rng.choice(np.arange(0, 2_000_000), size=1_000_000, replace=False)).astype(float)
+    signal = rng.normal(size=1_000_000)
+    t0 = time.monotonic()
+    ps = _plug(times, signal)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 5.0, f"plug_missing_data too slow ({elapsed:.1f}s) - O(n^2) regression?"
+    assert np.allclose(np.diff(ps.sampling_times), 1.0)

--- a/tests/unit/test_cancellation.py
+++ b/tests/unit/test_cancellation.py
@@ -1,0 +1,52 @@
+"""Tests for cooperative scan / convert cancellation.
+
+The GUI Stop button flips a ``threading.Event`` whose ``is_set`` is passed
+to ``run_scan`` / ``run_convert`` as ``cancel_check``. The verbs poll it at
+unit-of-work boundaries and raise :class:`OperationCancelled`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bidsmgr.util.cancel import (
+    OperationCancelled,
+    is_cancelled,
+    raise_if_cancelled,
+)
+
+
+def test_is_cancelled_none_and_predicate() -> None:
+    assert is_cancelled(None) is False
+    assert is_cancelled(lambda: False) is False
+    assert is_cancelled(lambda: True) is True
+
+
+def test_raise_if_cancelled() -> None:
+    raise_if_cancelled(None)            # no-op
+    raise_if_cancelled(lambda: False)   # no-op
+    with pytest.raises(OperationCancelled):
+        raise_if_cancelled(lambda: True)
+
+
+def test_phase1_raises_when_cancelled_before_dispatch(tmp_path: Path) -> None:
+    """``_phase1_parallel_dcm2niix`` bails out before touching any task when
+    a stop is already pending — so a Stop click never launches new dcm2niix."""
+    from bidsmgr.cli.convert import _phase1_parallel_dcm2niix
+
+    with pytest.raises(OperationCancelled):
+        _phase1_parallel_dcm2niix(
+            [], tmp_path, [], n_jobs=1, cancel_check=lambda: True,
+        )
+
+
+def test_phase1_runs_normally_without_cancel(tmp_path: Path) -> None:
+    """With no cancel pending and no tasks, it returns an empty result list."""
+    from bidsmgr.cli.convert import _phase1_parallel_dcm2niix
+
+    assert _phase1_parallel_dcm2niix([], tmp_path, [], n_jobs=1) == []
+    assert _phase1_parallel_dcm2niix(
+        [], tmp_path, [], n_jobs=1, cancel_check=lambda: False,
+    ) == []

--- a/tests/unit/test_cli_project.py
+++ b/tests/unit/test_cli_project.py
@@ -1,0 +1,84 @@
+"""Tests for the additive ``--project`` CLI flags + ``bidsmgr-project``.
+
+The heavy scan/convert paths need real data (covered by the real-data flow);
+here we cover the argparse wiring, the metadata ``--project`` resolution, and
+the ``bidsmgr-project`` listing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bidsmgr.cli import convert as convert_cli
+from bidsmgr.cli import metadata as metadata_cli
+from bidsmgr.cli import project as project_cli
+from bidsmgr.cli import scan as scan_cli
+from bidsmgr.cli.create import open_or_create_workspace
+from bidsmgr.project.orchestration import import_scan_as_version
+
+
+def _seed_version(root: Path) -> None:
+    open_or_create_workspace(root)
+    staged = root / ".bidsmgr" / "project" / ".scan_staging" / "inventory.tsv"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame([{
+        "BIDS_name": "sub-001", "participant_id": "sub-001",
+        "series_uid": "U1", "dataset": root.name, "include": 1,
+    }]).to_csv(staged, sep="\t", index=False)
+    import_scan_as_version(root, staged, raw_root=root / "raw", row_ids=("U1",))
+
+
+def test_scan_requires_output_or_project(capsys):
+    with pytest.raises(SystemExit):
+        scan_cli.main(["/tmp/raw"])  # no output_tsv, no --project
+
+
+def test_convert_requires_positionals_or_project(capsys):
+    with pytest.raises(SystemExit):
+        convert_cli.main(["only_one_arg"])  # missing bids_parent + no --project
+
+
+def test_metadata_requires_target_or_project(capsys):
+    with pytest.raises(SystemExit):
+        metadata_cli.main([])  # no target, no --project
+
+
+def test_bidsmgr_project_lists_versions(tmp_path, capsys):
+    root = tmp_path / "ds"
+    _seed_version(root)
+    rc = project_cli.main([str(root)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1 scan version(s)" in out
+    assert "0001__" in out and "*" in out  # active marker
+
+
+def test_bidsmgr_project_rejects_non_project(tmp_path, capsys):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    rc = project_cli.main([str(plain)])
+    assert rc == 1
+    assert "not a BIDS-Manager project" in capsys.readouterr().out
+
+
+def test_convert_project_unknown_version_errors(tmp_path, capsys):
+    root = tmp_path / "ds"
+    _seed_version(root)
+    with pytest.raises(SystemExit):
+        convert_cli.main(["--project", str(root), "--version", "9999"])
+
+
+def test_metadata_project_writes_participants(tmp_path):
+    root = tmp_path / "ds"
+    _seed_version(root)
+    # A converted subject on disk so the metadata engine writes participants.tsv.
+    (root / "sub-001" / "anat").mkdir(parents=True)
+    (root / "sub-001" / "anat" / "sub-001_T1w.json").write_text("{}", encoding="utf-8")
+
+    rc = metadata_cli.main(["--project", str(root)])
+    assert rc == 0
+    assert (root / "participants.tsv").exists()

--- a/tests/unit/test_companion_fixup.py
+++ b/tests/unit/test_companion_fixup.py
@@ -1,0 +1,58 @@
+"""Tests for the companion-file copy fixup (task logs / events / beh / stim)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from bidsmgr.fixups.companion import attach_companion_files
+
+
+def _stage(tmp_path: Path, basename="sub-001_task-rest_eeg", datatype="eeg") -> Path:
+    d = tmp_path / ".tmp_bidsmgr" / "sub-001" / datatype
+    d.mkdir(parents=True)
+    (d / f"{basename}.json").write_text("{}", encoding="utf-8")
+    return tmp_path / ".tmp_bidsmgr" / "sub-001"
+
+
+def _task(basename="sub-001_task-rest_eeg", datatype="eeg", companions=()):
+    return SimpleNamespace(
+        basename=basename, datatype=datatype, companion_files=tuple(companions),
+    )
+
+
+def test_attach_copies_events_with_bids_name(tmp_path):
+    staging = _stage(tmp_path)
+    src = tmp_path / "my_events.tsv"
+    src.write_text("onset\tduration\ttrial_type\n0\t1\tgo\n", encoding="utf-8")
+    n = attach_companion_files(staging, [_task(companions=[("events", str(src))])])
+    assert n == 1
+    out = staging / "eeg" / "sub-001_task-rest_events.tsv"
+    assert out.exists() and "go" in out.read_text()
+
+
+def test_attach_skips_unsupported_suffix(tmp_path):
+    staging = _stage(tmp_path)
+    src = tmp_path / "x.tsv"
+    src.write_text("a", encoding="utf-8")
+    assert attach_companion_files(staging, [_task(companions=[("bogus", str(src))])]) == 0
+
+
+def test_attach_skips_missing_source(tmp_path):
+    staging = _stage(tmp_path)
+    assert attach_companion_files(
+        staging, [_task(companions=[("events", "/no/such/file.tsv")])]
+    ) == 0
+
+
+def test_attach_preserves_tsv_gz_extension(tmp_path):
+    staging = _stage(tmp_path)
+    src = tmp_path / "phys.tsv.gz"
+    src.write_bytes(b"\x1f\x8b")
+    attach_companion_files(staging, [_task(companions=[("physio", str(src))])])
+    assert (staging / "eeg" / "sub-001_task-rest_physio.tsv.gz").exists()
+
+
+def test_attach_noop_without_companions(tmp_path):
+    staging = _stage(tmp_path)
+    assert attach_companion_files(staging, [_task()]) == 0

--- a/tests/unit/test_convert_orchestrator.py
+++ b/tests/unit/test_convert_orchestrator.py
@@ -145,7 +145,7 @@ class TestHappyPath:
         # Staging cleaned up.
         assert not (bids_parent / "study_a" / ".tmp_bidsmgr").exists()
 
-    def test_dataset_description_appends_on_rerun(
+    def test_dataset_description_generatedby_is_idempotent_on_rerun(
         self, tmp_path: Path, patch_subprocess,
     ) -> None:
         dicoms = _make_dicoms(tmp_path, "T1")
@@ -163,7 +163,30 @@ class TestHappyPath:
             (bids_parent / "study_a" / "dataset_description.json").read_text()
         )
         assert isinstance(dd["GeneratedBy"], list)
-        assert len(dd["GeneratedBy"]) == 2  # one entry per run
+        # Re-running convert into the same dataset (the incremental-conversion
+        # case) must NOT pile up duplicate identical bidsmgr stamps.
+        bidsmgr_entries = [g for g in dd["GeneratedBy"] if g.get("Name") == "bidsmgr"]
+        assert len(bidsmgr_entries) == 1
+
+    def test_dataset_description_uses_schema_bids_version(
+        self, tmp_path: Path, patch_subprocess,
+    ) -> None:
+        from bidsmgr.schema import bids_version as schema_bids_version
+
+        dicoms = _make_dicoms(tmp_path, "T1")
+        tsv = _write_inventory(
+            tmp_path,
+            [_row(series_uid="UID1", basename="sub-001_T1w")],
+            {"UID1": [str(p) for p in dicoms]},
+        )
+        bids_parent = tmp_path / "out"
+        run_convert(tsv, bids_parent, n_jobs=1)
+
+        dd = json.loads(
+            (bids_parent / "study_a" / "dataset_description.json").read_text()
+        )
+        # No hardcoded version: stamped value tracks the bundled schema.
+        assert dd["BIDSVersion"] == schema_bids_version()
 
     def test_provenance_has_dcm2niix_version(
         self, tmp_path: Path, patch_subprocess,

--- a/tests/unit/test_convert_orchestrator.py
+++ b/tests/unit/test_convert_orchestrator.py
@@ -299,10 +299,12 @@ class TestFilteringAndDryRun:
 # ---------------------------------------------------------------------------
 
 
-class TestAtomicCommit:
-    def test_skip_when_target_exists_no_overwrite(
+class TestMergeCommit:
+    def test_merge_adds_new_files_keeps_existing_no_overwrite(
         self, tmp_path: Path, patch_subprocess,
     ) -> None:
+        # Incremental: an existing subject is merged into, not skipped. New files
+        # (anat/) are added; non-colliding existing content is left untouched.
         dicoms = _make_dicoms(tmp_path, "T1")
         tsv = _write_inventory(
             tmp_path,
@@ -310,17 +312,16 @@ class TestAtomicCommit:
             {"UID1": [str(p) for p in dicoms]},
         )
         bids_parent = tmp_path / "out"
-        # Pre-create the target.
-        (bids_parent / "study_a" / "sub-001").mkdir(parents=True)
-        (bids_parent / "study_a" / "sub-001" / "PRE-EXISTING").write_text("x")
+        sub = bids_parent / "study_a" / "sub-001"
+        sub.mkdir(parents=True)
+        (sub / "PRE-EXISTING").write_text("x")
 
         rc = run_convert(tsv, bids_parent, n_jobs=1)
         assert rc == 0
-        # Pre-existing content untouched; no anat/ written.
-        assert (bids_parent / "study_a" / "sub-001" / "PRE-EXISTING").exists()
-        assert not (bids_parent / "study_a" / "sub-001" / "anat").exists()
+        assert (sub / "PRE-EXISTING").read_text() == "x"     # kept
+        assert (sub / "anat" / "sub-001_T1w.nii.gz").exists()  # new file merged in
 
-    def test_overwrite_backs_up_existing(
+    def test_merge_keeps_colliding_file_without_overwrite(
         self, tmp_path: Path, patch_subprocess,
     ) -> None:
         dicoms = _make_dicoms(tmp_path, "T1")
@@ -330,19 +331,41 @@ class TestAtomicCommit:
             {"UID1": [str(p) for p in dicoms]},
         )
         bids_parent = tmp_path / "out"
-        old_target = bids_parent / "study_a" / "sub-001"
-        old_target.mkdir(parents=True)
-        (old_target / "OLD").write_text("preserved")
+        anat = bids_parent / "study_a" / "sub-001" / "anat"
+        anat.mkdir(parents=True)
+        (anat / "sub-001_T1w.nii.gz").write_text("ORIGINAL")  # collides
+
+        run_convert(tsv, bids_parent, n_jobs=1)  # no overwrite
+        # Existing file is preserved; nothing backed up.
+        assert (anat / "sub-001_T1w.nii.gz").read_text() == "ORIGINAL"
+        assert not (bids_parent / "study_a" / ".bidsmgr" / "backup").exists()
+
+    def test_overwrite_backs_up_only_colliding_files(
+        self, tmp_path: Path, patch_subprocess,
+    ) -> None:
+        dicoms = _make_dicoms(tmp_path, "T1")
+        tsv = _write_inventory(
+            tmp_path,
+            [_row(series_uid="UID1", basename="sub-001_T1w")],
+            {"UID1": [str(p) for p in dicoms]},
+        )
+        bids_parent = tmp_path / "out"
+        sub = bids_parent / "study_a" / "sub-001"
+        (sub / "anat").mkdir(parents=True)
+        (sub / "anat" / "sub-001_T1w.nii.gz").write_text("OLD-T1")  # collides
+        (sub / "OTHER-SESSION-FILE").write_text("keep me")          # no collision
 
         run_convert(tsv, bids_parent, n_jobs=1, overwrite=True)
 
-        # New tree present.
-        assert (old_target / "anat" / "sub-001_T1w.nii.gz").exists()
-        # Old content moved to backup.
-        backup_root = bids_parent / "study_a" / ".bidsmgr" / "backup"
-        backups = list(backup_root.glob("sub-001_*"))
+        # Colliding file replaced; non-colliding existing content untouched.
+        # (The converted .nii.gz is gzipped binary, so compare bytes.)
+        assert (sub / "anat" / "sub-001_T1w.nii.gz").read_bytes() != b"OLD-T1"
+        assert (sub / "OTHER-SESSION-FILE").read_text() == "keep me"
+        # Only the colliding file is in the backup.
+        backups = list((sub.parent / ".bidsmgr" / "backup").glob("sub-001_*"))
         assert len(backups) == 1
-        assert (backups[0] / "OLD").read_text() == "preserved"
+        assert (backups[0] / "anat" / "sub-001_T1w.nii.gz").read_bytes() == b"OLD-T1"
+        assert not (backups[0] / "OTHER-SESSION-FILE").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_convert_orchestrator.py
+++ b/tests/unit/test_convert_orchestrator.py
@@ -466,3 +466,37 @@ class TestFailureHandling:
         anat = bids_parent / "study_a" / "sub-001" / "anat"
         assert (anat / "sub-001_T2w.nii.gz").exists()
         assert not (anat / "sub-001_T1w.nii.gz").exists()
+
+
+def _eeg_row(**over):
+    base = {
+        "source_file": "sub-01_task-rest.edf",
+        "series_uid": "",
+        "BIDS_name": "sub-001",
+        "session": "",
+        "proposed_datatype": "eeg",
+        "bids_guess_suffix": "eeg",
+        "proposed_basename": "sub-001_task-rest_eeg",
+        "entities": json.dumps({"subject": "001", "task": "rest"}),
+        "task": "rest",
+        "run": "",
+        "line_freq": "",
+        "montage": "",
+        "eeg_reference": "",
+        "eeg_ground": "",
+        "dataset": "ds",
+        "companion_files": "",
+    }
+    base.update(over)
+    return pd.Series(base)
+
+
+def test_force_edf_flag_threads_onto_eeg_task(tmp_path):
+    """``--force-edf`` reaches the EEG ConvertTask; default leaves it off."""
+    row = _eeg_row()
+    t_off = convert_mod._row_to_task_eeg_meg(row, tmp_path)
+    assert t_off is not None and t_off.force_edf is False
+
+    t_on = convert_mod._row_to_task_eeg_meg(row, tmp_path, force_edf=True)
+    assert t_on is not None and t_on.force_edf is True
+    assert t_on.datatype == "eeg"

--- a/tests/unit/test_create.py
+++ b/tests/unit/test_create.py
@@ -1,0 +1,86 @@
+"""Tests for ``bidsmgr-create`` (create/adopt a BIDS dataset workspace).
+
+The verb scaffolds a minimal valid BIDS dataset (dataset_description.json +
+README + .bidsignore) and an event-sourced project bundle at
+``<bids_root>/.bidsmgr/project``. It adopts a pre-existing dataset without
+overwriting it and is idempotent on re-run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bidsmgr.cli._scaffold import BIDSIGNORE_LINES, project_bundle_dir
+from bidsmgr.cli.create import run_create
+from bidsmgr.editor.validator import validate
+from bidsmgr.project import Project
+from bidsmgr.schema import bids_version as schema_bids_version
+
+
+def test_create_scaffolds_a_valid_subjectless_dataset(tmp_path: Path):
+    root = tmp_path / "my_study"
+    rc = run_create(root)
+    assert rc == 0
+
+    dd = json.loads((root / "dataset_description.json").read_text())
+    assert dd["Name"] == "my_study"
+    assert dd["BIDSVersion"] == schema_bids_version()
+    assert (root / "README").exists()
+    bidsignore = (root / ".bidsignore").read_text().splitlines()
+    assert all(line in bidsignore for line in BIDSIGNORE_LINES)
+
+    # A scaffolded-but-subjectless dataset is valid BIDS: no errors.
+    report = validate(root)
+    assert report.counts["err"] == 0
+
+
+def test_create_initializes_project_bundle(tmp_path: Path):
+    root = tmp_path / "study"
+    run_create(root, name="My Study", description="pilot")
+
+    bundle = project_bundle_dir(root)
+    assert (bundle / "events.jsonl").exists()
+    assert (bundle / "meta.json").exists()
+    # The bundle opens and replays (one ProjectCreated event).
+    proj = Project.open(bundle)
+    assert proj.state() is not None
+
+
+def test_create_name_sets_dataset_description_name(tmp_path: Path):
+    root = tmp_path / "folder_slug"
+    run_create(root, name="Human Readable Name")
+    dd = json.loads((root / "dataset_description.json").read_text())
+    assert dd["Name"] == "Human Readable Name"
+
+
+def test_create_adopts_existing_dataset_without_clobbering(tmp_path: Path):
+    root = tmp_path / "existing"
+    root.mkdir()
+    # A dataset made by some other tool, with hand-edited fields.
+    (root / "dataset_description.json").write_text(
+        json.dumps({"Name": "Pre-existing", "Authors": ["A. Person"]})
+    )
+    (root / "README").write_text("hand-written readme")
+
+    rc = run_create(root)
+    assert rc == 0
+
+    dd = json.loads((root / "dataset_description.json").read_text())
+    assert dd["Name"] == "Pre-existing"          # not overwritten
+    assert dd["Authors"] == ["A. Person"]        # preserved
+    assert dd["BIDSVersion"] == schema_bids_version()  # filled in
+    assert (root / "README").read_text() == "hand-written readme"  # preserved
+    assert project_bundle_dir(root).exists()     # bundle added
+
+
+def test_create_is_idempotent(tmp_path: Path):
+    root = tmp_path / "twice"
+    run_create(root)
+    bundle = project_bundle_dir(root)
+    n_events_first = (bundle / "events.jsonl").read_text().count("\n")
+
+    rc = run_create(root)  # second run must not error or re-init the bundle
+    assert rc == 0
+    n_events_second = (bundle / "events.jsonl").read_text().count("\n")
+    assert n_events_second == n_events_first  # bundle untouched

--- a/tests/unit/test_dataset_identity.py
+++ b/tests/unit/test_dataset_identity.py
@@ -1,0 +1,125 @@
+"""Tests for incremental-conversion identity comparison (Phase F item #5).
+
+``dataset_identity`` compares a scanned subject against an existing dataset to
+produce a specific collision hint: same subject (new session vs re-scan),
+different subject (with a suggested free id), or unknown.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bidsmgr.inventory import dataset_identity as di
+
+
+def _participants(root: Path, rows: list[dict]) -> None:
+    cols = ["participant_id", "patient_id", "given_name", "family_name"]
+    lines = ["\t".join(cols)]
+    for r in rows:
+        lines.append("\t".join(str(r.get(c, "")) for c in cols))
+    (root / "participants.tsv").write_text("\n".join(lines) + "\n")
+
+
+def test_read_existing_identities(tmp_path: Path):
+    _participants(tmp_path, [
+        {"participant_id": "sub-001", "patient_id": "P1", "given_name": "Ann", "family_name": "Lee"},
+    ])
+    ids = di.read_existing_identities(tmp_path)
+    assert ids["sub-001"]["patient_id"] == "P1"
+    assert ids["sub-001"]["family_name"] == "Lee"
+
+
+def test_identity_match_by_patient_id_and_name():
+    assert di.identity_match({"patient_id": "P1"}, {"patient_id": "P1"}) is True
+    assert di.identity_match({"patient_id": "P1"}, {"patient_id": "P2"}) is False
+    assert di.identity_match(
+        {"given_name": "Ann", "family_name": "Lee"},
+        {"given_name": "ann", "family_name": "LEE"},
+    ) is True
+    assert di.identity_match({}, {"patient_id": "P1"}) is None      # no existing info
+    assert di.identity_match({"patient_id": ""}, {"patient_id": ""}) is None  # nothing comparable
+
+
+def test_any_single_coincidence_counts_as_possible_match():
+    # Technician relabelled PatientID per session, but the given name is the
+    # same -> must be treated as a POSSIBLE same subject, not a different one.
+    assert di.identity_match(
+        {"patient_id": "P1", "given_name": "Ann"},
+        {"patient_id": "P2_ses2", "given_name": "Ann"},
+    ) is True
+    matched, differing = di.compare_identity(
+        {"patient_id": "P1", "given_name": "Ann", "family_name": "Lee"},
+        {"patient_id": "P2", "given_name": "Ann", "family_name": "Lee"},
+    )
+    assert matched == ["given_name", "family_name"]
+    assert differing == ["patient_id"]
+
+
+def test_next_free_subject_id(tmp_path: Path):
+    (tmp_path / "sub-001").mkdir()
+    (tmp_path / "sub-003").mkdir()
+    assert di.next_free_subject_id(tmp_path) == "sub-004"
+    assert di.next_free_subject_id(tmp_path / "empty") == "sub-001"
+
+
+def test_classify_same_subject_new_session():
+    note = di.classify(
+        "sub-001",
+        {"patient_id": "P1"}, "ses-post",
+        {"patient_id": "P1"}, {"ses-pre"}, "sub-002",
+    )
+    assert "same subject" in note and "new session" in note and "ses-post" in note
+
+
+def test_classify_same_subject_rescan():
+    note = di.classify(
+        "sub-001",
+        {"patient_id": "P1"}, "ses-pre",
+        {"patient_id": "P1"}, {"ses-pre"}, "sub-002",
+    )
+    assert "re-scan" in note and "same subject" in note
+
+
+def test_classify_partial_match_flags_possible_same_subject():
+    # PatientID differs (relabelled per session) but given name matches: must
+    # tell the user it MAY be the same subject and name the differing field.
+    note = di.classify(
+        "sub-001",
+        {"patient_id": "P2_ses2", "given_name": "Ann"}, "ses-post",
+        {"patient_id": "P1", "given_name": "Ann"}, {"ses-pre"}, "sub-002",
+    )
+    assert "may be the same subject" in note
+    assert "given name" in note          # the coincidence is named
+    assert "PatientID" in note           # the difference is named
+    assert "ses-post" in note            # new-session hint included
+
+
+def test_classify_different_subject_suggests_free_id():
+    note = di.classify(
+        "sub-001",
+        {"patient_id": "P9", "given_name": "Bob"}, "",
+        {"patient_id": "P1", "given_name": "Ann"}, set(), "sub-007",
+    )
+    assert "DIFFERENT subject" in note and "sub-007" in note
+
+
+def test_classify_unknown_when_no_identity():
+    note = di.classify("sub-001", {}, "", None, set(), "sub-002")
+    assert "already in the dataset" in note
+
+
+def test_notes_are_warnings_not_errors():
+    # The model treats these proposed_issues tokens as fatal; the hints must
+    # avoid all of them so the row reads as a warning.
+    err_tokens = ("suspected_abort", "required", "build_basename", "missing")
+    notes = [
+        di.classify("sub-001", {"patient_id": "P1"}, "ses-post",
+                    {"patient_id": "P1"}, {"ses-pre"}, "sub-002"),
+        di.classify("sub-001", {"patient_id": "P9"}, "",
+                    {"patient_id": "P1"}, set(), "sub-007"),
+        di.classify("sub-001", {}, "", None, set(), "sub-002"),
+        di.classify("sub-001", {"patient_id": "P2", "given_name": "Ann"}, "ses-post",
+                    {"patient_id": "P1", "given_name": "Ann"}, {"ses-pre"}, "sub-002"),
+    ]
+    for note in notes:
+        assert not any(tok in note.lower() for tok in err_tokens)

--- a/tests/unit/test_demographics.py
+++ b/tests/unit/test_demographics.py
@@ -1,0 +1,105 @@
+"""Tests for demographic normalization, participants-file import, and the
+handedness column flowing into participants.tsv."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from bidsmgr.metadata.demographics import (
+    load_participants_table,
+    merge_demographics,
+    normalize_handedness,
+    normalize_sex,
+)
+from bidsmgr.metadata.engine import _write_participants
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("M", "M"), ("m", "M"), ("male", "M"), ("1", "M"),
+    ("F", "F"), ("female", "F"), ("2", "F"),
+    ("O", "O"), ("other", "O"),
+    ("", ""), ("unknown", ""), ("xyz", ""),
+])
+def test_normalize_sex(raw, expected):
+    assert normalize_sex(raw) == expected
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("R", "R"), ("right", "R"), ("right-handed", "R"), ("1", "R"),
+    ("L", "L"), ("left", "L"), ("2", "L"),
+    ("A", "A"), ("ambidextrous", "A"), ("both", "A"), ("3", "A"),
+    ("", ""), ("?", ""),
+])
+def test_normalize_handedness(raw, expected):
+    assert normalize_handedness(raw) == expected
+
+
+def test_load_participants_table_tsv(tmp_path):
+    p = tmp_path / "participants.tsv"
+    p.write_text(
+        "participant_id\tage\tsex\thandedness\n"
+        "sub-001\t24\tfemale\tleft\n"
+        "002\t31\tmale\tright\n",
+        encoding="utf-8",
+    )
+    table = load_participants_table(p)
+    assert set(table) == {"sub-001", "sub-002"}  # bare id normalised to sub-
+    assert table["sub-001"]["age"] == "24"
+    assert table["sub-001"]["sex"] == "female"
+
+
+def test_load_participants_table_requires_participant_id(tmp_path):
+    p = tmp_path / "bad.tsv"
+    p.write_text("name\tage\nx\t1\n", encoding="utf-8")
+    assert load_participants_table(p) == {}
+
+
+def test_merge_demographics_overlay_wins_nonblank():
+    base = {"sub-001": {"sex": "M", "age": "20"}}
+    overlay = {"sub-001": {"sex": "F", "age": ""}}  # blank age must not clobber
+    out = merge_demographics(base, overlay)
+    assert out["sub-001"]["sex"] == "F"
+    assert out["sub-001"]["age"] == "20"
+
+
+def _report():
+    return SimpleNamespace(files_written=[], warnings=[])
+
+
+def test_handedness_flows_from_inventory_to_participants(tmp_path):
+    bids_root = tmp_path / "ds"
+    (bids_root / "sub-001").mkdir(parents=True)
+    inv = tmp_path / "inv.tsv"
+    inv.write_text(
+        "BIDS_name\tPatientSex\tHandedness\tPatientAge\n"
+        "sub-001\tmale\tright\t29\n",
+        encoding="utf-8",
+    )
+    _write_participants(bids_root, inv, _report())
+
+    df = pd.read_csv(bids_root / "participants.tsv", sep="\t", dtype=str, keep_default_na=False)
+    row = df.iloc[0]
+    assert row["handedness"] == "R"  # normalised from "right"
+    assert row["sex"] == "M"         # normalised from "male"
+    assert row["age"] == "29"
+
+    desc = json.loads((bids_root / "participants.json").read_text())
+    assert desc["handedness"]["Levels"]["R"] == "right"
+
+
+def test_participants_file_overrides_inventory(tmp_path):
+    bids_root = tmp_path / "ds"
+    (bids_root / "sub-001").mkdir(parents=True)
+    inv = tmp_path / "inv.tsv"
+    inv.write_text("BIDS_name\tHandedness\nsub-001\tleft\n", encoding="utf-8")
+    pfile = tmp_path / "participants_src.tsv"
+    pfile.write_text("participant_id\thandedness\nsub-001\tright\n", encoding="utf-8")
+
+    _write_participants(bids_root, inv, _report(), participants_file=pfile)
+    df = pd.read_csv(bids_root / "participants.tsv", sep="\t", dtype=str, keep_default_na=False)
+    assert df.iloc[0]["handedness"] == "R"  # spreadsheet ("right") wins over inventory ("left")

--- a/tests/unit/test_eeg_meg_inventory.py
+++ b/tests/unit/test_eeg_meg_inventory.py
@@ -8,8 +8,11 @@ and don't need a real mne.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional
 
 import pytest
@@ -29,18 +32,79 @@ from bidsmgr.inventory.eeg_meg import (
 
 
 def test_eeg_meg_columns_exact_order() -> None:
-    """The 12 EEG/MEG-specific columns are in the locked order.
+    """The 15 EEG/MEG-specific columns are in the locked order.
 
-    User-editable: ``task``, ``run``, ``line_freq``, ``montage``.
-    These four condition how the BIDS basename is built and what
-    metadata mne-bids writes.
+    User-editable: ``task``, ``run``, ``line_freq``, ``montage``,
+    ``eeg_reference``, ``eeg_ground``. ``montage_suggestion`` is a read-only
+    scan hint. These condition the BIDS basename + enrichment.
     """
     assert EEG_MEG_COLUMNS == (
         "task", "run", "format", "source_file",
         "n_channels", "sfreq", "duration_sec", "n_times",
         "recording_time", "has_positions",
-        "line_freq", "montage",
+        "line_freq", "montage", "eeg_reference", "eeg_ground",
+        "montage_suggestion",
     )
+
+
+def _fake_raw(info: dict, annotations=()):
+    return SimpleNamespace(
+        info=info, annotations=SimpleNamespace(description=list(annotations)),
+    )
+
+
+def test_subject_info_seeds_sex_age_with_real_birthday() -> None:
+    raw = _fake_raw({"subject_info": {"sex": 2, "hand": 2, "birthday": date(1990, 6, 1)}})
+    # (sex, age) only; handedness is never returned even though hand=2 is set.
+    assert eeg_meg_mod._subject_info(raw, date(2020, 1, 1)) == ("F", "30")
+
+
+def test_subject_info_seeds_nothing_for_1900_placeholder() -> None:
+    raw = _fake_raw({"subject_info": {"sex": 1, "hand": 1, "birthday": date(1900, 1, 1)}})
+    # The 1900 placeholder means the record is anonymised -> seed nothing.
+    assert eeg_meg_mod._subject_info(raw, date(2022, 1, 1)) == ("", "")
+
+
+def test_subject_info_seeds_nothing_without_birthday() -> None:
+    # A real sex but no birthday is not trusted (don't assume).
+    raw = _fake_raw({"subject_info": {"sex": 1}})
+    assert eeg_meg_mod._subject_info(raw, date(2022, 1, 1)) == ("", "")
+
+
+def test_subject_info_empty_when_absent() -> None:
+    assert eeg_meg_mod._subject_info(_fake_raw({}), date(2022, 1, 1)) == ("", "")
+
+
+def test_best_montage_suggests_by_overlap(monkeypatch) -> None:
+    # Stub the montage channel-name sets so the test is independent of MNE.
+    monkeypatch.setattr(
+        eeg_meg_mod, "_montage_chname_sets",
+        lambda: {"standard_1005": frozenset({"fp1", "fp2", "cz", "pz"}),
+                 "biosemi16": frozenset({"a1", "a2"})},
+    )
+    out = eeg_meg_mod._best_montage(["Fp1", "Fp2", "Cz", "Oz"])
+    assert out.startswith("standard_1005 (")
+    assert "3/4" in out  # Fp1, Fp2, Cz matched of 4 channels
+
+
+def test_best_montage_empty_when_no_overlap(monkeypatch) -> None:
+    monkeypatch.setattr(
+        eeg_meg_mod, "_montage_chname_sets",
+        lambda: {"standard_1005": frozenset({"fp1", "cz"})},
+    )
+    assert eeg_meg_mod._best_montage(["X1", "X2"]) == ""
+
+
+def test_device_info_extraction() -> None:
+    raw = _fake_raw({"device_info": {"type": "Elekta", "model": "TRIUX"}})
+    assert eeg_meg_mod._device_info(raw) == ("Elekta", "TRIUX")
+    assert eeg_meg_mod._device_info(_fake_raw({"device_info": None})) == ("", "")
+
+
+def test_event_codes_unique_sorted() -> None:
+    raw = _fake_raw({}, annotations=["T1", "T0", "T1", "T2"])
+    assert eeg_meg_mod._event_codes(raw) == ("T0", "T1", "T2")
+    assert eeg_meg_mod._event_codes(_fake_raw({})) == ()
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +266,12 @@ class _StubProbe:
     datatype: str = "eeg"
     has_positions: bool = False
     fmt: str = "EDF"
+    manufacturer: str = ""
+    model: str = ""
+    subj_sex: str = ""
+    subj_age: str = ""
+    event_codes: tuple[str, ...] = ()
+    montage_suggestion: str = ""
 
 
 def _patch_probe(monkeypatch, *, datatype: str = "eeg") -> None:
@@ -244,6 +314,33 @@ class TestScanEegMeg:
         # Every row's modality and proposed_datatype are set.
         assert (df["modality"] == "eeg").all()
         assert (df["proposed_datatype"] == "eeg").all()
+
+    def test_seeds_demographics_and_event_codes_from_probe(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Header-derived sex/age fill the participant columns; the annotation
+        codes + device are stashed for the scaffold. Handedness is NEVER
+        auto-seeded (left blank for the user)."""
+        monkeypatch.setattr(eeg_meg_mod, "_HAS_MNE", True, raising=False)
+        monkeypatch.setattr(
+            eeg_meg_mod, "_probe",
+            lambda path: _StubProbe(
+                source=path, subj_sex="M", subj_age="25",
+                manufacturer="Elekta", model="TRIUX",
+                event_codes=("T0", "T1", "T2"),
+                montage_suggestion="standard_1005 (60/64)",
+            ),
+        )
+        (tmp_path / "S00.edf").write_bytes(b"x")
+        df = scan_eeg_meg(tmp_path)
+        row = df.iloc[0]
+        assert row["PatientSex"] == "M"
+        assert row["PatientAge"] == "25"
+        assert row["Handedness"] == ""  # never auto-seeded
+        assert row["eeg_reference"] == "" and row["eeg_ground"] == ""
+        assert row["montage_suggestion"] == "standard_1005 (60/64)"
+        assert json.loads(row["_event_codes"]) == ["T0", "T1", "T2"]
+        assert row["_manufacturer"] == "Elekta"
 
     def test_eeg_meg_rows_carry_bids_guess_suffix(
         self, tmp_path: Path, monkeypatch,

--- a/tests/unit/test_eeg_meg_inventory.py
+++ b/tests/unit/test_eeg_meg_inventory.py
@@ -514,3 +514,15 @@ class TestUnsupportedFormats:
         (tmp_path / "a.edf").write_bytes(b"x")
         df = scan_eeg_meg(tmp_path, dataset="study")
         assert df.iloc[0]["proposed_issues"] == ""
+
+
+def test_pdf_documents_are_never_scanned(tmp_path):
+    """Adobe PDF documents (consent forms, reports) sitting in a data folder
+    must never be treated as EEG/MEG recordings (the '.pdf' 4D collision)."""
+    (tmp_path / "consent_form.pdf").write_bytes(b"%PDF-1.7\n...")
+    (tmp_path / "report.pdf").write_bytes(b"%PDF-1.4\n...")
+    cands = candidate_paths(tmp_path)
+    assert all(not str(p).lower().endswith(".pdf") for p in cands)
+    # A full scan yields no rows at all (and no "unsupported format" rows).
+    df = scan_eeg_meg(tmp_path, dataset="study")
+    assert df.empty

--- a/tests/unit/test_eeg_meg_inventory.py
+++ b/tests/unit/test_eeg_meg_inventory.py
@@ -458,3 +458,59 @@ class TestScanEegMeg:
         df = scan_eeg_meg(tmp_path, dataset="study")
         assert df.iloc[0]["line_freq"] == ""
         assert df.iloc[0]["montage"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Unsupported / non-BIDS-native format detection (gap #3)
+# ---------------------------------------------------------------------------
+
+
+class TestUnsupportedFormats:
+    def test_unreadable_recognised_file_is_flagged_not_skipped(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """A recognised EEG/MEG extension mne cannot read becomes a visible,
+        excluded row (not silently dropped)."""
+        monkeypatch.setattr(eeg_meg_mod, "_HAS_MNE", True, raising=False)
+        monkeypatch.setattr(eeg_meg_mod, "_probe", lambda path: None)
+
+        (tmp_path / "901flankers.cnt").write_bytes(b"not really a cnt")
+        df = scan_eeg_meg(tmp_path, dataset="study")
+
+        assert len(df) == 1  # the file is surfaced, not skipped
+        row = df.iloc[0]
+        assert str(row["include"]) in ("0", "False", "false")
+        assert row["format"] == "CNT"
+        assert eeg_meg_mod.UNSUPPORTED_FORMAT_TOKEN in row["proposed_issues"]
+        # No half-built BIDS name for an unconvertible row.
+        assert row["proposed_basename"] == ""
+
+    def test_nonnative_readable_format_gets_warning_note(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """A format mne CAN read but mne-bids cannot write natively (e.g. GDF)
+        stays included but carries a non-native warning note."""
+        monkeypatch.setattr(eeg_meg_mod, "_HAS_MNE", True, raising=False)
+
+        def fake_probe(path: Path):
+            return _StubProbe(source=path, datatype="eeg", fmt="GDF")
+
+        monkeypatch.setattr(eeg_meg_mod, "_probe", fake_probe)
+
+        (tmp_path / "rec.gdf").write_bytes(b"x")
+        df = scan_eeg_meg(tmp_path, dataset="study")
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert str(row["include"]) in ("1", "True", "true")  # still convertible
+        assert eeg_meg_mod.NONNATIVE_FORMAT_TOKEN in row["proposed_issues"]
+        assert row["proposed_basename"]  # has a real BIDS name
+
+    def test_native_format_has_no_note(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """An EDF (BIDS-native) row carries no format warning."""
+        _patch_probe(monkeypatch)  # stub fmt defaults to EDF
+        (tmp_path / "a.edf").write_bytes(b"x")
+        df = scan_eeg_meg(tmp_path, dataset="study")
+        assert df.iloc[0]["proposed_issues"] == ""

--- a/tests/unit/test_eeg_meg_inventory.py
+++ b/tests/unit/test_eeg_meg_inventory.py
@@ -32,18 +32,18 @@ from bidsmgr.inventory.eeg_meg import (
 
 
 def test_eeg_meg_columns_exact_order() -> None:
-    """The 15 EEG/MEG-specific columns are in the locked order.
+    """The 16 EEG/MEG-specific columns are in the locked order.
 
     User-editable: ``task``, ``run``, ``line_freq``, ``montage``,
-    ``eeg_reference``, ``eeg_ground``. ``montage_suggestion`` is a read-only
-    scan hint. These condition the BIDS basename + enrichment.
+    ``eeg_reference``, ``eeg_ground``. ``montage_suggestion`` and
+    ``manufacturer_suggestion`` are read-only scan hints.
     """
     assert EEG_MEG_COLUMNS == (
         "task", "run", "format", "source_file",
         "n_channels", "sfreq", "duration_sec", "n_times",
         "recording_time", "has_positions",
         "line_freq", "montage", "eeg_reference", "eeg_ground",
-        "montage_suggestion",
+        "montage_suggestion", "manufacturer_suggestion",
     )
 
 
@@ -99,6 +99,20 @@ def test_device_info_extraction() -> None:
     raw = _fake_raw({"device_info": {"type": "Elekta", "model": "TRIUX"}})
     assert eeg_meg_mod._device_info(raw) == ("Elekta", "TRIUX")
     assert eeg_meg_mod._device_info(_fake_raw({"device_info": None})) == ("", "")
+
+
+def test_meg_manufacturer_inferred_from_format() -> None:
+    """When the MEG header carries no manufacturer, infer it from the file
+    format (the format identifies the system). Estimate only - user overridable."""
+    raw = _fake_raw({"device_info": None})
+    from pathlib import Path
+    assert eeg_meg_mod._device_info(raw, Path("rec.fif"), "meg")[0] == "MEGIN / Elekta / Neuromag"
+    assert eeg_meg_mod._device_info(raw, Path("rec.ds"), "meg")[0] == "CTF"
+    assert eeg_meg_mod._device_info(raw, Path("rec.con"), "meg")[0] == "KIT / Yokogawa"
+    # Not inferred for EEG, and a present header manufacturer always wins.
+    assert eeg_meg_mod._device_info(raw, Path("rec.fif"), "eeg")[0] == ""
+    raw2 = _fake_raw({"device_info": {"type": "CTF", "model": "x"}})
+    assert eeg_meg_mod._device_info(raw2, Path("rec.fif"), "meg")[0] == "CTF"
 
 
 def test_event_codes_unique_sorted() -> None:
@@ -339,8 +353,8 @@ class TestScanEegMeg:
         assert row["Handedness"] == ""  # never auto-seeded
         assert row["eeg_reference"] == "" and row["eeg_ground"] == ""
         assert row["montage_suggestion"] == "standard_1005 (60/64)"
+        assert row["manufacturer_suggestion"] == "Elekta"  # read-only hint
         assert json.loads(row["_event_codes"]) == ["T0", "T1", "T2"]
-        assert row["_manufacturer"] == "Elekta"
 
     def test_eeg_meg_rows_carry_bids_guess_suffix(
         self, tmp_path: Path, monkeypatch,

--- a/tests/unit/test_eeg_sidecar_fixup.py
+++ b/tests/unit/test_eeg_sidecar_fixup.py
@@ -1,0 +1,144 @@
+"""Unit tests for the post-write EEG/MEG enrichment fixup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from bidsmgr.fixups.eeg_sidecar import enrich_recording_sidecars
+from bidsmgr.recording_meta import (
+    AcquisitionSpec,
+    AuxChannelSpec,
+    FilterSpec,
+    RecordingMetaSpec,
+    TaskProtocol,
+)
+
+
+def _task(datatype="eeg", basename="sub-001_task-rest_eeg", row_id="r1", task="rest"):
+    return SimpleNamespace(
+        datatype=datatype, basename=basename, row_id=row_id, entities={"task": task},
+    )
+
+
+def _stage_eeg(tmp_path: Path, datatype="eeg", basename="sub-001_task-rest_eeg") -> Path:
+    """Create a synthetic staged datatype dir with the files mne-bids writes."""
+    prefix = basename.rsplit("_", 1)[0]
+    d = tmp_path / ".tmp_bidsmgr" / "sub-001" / datatype
+    d.mkdir(parents=True)
+    (d / f"{basename}.json").write_text(
+        json.dumps({"SamplingFrequency": 1000.0, "PowerLineFrequency": 50}),
+        encoding="utf-8",
+    )
+    # mne-bids writes TSVs with a UTF-8 BOM; replicate that (encoding
+    # "utf-8-sig") so the fixup's BOM tolerance is exercised.
+    (d / f"{prefix}_channels.tsv").write_text(
+        "name\ttype\tunits\tdescription\n"
+        "Fp1\tEEG\tµV\tn/a\n"
+        "ECG\tMISC\tn/a\tn/a\n"
+        "EOG\tMISC\tn/a\tn/a\n",
+        encoding="utf-8-sig",
+    )
+    (d / f"{prefix}_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n"
+        "12.0\t0\tS 20\n"
+        "72.0\t0\tS 21\n",
+        encoding="utf-8-sig",
+    )
+    return tmp_path / ".tmp_bidsmgr" / "sub-001"
+
+
+def _full_spec() -> RecordingMetaSpec:
+    return RecordingMetaSpec(
+        defaults=AcquisitionSpec(
+            eeg_reference="Cz",
+            eeg_ground="AFz",
+            manufacturer="Brain Products",
+            amplifier_model="BrainAmp Standard",
+            institution_name="University X",
+            institution_dept="Psychology",
+            filters=[FilterSpec(name="LP", kind="Hardware", info={"cutoff": 260})],
+            aux_channels={
+                "ECG": AuxChannelSpec(
+                    mne_type="ecg", bids_type="ECG", units="mV", description="ecg"
+                ),
+                "EOG": AuxChannelSpec(bids_type="EOG"),
+            },
+        ),
+        event_maps={"rest": {"S 20": "eyes_open", "S 21": "eyes_closed"}},
+        task_protocols={"rest": TaskProtocol(task_description="resting", instructions="relax")},
+    )
+
+
+def _read_json(p: Path) -> dict:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def test_noop_when_spec_none(tmp_path):
+    staging = _stage_eeg(tmp_path)
+    assert enrich_recording_sidecars(staging, [_task()], None) == 0
+
+
+def test_sidecar_fields_written(tmp_path):
+    staging = _stage_eeg(tmp_path)
+    n = enrich_recording_sidecars(staging, [_task()], _full_spec())
+    assert n > 0
+    side = _read_json(staging / "eeg" / "sub-001_task-rest_eeg.json")
+    assert side["EEGReference"] == "Cz"
+    assert side["EEGGround"] == "AFz"
+    assert side["Manufacturer"] == "Brain Products"
+    assert side["ManufacturersModelName"] == "BrainAmp Standard"
+    assert side["InstitutionName"] == "University X"
+    assert side["InstitutionalDepartmentName"] == "Psychology"
+    assert side["HardwareFilters"] == {"LP": {"cutoff": 260}}
+    assert side["TaskDescription"] == "resting"
+    assert side["Instructions"] == "relax"
+    # PowerLineFrequency is owned by the backend; the fixup must not touch it.
+    assert side["PowerLineFrequency"] == 50
+
+
+def test_channels_retyped(tmp_path):
+    staging = _stage_eeg(tmp_path)
+    enrich_recording_sidecars(staging, [_task()], _full_spec())
+    text = (staging / "eeg" / "sub-001_task-rest_channels.tsv").read_text()
+    lines = {ln.split("\t")[0]: ln.split("\t") for ln in text.strip().splitlines()}
+    assert lines["ECG"][1] == "ECG"
+    assert lines["ECG"][2] == "mV"
+    assert lines["EOG"][1] == "EOG"
+    # The real EEG channel is left alone (not generic).
+    assert lines["Fp1"][1] == "EEG"
+
+
+def test_events_mapped_and_json_written(tmp_path):
+    staging = _stage_eeg(tmp_path)
+    enrich_recording_sidecars(staging, [_task()], _full_spec())
+    ev = (staging / "eeg" / "sub-001_task-rest_events.tsv").read_text()
+    assert "eyes_open" in ev and "eyes_closed" in ev
+    assert "S 20" not in ev
+    ev_json = _read_json(staging / "eeg" / "sub-001_task-rest_events.json")
+    assert set(ev_json["trial_type"]["Levels"]) == {"eyes_open", "eyes_closed"}
+
+
+def test_meg_skips_eeg_only_keys(tmp_path):
+    staging = _stage_eeg(tmp_path, datatype="meg", basename="sub-001_task-rest_meg")
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(eeg_reference="Cz", manufacturer="Elekta"),
+    )
+    enrich_recording_sidecars(
+        staging, [_task(datatype="meg", basename="sub-001_task-rest_meg")], spec,
+    )
+    side = _read_json(staging / "meg" / "sub-001_task-rest_meg.json")
+    assert "EEGReference" not in side  # EEG-only key skipped for MEG
+    assert side["Manufacturer"] == "Elekta"  # common key still written
+
+
+def test_per_row_override_applies(tmp_path):
+    staging = _stage_eeg(tmp_path)
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(eeg_reference="Cz"),
+        overrides={"r1": AcquisitionSpec(eeg_reference="FCz")},
+    )
+    enrich_recording_sidecars(staging, [_task(row_id="r1")], spec)
+    side = _read_json(staging / "eeg" / "sub-001_task-rest_eeg.json")
+    assert side["EEGReference"] == "FCz"

--- a/tests/unit/test_eeg_sidecar_fixup.py
+++ b/tests/unit/test_eeg_sidecar_fixup.py
@@ -142,3 +142,38 @@ def test_per_row_override_applies(tmp_path):
     enrich_recording_sidecars(staging, [_task(row_id="r1")], spec)
     side = _read_json(staging / "eeg" / "sub-001_task-rest_eeg.json")
     assert side["EEGReference"] == "FCz"
+
+
+def test_meg_specific_fields_written(tmp_path):
+    """Only MEG fields mne-bids cannot derive are written here; the channel-
+    derived ones are left to mne-bids and never appear from the spec."""
+    staging = _stage_eeg(tmp_path, datatype="meg", basename="sub-001_task-rest_meg")
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(
+            dewar_position="upright",
+            associated_empty_room="bids::sub-emptyroom/ses-x/meg/...",
+            subject_artefact_description="occasional jaw clench",
+        ),
+    )
+    enrich_recording_sidecars(
+        staging, [_task(datatype="meg", basename="sub-001_task-rest_meg")], spec,
+    )
+    side = _read_json(staging / "meg" / "sub-001_task-rest_meg.json")
+    assert side["DewarPosition"] == "upright"
+    assert side["AssociatedEmptyRoom"].startswith("bids::")
+    assert side["SubjectArtefactDescription"] == "occasional jaw clench"
+    # Channel-derived MEG facts are NOT written from the spec (mne-bids owns them).
+    assert "ContinuousHeadLocalization" not in side
+    assert "DigitizedLandmarks" not in side
+
+
+def test_meg_fields_not_written_for_eeg(tmp_path):
+    """MEG-only keys never leak into an EEG sidecar."""
+    staging = _stage_eeg(tmp_path)
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(dewar_position="supine", eeg_reference="Cz"),
+    )
+    enrich_recording_sidecars(staging, [_task()], spec)
+    side = _read_json(staging / "eeg" / "sub-001_task-rest_eeg.json")
+    assert "DewarPosition" not in side
+    assert side["EEGReference"] == "Cz"

--- a/tests/unit/test_merge_commit.py
+++ b/tests/unit/test_merge_commit.py
@@ -1,0 +1,126 @@
+"""Direct tests for the merge-aware commit policy (Phase F).
+
+``_merge_commit`` is the per-subject commit used by convert: a new subject moves
+in wholesale; an existing subject is merged file-by-file per ``on_existing``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bidsmgr.cli.convert import (
+    CollisionAbort,
+    _log_existing_subject_summary,
+    _merge_commit,
+)
+
+
+def _staging(tmp_path: Path, files: dict[str, str]) -> Path:
+    s = tmp_path / "staging" / "sub-001"
+    for rel, content in files.items():
+        p = s / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return s
+
+
+def _target(tmp_path: Path, files: dict[str, str]) -> Path:
+    t = tmp_path / "out" / "sub-001"
+    for rel, content in files.items():
+        p = t / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return t
+
+
+def _backups(target: Path) -> list[Path]:
+    return list((target.parent / ".bidsmgr" / "backup").glob("sub-001_*"))
+
+
+def test_new_subject_moves_in_wholesale(tmp_path: Path):
+    s = _staging(tmp_path, {"anat/sub-001_T1w.nii.gz": "T1"})
+    target = tmp_path / "out" / "sub-001"  # absent
+    added, replaced, kept = _merge_commit(s, target, on_existing="skip")
+    assert (added, replaced, kept) == (1, 0, 0)
+    assert (target / "anat" / "sub-001_T1w.nii.gz").read_text() == "T1"
+
+
+def test_skip_adds_new_keeps_colliding(tmp_path: Path):
+    s = _staging(tmp_path, {
+        "ses-post/anat/sub-001_ses-post_T1w.nii.gz": "new",   # new session
+        "ses-pre/anat/sub-001_ses-pre_T1w.nii.gz": "STAGED",  # collides
+    })
+    target = _target(tmp_path, {"ses-pre/anat/sub-001_ses-pre_T1w.nii.gz": "EXISTING"})
+    added, replaced, kept = _merge_commit(s, target, on_existing="skip")
+    assert (added, replaced, kept) == (1, 0, 1)
+    assert (target / "ses-post/anat/sub-001_ses-post_T1w.nii.gz").read_text() == "new"
+    assert (target / "ses-pre/anat/sub-001_ses-pre_T1w.nii.gz").read_text() == "EXISTING"
+    assert _backups(target) == []
+
+
+def test_replace_backs_up_and_replaces_colliding(tmp_path: Path):
+    s = _staging(tmp_path, {"anat/sub-001_T1w.nii.gz": "NEW"})
+    target = _target(tmp_path, {"anat/sub-001_T1w.nii.gz": "OLD"})
+    added, replaced, kept = _merge_commit(s, target, on_existing="replace")
+    assert (added, replaced, kept) == (0, 1, 0)
+    assert (target / "anat/sub-001_T1w.nii.gz").read_text() == "NEW"
+    backups = _backups(target)
+    assert len(backups) == 1
+    assert (backups[0] / "anat/sub-001_T1w.nii.gz").read_text() == "OLD"
+
+
+def test_update_keeps_identical_replaces_changed(tmp_path: Path):
+    s = _staging(tmp_path, {
+        "anat/same.nii.gz": "SAME",
+        "anat/diff.nii.gz": "NEW",
+    })
+    target = _target(tmp_path, {
+        "anat/same.nii.gz": "SAME",   # identical -> kept
+        "anat/diff.nii.gz": "OLD",    # different -> replaced
+    })
+    added, replaced, kept = _merge_commit(s, target, on_existing="update")
+    assert (added, replaced, kept) == (0, 1, 1)
+    assert (target / "anat/diff.nii.gz").read_text() == "NEW"
+    assert (target / "anat/same.nii.gz").read_text() == "SAME"
+    # Only the changed file is backed up.
+    backups = _backups(target)
+    assert len(backups) == 1
+    assert (backups[0] / "anat/diff.nii.gz").read_text() == "OLD"
+    assert not (backups[0] / "anat/same.nii.gz").exists()
+
+
+def test_error_aborts_without_moving_anything(tmp_path: Path):
+    s = _staging(tmp_path, {
+        "ses-post/new.nii.gz": "new",        # would be a safe add
+        "ses-pre/clash.nii.gz": "STAGED",    # collides
+    })
+    target = _target(tmp_path, {"ses-pre/clash.nii.gz": "EXISTING"})
+    with pytest.raises(CollisionAbort):
+        _merge_commit(s, target, on_existing="error")
+    # Nothing moved: existing untouched, the safe-add NOT committed.
+    assert (target / "ses-pre/clash.nii.gz").read_text() == "EXISTING"
+    assert not (target / "ses-post/new.nii.gz").exists()
+
+
+def test_error_proceeds_when_no_collision(tmp_path: Path):
+    s = _staging(tmp_path, {"ses-post/new.nii.gz": "new"})
+    target = _target(tmp_path, {"ses-pre/old.nii.gz": "old"})
+    added, replaced, kept = _merge_commit(s, target, on_existing="error")
+    assert (added, replaced, kept) == (1, 0, 0)
+    assert (target / "ses-post/new.nii.gz").read_text() == "new"
+    assert (target / "ses-pre/old.nii.gz").read_text() == "old"
+
+
+def test_preflight_summary_flags_existing_subjects(tmp_path: Path, caplog):
+    bids_root = tmp_path / "ds"
+    (bids_root / "sub-001").mkdir(parents=True)  # already present
+    df = pd.DataFrame({"BIDS_name": ["sub-001", "sub-002"]})
+    with caplog.at_level(logging.INFO, logger="bidsmgr.cli.convert"):
+        _log_existing_subject_summary(bids_root, df, "skip")
+    msg = " ".join(r.getMessage() for r in caplog.records)
+    assert "already present" in msg and "sub-001" in msg
+    assert "1 new" in msg  # sub-002 is new

--- a/tests/unit/test_metadata_engine.py
+++ b/tests/unit/test_metadata_engine.py
@@ -605,3 +605,44 @@ class TestInferDatatypeSuffix:
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text("{}")
         assert _infer_datatype_suffix(target, root) == expected
+
+
+class TestParticipantsExtraColumns:
+    def test_spreadsheet_extra_columns_carried_with_codebook(self, tmp_path):
+        """Columns beyond the known demographics flow into participants.tsv and
+        are described in participants.json (rs-bidsify-style), using a sibling
+        codebook when present."""
+        root = _make_minimal_bids(tmp_path)
+        participants = tmp_path / "subjects.csv"
+        participants.write_text(
+            "participant_id,age,sex,group,iq\nsub-001,30,female,patient,118\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "subjects.json").write_text(json.dumps({
+            "group": {"Description": "Study group", "Levels": {"patient": "clinical"}},
+            "iq": {"Description": "Full-scale IQ", "Units": "points"},
+        }), encoding="utf-8")
+
+        run_metadata(root, participants_file=participants)
+
+        tsv = (root / "participants.tsv").read_text()
+        header = tsv.splitlines()[0].split("\t")
+        assert "group" in header and "iq" in header
+        assert "patient" in tsv and "118" in tsv
+
+        pj = json.loads((root / "participants.json").read_text())
+        assert pj["group"]["Levels"]["patient"] == "clinical"
+        assert pj["iq"]["Units"] == "points"
+        # Known demographic columns keep their built-in descriptions.
+        assert pj["sex"]["Levels"]["F"] == "female"
+
+    def test_extra_column_without_codebook_gets_default_description(self, tmp_path):
+        root = _make_minimal_bids(tmp_path)
+        participants = tmp_path / "subjects.tsv"
+        participants.write_text(
+            "participant_id\tcohort\nsub-001\twave1\n", encoding="utf-8",
+        )
+        run_metadata(root, participants_file=participants)
+        pj = json.loads((root / "participants.json").read_text())
+        assert pj["cohort"] == {"Description": "cohort"}
+        assert "cohort" in (root / "participants.tsv").read_text().splitlines()[0]

--- a/tests/unit/test_metadata_engine.py
+++ b/tests/unit/test_metadata_engine.py
@@ -124,6 +124,32 @@ class TestDatasetDescription:
         assert dd["Funding"] == ["NIH-12345"]
         assert dd["DatasetDOI"] == "10.1234/x"
 
+    def test_metadata_preserves_existing_name_without_explicit_name(
+        self, tmp_path: Path,
+    ) -> None:
+        # A Name set by `bidsmgr create` / hand-edit must survive a metadata run
+        # that did not pass an explicit name (no clobber to the folder name).
+        root = _make_minimal_bids(tmp_path)  # folder is named "study"
+        p = root / "dataset_description.json"
+        data = json.loads(p.read_text())
+        data["Name"] = "Human Chosen Name"
+        p.write_text(json.dumps(data))
+
+        run_metadata(root)  # no dataset_meta, no name
+
+        assert json.loads(p.read_text())["Name"] == "Human Chosen Name"
+
+    def test_metadata_falls_back_to_folder_name_when_none_on_disk(
+        self, tmp_path: Path,
+    ) -> None:
+        # Fresh dataset with no Name on disk + no explicit name => folder name.
+        root = tmp_path / "my_dataset"
+        (root / "sub-001" / "anat").mkdir(parents=True)
+        _write_pair(root / "sub-001" / "anat", "sub-001_T1w", sidecar={})
+        run_metadata(root)
+        dd = json.loads((root / "dataset_description.json").read_text())
+        assert dd["Name"] == "my_dataset"
+
     def test_user_edits_not_clobbered(self, tmp_path: Path) -> None:
         """A field added by the user is preserved across a metadata rerun."""
         root = _make_minimal_bids(tmp_path)

--- a/tests/unit/test_metadata_help.py
+++ b/tests/unit/test_metadata_help.py
@@ -1,0 +1,44 @@
+"""The recording-metadata tooltips are sourced from the live BIDS schema,
+which also confirms every exposed field is a genuine schema key."""
+
+from __future__ import annotations
+
+import pytest
+
+from bidsmgr.gui.metadata_help import bids_tooltip, tooltip_for
+
+
+@pytest.mark.parametrize(
+    "ui_key, must_contain",
+    [
+        ("manufacturer", "Manufacturer"),
+        ("line_freq", "Power"),               # PowerLineFrequency
+        ("eeg_reference", "reference"),
+        ("eeg_ground", "ground"),
+        ("cap_manufacturer", "cap"),
+        ("dewar_position", "dewar"),
+        ("associated_empty_room", "empty"),
+        ("subject_artefact_description", "artifact"),
+    ],
+)
+def test_tooltip_from_schema(ui_key, must_contain):
+    tip = tooltip_for(ui_key)
+    assert tip, f"no tooltip for {ui_key}"
+    assert must_contain.lower() in tip.lower()
+
+
+def test_tooltip_markdown_stripped():
+    # CapManufacturer's schema description has a backticked example.
+    tip = bids_tooltip("CapManufacturer")
+    assert "`" not in tip and tip
+
+
+def test_fallback_for_non_metadata_fields():
+    # montage is a convention (electrodes.tsv), demographics are participant cols.
+    assert "electrodes.tsv" in tooltip_for("montage")
+    assert "participants.tsv" in tooltip_for("PatientSex")
+    assert "participants.tsv" in tooltip_for("Handedness")
+
+
+def test_unknown_field_returns_empty():
+    assert tooltip_for("definitely_not_a_field") == ""

--- a/tests/unit/test_mne_bids_backend.py
+++ b/tests/unit/test_mne_bids_backend.py
@@ -118,7 +118,15 @@ def _patch_mne_bids(
             raise raw_exception
         return _FakeRaw()
 
-    def fake_write_raw_bids(raw, bids_path, *, overwrite=False, format="auto", verbose=None):
+    def fake_write_raw_bids(
+        raw, bids_path, *, overwrite=False, format="auto",
+        allow_preload=False, verbose=None,
+    ):
+        # Record the format / allow_preload the backend chose so tests can
+        # assert force-EDF behaviour. The real mne-bids accepts these kwargs.
+        fake_mne_bids.last_write_kwargs = {
+            "format": format, "allow_preload": allow_preload,
+        }
         if write_exception is not None:
             raise write_exception
         sub_dir = Path(bids_path.root) / f"sub-{bids_path.subject}"
@@ -517,3 +525,39 @@ class TestCoerceRun:
     ])
     def test_run_coercion(self, value, expected) -> None:
         assert _coerce_run(value) == expected
+
+
+class TestForceEdf:
+    def _eeg_task(self, tmp_path, *, datatype="eeg", force_edf=False):
+        return ConvertTask(
+            row_id="r1", series_uid="", source_files=(_make_source(tmp_path),),
+            dataset="study", bids_root=tmp_path / "bids" / "study",
+            subject="001", session=None, datatype=datatype, suffix=datatype,
+            entities={"task": "rest"}, basename=f"sub-001_task-rest_{datatype}",
+            expected_outputs=(".edf", ".json"), force_edf=force_edf,
+        )
+
+    def test_force_edf_passes_edf_format_for_eeg(self, tmp_path, monkeypatch):
+        _patch_mne_bids(monkeypatch, write_extensions=(".edf", ".json"))
+        import mne_bids
+        b = MneBidsBackend()
+        staging = tmp_path / ".tmp_bidsmgr" / "sub-001"; staging.mkdir(parents=True)
+        b.convert(self._eeg_task(tmp_path, force_edf=True), staging)
+        assert mne_bids.last_write_kwargs == {"format": "EDF", "allow_preload": True}
+
+    def test_default_keeps_auto_format(self, tmp_path, monkeypatch):
+        _patch_mne_bids(monkeypatch, write_extensions=(".edf", ".json"))
+        import mne_bids
+        b = MneBidsBackend()
+        staging = tmp_path / ".tmp_bidsmgr" / "sub-001"; staging.mkdir(parents=True)
+        b.convert(self._eeg_task(tmp_path, force_edf=False), staging)
+        assert mne_bids.last_write_kwargs == {"format": "auto", "allow_preload": False}
+
+    def test_force_edf_ignored_for_meg(self, tmp_path, monkeypatch):
+        """EDF is not a MEG format; force_edf must not touch MEG rows."""
+        _patch_mne_bids(monkeypatch, write_extensions=(".fif", ".json"))
+        import mne_bids
+        b = MneBidsBackend()
+        staging = tmp_path / ".tmp_bidsmgr" / "sub-001"; staging.mkdir(parents=True)
+        b.convert(self._eeg_task(tmp_path, datatype="meg", force_edf=True), staging)
+        assert mne_bids.last_write_kwargs["format"] == "auto"

--- a/tests/unit/test_mne_bids_backend.py
+++ b/tests/unit/test_mne_bids_backend.py
@@ -288,16 +288,16 @@ class TestConvertSuccess:
         a montage name.
         """
         calls: list = []
-        # Backend-level default carries the EEG montage; the task itself
-        # doesn't set one. The MEG-datatype guard in the backend must
-        # short-circuit before _apply_standard_montage is reached.
-        b = MneBidsBackend(montage="standard_1005")
+        # The task carries an EEG montage. The MEG-datatype guard in the
+        # backend must short-circuit before _apply_standard_montage is
+        # reached, even when a montage name is present on the task.
+        b = MneBidsBackend()
         task = _make_task(
             tmp_path,
             datatype="meg",
             suffix="meg",
             basename="sub-001_task-rest_meg",
-        )
+        ).model_copy(update={"montage": "standard_1005"})
         _patch_mne_bids(monkeypatch, write_extensions=(".fif", ".json"))
 
         # Spy on _apply_standard_montage — it must NOT be called for MEG.

--- a/tests/unit/test_nonimage_detection.py
+++ b/tests/unit/test_nonimage_detection.py
@@ -1,0 +1,195 @@
+"""Tests for non-image (no-pixel-data) DICOM detection.
+
+A DICOM series whose files carry no Image Pixel module (Rows/Columns) is a
+DERIVED non-image object (e.g. a Siemens diffusion ``TENSOR`` map or a
+``PhoenixZIPReport``). dcm2niix cannot convert it to NIfTI, so the scanner
+flags it: excluded from conversion (``include=0`` / ``bids_guess_skip``)
+with a ``non-image series`` note in ``proposed_issues`` so it surfaces in
+the inventory table highlighted rather than failing dcm2niix with ``rc=2``.
+
+Covers the engine layer:
+* ``mri_dicom._read_one`` stamps ``has_pixels`` per file.
+* ``mri_dicom.scan_dicoms_long`` aggregates it into the internal
+  ``_has_pixel_data`` column (OR across a series' files).
+* ``cli/scan._flag_nonimage_rows`` excludes + annotates non-image rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pydicom
+import pytest
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, MRImageStorage, generate_uid
+
+from bidsmgr.cli.scan import (
+    NONIMAGE_ISSUE_TOKEN,
+    _flag_nonimage_rows,
+    _is_nonimage_flag,
+)
+from bidsmgr.inventory.mri_dicom import _read_one, scan_dicoms_long
+
+
+# ---------------------------------------------------------------------------
+# Synthetic DICOM helper
+# ---------------------------------------------------------------------------
+
+
+def _write_dicom(
+    path: Path,
+    *,
+    with_pixels: bool,
+    series_desc: str,
+    series_uid: str,
+    patient_id: str = "P1",
+    patient_name: str = "Doe^Jane",
+) -> None:
+    """Write a minimal DICOM with or without the Image Pixel module."""
+    fm = FileMetaDataset()
+    fm.MediaStorageSOPClassUID = MRImageStorage
+    fm.MediaStorageSOPInstanceUID = generate_uid()
+    fm.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = FileDataset(str(path), {}, file_meta=fm, preamble=b"\0" * 128)
+    ds.PatientID = patient_id
+    ds.PatientName = patient_name
+    ds.Modality = "MR"
+    ds.SeriesDescription = series_desc
+    ds.SeriesInstanceUID = series_uid
+    ds.StudyInstanceUID = generate_uid()
+    ds.SOPInstanceUID = fm.MediaStorageSOPInstanceUID
+    if with_pixels:
+        ds.ImageType = ["ORIGINAL", "PRIMARY", "M", "ND"]
+        ds.Rows = 4
+        ds.Columns = 4
+        ds.BitsAllocated = 16
+        ds.PixelData = (b"\x00\x00") * 16
+    else:
+        # DERIVED non-image object: no Rows/Columns, no PixelData.
+        ds.ImageType = ["DERIVED", "PRIMARY", "DIFFUSION", "TENSOR", "ND"]
+    ds.save_as(str(path), enforce_file_format=True)
+
+
+# ---------------------------------------------------------------------------
+# _read_one pixel detection
+# ---------------------------------------------------------------------------
+
+
+def test_read_one_detects_pixels(tmp_path: Path) -> None:
+    p = tmp_path / "img.dcm"
+    _write_dicom(p, with_pixels=True, series_desc="t1_mprage", series_uid="1.1")
+    res = _read_one(str(p), tmp_path)
+    assert res is not None
+    assert res["has_pixels"] is True
+
+
+def test_read_one_detects_nonimage(tmp_path: Path) -> None:
+    p = tmp_path / "tensor.dcm"
+    _write_dicom(p, with_pixels=False, series_desc="dwi_TENSOR", series_uid="1.2")
+    res = _read_one(str(p), tmp_path)
+    assert res is not None
+    assert res["has_pixels"] is False
+
+
+# ---------------------------------------------------------------------------
+# scan_dicoms_long aggregation -> internal _has_pixel_data column
+# ---------------------------------------------------------------------------
+
+
+def test_scan_aggregates_pixel_presence(tmp_path: Path) -> None:
+    # One image series (2 files) + one non-image series (1 file), same subject.
+    img_uid, ten_uid = "1.10", "1.20"
+    _write_dicom(tmp_path / "a1.dcm", with_pixels=True, series_desc="t1_mprage", series_uid=img_uid)
+    _write_dicom(tmp_path / "a2.dcm", with_pixels=True, series_desc="t1_mprage", series_uid=img_uid)
+    _write_dicom(tmp_path / "t.dcm", with_pixels=False, series_desc="dwi_TENSOR", series_uid=ten_uid)
+
+    df = scan_dicoms_long(tmp_path, n_jobs=1)
+    assert "_has_pixel_data" in df.columns
+
+    img = df[df["series_uid"] == img_uid].iloc[0]
+    ten = df[df["series_uid"] == ten_uid].iloc[0]
+    assert bool(img["_has_pixel_data"]) is True
+    assert bool(ten["_has_pixel_data"]) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_nonimage_flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (False, True),          # explicit False -> non-image
+        (True, False),          # explicit True -> image
+        (float("nan"), False),  # fmap-collapsed / EEG rows -> image
+        ("", False),
+        ("False", True),        # stringified survives a round-trip
+        ("True", False),
+        (0, True),
+        (1, False),
+    ],
+)
+def test_is_nonimage_flag(val, expected: bool) -> None:
+    assert _is_nonimage_flag(val) is expected
+
+
+# ---------------------------------------------------------------------------
+# _flag_nonimage_rows
+# ---------------------------------------------------------------------------
+
+
+def test_flag_nonimage_rows_excludes_and_annotates() -> None:
+    df = pd.DataFrame([
+        {"_has_pixel_data": True,  "include": 1, "bids_guess_skip": False, "proposed_issues": ""},
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False, "proposed_issues": ""},
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False, "proposed_issues": "trivial: x"},
+    ])
+    _flag_nonimage_rows(df)
+
+    # Image row untouched.
+    assert df.at[0, "include"] == 1
+    assert not bool(df.at[0, "bids_guess_skip"])
+    assert df.at[0, "proposed_issues"] == ""
+
+    # Non-image row excluded + annotated.
+    assert df.at[1, "include"] == 0
+    assert bool(df.at[1, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN in df.at[1, "proposed_issues"]
+
+    # Existing issue preserved after the prepended non-image note.
+    assert NONIMAGE_ISSUE_TOKEN in df.at[2, "proposed_issues"]
+    assert "trivial: x" in df.at[2, "proposed_issues"]
+
+
+def test_flag_nonimage_rows_noop_without_column() -> None:
+    df = pd.DataFrame([{"include": 1, "bids_guess_skip": False, "proposed_issues": ""}])
+    _flag_nonimage_rows(df)  # no _has_pixel_data column -> no-op
+    assert df.at[0, "include"] == 1
+
+
+def test_physio_rows_are_exempt_from_nonimage_flag() -> None:
+    """Siemens physio (_PhysioLog.dcm) has no pixel data either, but it IS
+    convertible by the bidsphysio backend -> must NOT be flagged/excluded."""
+    df = pd.DataFrame([
+        # physio identified by suffix
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False,
+         "proposed_issues": "", "bids_guess_suffix": "physio", "modality": "physio",
+         "proposed_basename": "sub-001_task-rest_physio"},
+        # a genuine non-image object (TENSOR) for contrast
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False,
+         "proposed_issues": "", "bids_guess_suffix": "TENSOR", "modality": "dwi",
+         "proposed_basename": "sub-001_desc-TENSOR_dwi"},
+    ])
+    _flag_nonimage_rows(df)
+
+    # Physio row untouched.
+    assert df.at[0, "include"] == 1
+    assert not bool(df.at[0, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN not in df.at[0, "proposed_issues"]
+
+    # TENSOR row still flagged.
+    assert df.at[1, "include"] == 0
+    assert bool(df.at[1, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN in df.at[1, "proposed_issues"]

--- a/tests/unit/test_phenotype.py
+++ b/tests/unit/test_phenotype.py
@@ -1,0 +1,97 @@
+"""Tests for the phenotype/ table importer."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+
+from bidsmgr.metadata.phenotype import write_phenotype
+
+
+def _report():
+    return SimpleNamespace(files_written=[], warnings=[])
+
+
+def test_writes_measure_tsv_and_json(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    src = tmp_path / "edinburgh.tsv"
+    src.write_text(
+        "participant_id\tehi_total\tehi_decile\n"
+        "sub-001\t80\t9\n"
+        "sub-002\t-40\t2\n",
+        encoding="utf-8",
+    )
+    report = _report()
+    write_phenotype(bids_root, [src], report)
+
+    tsv = bids_root / "phenotype" / "edinburgh.tsv"
+    js = bids_root / "phenotype" / "edinburgh.json"
+    assert tsv.exists() and js.exists()
+    df = pd.read_csv(tsv, sep="\t", dtype=str, keep_default_na=False)
+    assert list(df["participant_id"]) == ["sub-001", "sub-002"]
+    data_dict = json.loads(js.read_text())
+    # participant_id is the index, not described; measures are.
+    assert "participant_id" not in data_dict
+    assert set(data_dict) == {"ehi_total", "ehi_decile"}
+    assert tsv in report.files_written and js in report.files_written
+
+
+def test_none_is_noop(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    write_phenotype(bids_root, None, _report())
+    assert not (bids_root / "phenotype").exists()
+
+
+def test_skips_table_without_participant_id(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    src = tmp_path / "bad.tsv"
+    src.write_text("subject\tscore\nx\t1\n", encoding="utf-8")
+    report = _report()
+    write_phenotype(bids_root, [src], report)
+    assert not (bids_root / "phenotype" / "bad.tsv").exists()
+    assert any("participant_id" in w for w in report.warnings)
+
+
+def test_missing_file_warns(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    report = _report()
+    write_phenotype(bids_root, [tmp_path / "nope.tsv"], report)
+    assert any("not found" in w for w in report.warnings)
+
+
+def test_multiple_instruments(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    a = tmp_path / "bdi.tsv"
+    a.write_text("participant_id\tbdi_total\nsub-001\t12\n", encoding="utf-8")
+    b = tmp_path / "stai.csv"
+    b.write_text("participant_id,stai_state\nsub-001,40\n", encoding="utf-8")
+    write_phenotype(bids_root, [a, b], _report())
+    assert (bids_root / "phenotype" / "bdi.tsv").exists()
+    assert (bids_root / "phenotype" / "stai.tsv").exists()  # .csv read, .tsv written
+
+
+def test_phenotype_auto_discovered_from_scaffold(tmp_path):
+    """run_metadata picks up phenotype tables listed in the inventory scaffold."""
+    from bidsmgr.metadata.engine import run_metadata
+    from bidsmgr.recording_meta import RecordingMetaSpec, dump_spec, scaffold_sidecar_path
+
+    bids_root = tmp_path / "ds"
+    (bids_root / "sub-001").mkdir(parents=True)
+    inv = tmp_path / "inv.tsv"
+    inv.write_text("BIDS_name\nsub-001\n", encoding="utf-8")
+    pheno = tmp_path / "edinburgh.tsv"
+    pheno.write_text("participant_id\tehi\nsub-001\t80\n", encoding="utf-8")
+
+    spec = RecordingMetaSpec(phenotype_files=[str(pheno)])
+    scaffold_sidecar_path(inv).write_text(dump_spec(spec), encoding="utf-8")
+
+    run_metadata(bids_root, inventory_tsv=inv, write_report=False)
+    assert (bids_root / "phenotype" / "edinburgh.tsv").exists()
+    assert (bids_root / "phenotype" / "edinburgh.json").exists()

--- a/tests/unit/test_phenotype.py
+++ b/tests/unit/test_phenotype.py
@@ -95,3 +95,37 @@ def test_phenotype_auto_discovered_from_scaffold(tmp_path):
     run_metadata(bids_root, inventory_tsv=inv, write_report=False)
     assert (bids_root / "phenotype" / "edinburgh.tsv").exists()
     assert (bids_root / "phenotype" / "edinburgh.json").exists()
+
+
+def test_codebook_sidecar_merges_into_measure_json(tmp_path):
+    """A sibling <measure>.json codebook supplies real Descriptions / Levels /
+    Units (and MeasurementToolMetadata); auto-fill covers the rest."""
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    src = tmp_path / "bdi.tsv"
+    src.write_text(
+        "participant_id\tbdi_total\tseverity\nsub-001\t24\tmoderate\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bdi.json").write_text(json.dumps({
+        "MeasurementToolMetadata": {"Description": "Beck Depression Inventory II"},
+        "bdi_total": {"Description": "BDI-II total score", "Units": "points"},
+        "severity": {"Description": "band", "Levels": {"moderate": "20-28"}},
+    }), encoding="utf-8")
+
+    write_phenotype(bids_root, [src], _report())
+
+    dd = json.loads((bids_root / "phenotype" / "bdi.json").read_text())
+    assert dd["MeasurementToolMetadata"]["Description"] == "Beck Depression Inventory II"
+    assert dd["bdi_total"]["Units"] == "points"
+    assert dd["severity"]["Levels"]["moderate"] == "20-28"
+
+
+def test_no_codebook_falls_back_to_column_name(tmp_path):
+    bids_root = tmp_path / "ds"
+    bids_root.mkdir()
+    src = tmp_path / "stai.tsv"
+    src.write_text("participant_id\tstai_state\nsub-001\t40\n", encoding="utf-8")
+    write_phenotype(bids_root, [src], _report())
+    dd = json.loads((bids_root / "phenotype" / "stai.json").read_text())
+    assert dd["stai_state"] == {"Description": "stai_state"}  # auto-filled

--- a/tests/unit/test_project_orchestration.py
+++ b/tests/unit/test_project_orchestration.py
@@ -1,0 +1,118 @@
+"""Tests for the shared, Qt-free project orchestration (``--project`` engine).
+
+Covers the version-import + edit-replay + active-version-load functions that
+both the GUI and the CLI ``--project`` flags drive.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from bidsmgr.cli.create import open_or_create_workspace
+from bidsmgr.project import Project, UserSetEntity, UserToggleInclude, workspace
+from bidsmgr.project.orchestration import (
+    apply_project_state,
+    find_version,
+    import_scan_as_version,
+    latest_version,
+    row_id,
+    version_dataframe,
+)
+
+
+def _inv_df(subject="001", task="rest", uid="UID1") -> pd.DataFrame:
+    return pd.DataFrame([{
+        "BIDS_name": f"sub-{subject}", "session": "", "include": 1,
+        "modality": "mri", "proposed_datatype": "func",
+        "proposed_basename": f"sub-{subject}_task-{task}_bold",
+        "bids_guess_suffix": "bold", "bids_guess_skip": False,
+        "proposed_issues": "",
+        "entities": json.dumps({"subject": subject, "task": task}, sort_keys=True),
+        "task": task, "run": "", "series_uid": uid, "dataset": "ds",
+        "source_file": "",
+    }])
+
+
+def test_row_id_prefers_series_uid_then_source_file(tmp_path):
+    df = pd.DataFrame([
+        {"series_uid": "U1", "source_file": ""},
+        {"series_uid": "", "source_file": "/x/rec.edf"},
+        {"series_uid": "", "source_file": ""},
+    ])
+    assert row_id(df, 0) == "U1"
+    assert row_id(df, 1) == "/x/rec.edf"
+    assert row_id(df, 2) == "row-2"
+
+
+def test_apply_project_state_replays_entity_cell_include(tmp_path):
+    df = _inv_df(uid="U1")
+    proj = Project.create(tmp_path / "v", name="ds")
+    proj.append(UserSetEntity(row_id="U1", entity="task", value="memory", previous="rest"))
+    proj.append(UserToggleInclude(row_id="U1", include=False))
+
+    apply_project_state(df, proj.state())
+    assert df.iloc[0]["task"] == "memory"
+    assert "task-memory" in df.iloc[0]["proposed_basename"]
+    assert str(df.iloc[0]["include"]) in ("0", "False", "false")
+
+
+def test_import_scan_as_version_and_latest(tmp_path):
+    root = tmp_path / "ds"
+    open_or_create_workspace(root)
+    staged = root / ".bidsmgr" / "project" / ".scan_staging" / "inventory.tsv"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    df = _inv_df(uid="U1")
+    df.to_csv(staged, sep="\t", index=False)
+
+    version = import_scan_as_version(
+        root, staged, raw_root=tmp_path / "raw",
+        row_ids=("U1",), n_rows=len(df),
+    )
+    # The staged TSV moved into the version dir.
+    assert version.inventory.exists()
+    assert not staged.exists()
+    assert latest_version(root).version_id == version.version_id
+    # ScanImported event recorded in the version bundle.
+    proj = Project.open(version.dir)
+    from bidsmgr.project import ScanImported
+    assert any(isinstance(e, ScanImported) for e in proj.log)
+
+
+def test_version_dataframe_replays_edits(tmp_path):
+    root = tmp_path / "ds"
+    open_or_create_workspace(root)
+    staged = root / ".bidsmgr" / "project" / ".scan_staging" / "inventory.tsv"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    _inv_df(subject="001", uid="U1").to_csv(staged, sep="\t", index=False)
+    version = import_scan_as_version(root, staged, raw_root=tmp_path / "raw", row_ids=("U1",))
+
+    # Simulate a GUI rename of the subject, recorded in the version bundle.
+    proj = Project.open(version.dir)
+    proj.append(UserSetEntity(row_id="U1", entity="subject", value="042", previous="001"))
+
+    df = version_dataframe(latest_version(root), apply_edits=True)
+    assert df.iloc[0]["BIDS_name"] == "sub-042"
+    # Without replay the on-disk inventory is unchanged.
+    raw = version_dataframe(latest_version(root), apply_edits=False)
+    assert raw.iloc[0]["BIDS_name"] == "sub-001"
+
+
+def test_find_version_by_id_and_index(tmp_path):
+    root = tmp_path / "ds"
+    open_or_create_workspace(root)
+    for label in ("alpha", "beta"):
+        staged = root / ".bidsmgr" / "project" / ".scan_staging" / "inventory.tsv"
+        staged.parent.mkdir(parents=True, exist_ok=True)
+        _inv_df().to_csv(staged, sep="\t", index=False)
+        import_scan_as_version(root, staged, raw_root=tmp_path / label, source_label=label)
+
+    versions = workspace.list_versions(root)
+    assert len(versions) == 2
+    # By full id, by numeric index, by zero-padded index.
+    assert find_version(root, versions[0].version_id).index == 1
+    assert find_version(root, "2").index == 2
+    assert find_version(root, "0001").index == 1
+    assert find_version(root, "nope") is None

--- a/tests/unit/test_recording_meta_models.py
+++ b/tests/unit/test_recording_meta_models.py
@@ -38,6 +38,33 @@ def test_default_spec_preserves_50hz_default():
     assert spec.defaults.power_line_freq == 50.0
 
 
+def test_common_manufacturers_exported_pure_data():
+    from bidsmgr.recording_meta import COMMON_CAP_MANUFACTURERS, COMMON_MANUFACTURERS
+    assert isinstance(COMMON_MANUFACTURERS, tuple)
+    assert "Brain Products" in COMMON_MANUFACTURERS
+    assert "MEGIN / Elekta / Neuromag" in COMMON_MANUFACTURERS
+    assert "CTF" in COMMON_MANUFACTURERS              # MEG
+    assert "NIRx" in COMMON_MANUFACTURERS             # fNIRS
+    assert "EasyCap" in COMMON_CAP_MANUFACTURERS
+
+
+def test_meg_fields_on_acquisition_spec():
+    # Only the manual MEG fields exist; channel-derived ones are mne-bids's job.
+    acq = AcquisitionSpec(
+        dewar_position="supine",
+        associated_empty_room="bids::sub-x",
+        subject_artefact_description="movement",
+    )
+    assert acq.dewar_position == "supine"
+    assert acq.associated_empty_room == "bids::sub-x"
+    # The auto-derived MEG fields are NOT part of the model.
+    assert not hasattr(acq, "continuous_head_localization")
+    assert not hasattr(acq, "digitized_landmarks")
+    # Additive: round-trips through JSON by attr name.
+    dumped = dump_spec(RecordingMetaSpec(defaults=acq))
+    assert "dewar_position" in dumped
+
+
 def test_aux_channel_bids_type_validated_against_schema():
     # A real BIDS channel type passes.
     ok = AuxChannelSpec(mne_type="ecg", bids_type="ECG", units="mV")

--- a/tests/unit/test_recording_meta_models.py
+++ b/tests/unit/test_recording_meta_models.py
@@ -1,0 +1,150 @@
+"""Unit tests for the recording_meta enrichment models + resolution."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from bidsmgr.recording_meta import (
+    AcquisitionSpec,
+    AuxChannelSpec,
+    FilterSpec,
+    RecordingMetaSpec,
+    bids_channel_types,
+    default_spec,
+    dump_spec,
+    load_spec,
+    merge_acquisition,
+    resolve_effective,
+)
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_spec_is_valid_and_additive():
+    spec = RecordingMetaSpec()
+    assert spec.schema_version == 1
+    assert spec.defaults.power_line_freq is None
+    assert spec.overrides == {}
+
+
+def test_default_spec_preserves_50hz_default():
+    spec = default_spec()
+    assert spec.defaults.power_line_freq == 50.0
+
+
+def test_aux_channel_bids_type_validated_against_schema():
+    # A real BIDS channel type passes.
+    ok = AuxChannelSpec(mne_type="ecg", bids_type="ECG", units="mV")
+    assert ok.bids_type == "ECG"
+    # The schema vocabulary actually contains it.
+    assert "ECG" in bids_channel_types()
+
+
+def test_aux_channel_rejects_unknown_bids_type():
+    with pytest.raises(ValidationError):
+        AuxChannelSpec(bids_type="NOTATYPE")
+
+
+def test_aux_channel_rejects_unknown_mne_type():
+    with pytest.raises(ValidationError):
+        AuxChannelSpec(mne_type="not_a_real_mne_type")
+
+
+def test_filter_kind_constrained():
+    FilterSpec(name="lp", kind="Hardware", info={"cutoff": 260})
+    with pytest.raises(ValidationError):
+        FilterSpec(name="lp", kind="firmware", info={})
+
+
+def test_extra_keys_forbidden():
+    with pytest.raises(ValidationError):
+        AcquisitionSpec(not_a_field="x")
+
+
+# ---------------------------------------------------------------------------
+# Resolution / precedence
+# ---------------------------------------------------------------------------
+
+
+def test_override_wins_over_default_scalar():
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(eeg_reference="Cz", eeg_ground="AFz"),
+        overrides={"row-1": AcquisitionSpec(eeg_reference="FCz")},
+    )
+    eff = resolve_effective(spec, "row-1")
+    assert eff.acquisition.eeg_reference == "FCz"  # override wins
+    assert eff.acquisition.eeg_ground == "AFz"  # default retained
+
+
+def test_unset_override_field_keeps_default():
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(manufacturer="Brain Products"),
+        overrides={"row-1": AcquisitionSpec(eeg_reference="Cz")},
+    )
+    eff = resolve_effective(spec, "row-1")
+    assert eff.acquisition.manufacturer == "Brain Products"
+    assert eff.acquisition.eeg_reference == "Cz"
+
+
+def test_aux_channels_merge_by_key():
+    base = AcquisitionSpec(aux_channels={"ECG": AuxChannelSpec(bids_type="ECG")})
+    over = AcquisitionSpec(aux_channels={"EOG": AuxChannelSpec(bids_type="EOG")})
+    merged = merge_acquisition(base, over)
+    assert set(merged.aux_channels) == {"ECG", "EOG"}
+
+
+def test_filters_replace_when_override_nonempty():
+    base = AcquisitionSpec(filters=[FilterSpec(name="a", kind="Hardware")])
+    over = AcquisitionSpec(filters=[FilterSpec(name="b", kind="Software")])
+    merged = merge_acquisition(base, over)
+    assert [f.name for f in merged.filters] == ["b"]
+
+
+def test_event_map_task_then_global_fallback():
+    spec = RecordingMetaSpec(
+        event_maps={"rest": {"S 20": "eyes_open"}, "*": {"S 99": "marker"}},
+    )
+    assert resolve_effective(spec, "row", "rest").event_map == {"S 20": "eyes_open"}
+    assert resolve_effective(spec, "row", "other").event_map == {"S 99": "marker"}
+    assert resolve_effective(spec, "row", None).event_map == {"S 99": "marker"}
+
+
+def test_missing_row_resolves_to_defaults_only():
+    spec = RecordingMetaSpec(defaults=AcquisitionSpec(eeg_reference="Cz"))
+    eff = resolve_effective(spec, "no-such-row")
+    assert eff.acquisition.eeg_reference == "Cz"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip I/O
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_json(tmp_path):
+    spec = RecordingMetaSpec(
+        defaults=AcquisitionSpec(
+            eeg_reference="Cz",
+            aux_channels={"ECG": AuxChannelSpec(mne_type="ecg", bids_type="ECG")},
+            filters=[FilterSpec(name="lp", kind="Software", info={"cutoff": 260})],
+        ),
+        event_maps={"rest": {"S 20": "eyes_open"}},
+    )
+    path = tmp_path / "meta.json"
+    path.write_text(dump_spec(spec), encoding="utf-8")
+    reloaded = load_spec(path)
+    assert reloaded.defaults.eeg_reference == "Cz"
+    assert reloaded.defaults.aux_channels["ECG"].bids_type == "ECG"
+    assert reloaded.event_maps["rest"]["S 20"] == "eyes_open"
+
+
+def test_load_rejects_unknown_key(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps({"defaults": {"bogus": 1}}), encoding="utf-8")
+    with pytest.raises(ValidationError):
+        load_spec(path)

--- a/tests/unit/test_recording_meta_scaffold.py
+++ b/tests/unit/test_recording_meta_scaffold.py
@@ -1,0 +1,73 @@
+"""Tests for the scan-time recording-metadata scaffold writer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from bidsmgr.cli.scan import _write_recording_meta_scaffold
+from bidsmgr.recording_meta import load_spec, scaffold_sidecar_path
+
+
+def _eeg_df(event_codes, manufacturer="", model=""):
+    return pd.DataFrame([
+        {
+            "source_file": "sub-001/rec.edf",
+            "proposed_datatype": "eeg",
+            "_event_codes": json.dumps(event_codes),
+            "_manufacturer": manufacturer,
+            "_model": model,
+        },
+        {
+            "source_file": "sub-002/rec.edf",
+            "proposed_datatype": "eeg",
+            "_event_codes": json.dumps(event_codes),
+            "_manufacturer": manufacturer,
+            "_model": model,
+        },
+    ])
+
+
+def test_scaffold_written_with_blank_event_labels(tmp_path):
+    tsv = tmp_path / "inv.tsv"
+    df = _eeg_df(["T1", "T0", "T2"], manufacturer="Elekta", model="TRIUX")
+    out = _write_recording_meta_scaffold(df, tsv)
+    assert out == scaffold_sidecar_path(tsv)
+    spec = load_spec(out)
+    # Codes seeded sorted, labels blank for the user to fill.
+    assert spec.event_maps["*"] == {"T0": "", "T1": "", "T2": ""}
+    assert spec.defaults.manufacturer == "Elekta"
+    assert spec.defaults.amplifier_model == "TRIUX"
+
+
+def test_scaffold_not_overwritten(tmp_path):
+    tsv = tmp_path / "inv.tsv"
+    sidecar = scaffold_sidecar_path(tsv)
+    sidecar.write_text('{"schema_version": 1, "event_maps": {"*": {"T0": "rest"}}}', encoding="utf-8")
+    out = _write_recording_meta_scaffold(_eeg_df(["T0"]), tsv)
+    assert out is None  # preserved
+    assert load_spec(sidecar).event_maps["*"]["T0"] == "rest"  # user label intact
+
+
+def test_no_scaffold_when_nothing_detected(tmp_path):
+    tsv = tmp_path / "inv.tsv"
+    out = _write_recording_meta_scaffold(_eeg_df([], manufacturer="", model=""), tsv)
+    assert out is None
+    assert not scaffold_sidecar_path(tsv).exists()
+
+
+def test_no_scaffold_for_mri_only(tmp_path):
+    tsv = tmp_path / "inv.tsv"
+    mri = pd.DataFrame([{"series_uid": "1.2.3", "source_file": ""}])
+    assert _write_recording_meta_scaffold(mri, tsv) is None
+
+
+def test_manufacturer_only_still_seeds(tmp_path):
+    tsv = tmp_path / "inv.tsv"
+    out = _write_recording_meta_scaffold(_eeg_df([], manufacturer="BrainProducts"), tsv)
+    assert out is not None
+    spec = load_spec(out)
+    assert spec.defaults.manufacturer == "BrainProducts"
+    assert spec.event_maps == {}

--- a/tests/unit/test_recording_meta_scaffold.py
+++ b/tests/unit/test_recording_meta_scaffold.py
@@ -38,8 +38,10 @@ def test_scaffold_written_with_blank_event_labels(tmp_path):
     spec = load_spec(out)
     # Codes seeded sorted, labels blank for the user to fill.
     assert spec.event_maps["*"] == {"T0": "", "T1": "", "T2": ""}
-    assert spec.defaults.manufacturer == "Elekta"
-    assert spec.defaults.amplifier_model == "TRIUX"
+    # Device fields are NOT seeded - manufacturer is a read-only suggestion and
+    # mne-bids fills the MEG sidecar value, so seeding would wrongly overwrite it.
+    assert spec.defaults.manufacturer is None
+    assert spec.defaults.amplifier_model is None
 
 
 def test_scaffold_not_overwritten(tmp_path):
@@ -64,10 +66,10 @@ def test_no_scaffold_for_mri_only(tmp_path):
     assert _write_recording_meta_scaffold(mri, tsv) is None
 
 
-def test_manufacturer_only_still_seeds(tmp_path):
+def test_manufacturer_alone_does_not_seed(tmp_path):
+    """A manufacturer with no event codes seeds NOTHING (manufacturer is a
+    read-only suggestion now, not a scaffold default)."""
     tsv = tmp_path / "inv.tsv"
     out = _write_recording_meta_scaffold(_eeg_df([], manufacturer="BrainProducts"), tsv)
-    assert out is not None
-    spec = load_spec(out)
-    assert spec.defaults.manufacturer == "BrainProducts"
-    assert spec.event_maps == {}
+    assert out is None
+    assert not scaffold_sidecar_path(tsv).exists()

--- a/tests/unit/test_recording_reader.py
+++ b/tests/unit/test_recording_reader.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Qt-free recording read/summary helpers.
+
+These functions live in :mod:`bidsmgr.gui.widgets.recording_viewer_pane`
+(imported by the loader workers) but are pure logic: extension routing,
+MNE read, the display summary, and events.tsv resolution. No QApplication
+is created here.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mne = pytest.importorskip("mne")
+
+from bidsmgr.gui.widgets.recording_viewer_pane import (  # noqa: E402
+    _events_sibling,
+    _full_ext,
+    _read_events_tsv,
+    _read_raw,
+    _summarize_raw,
+    is_recording_path,
+)
+
+
+def _make_fif(tmp: Path, name: str = "sub-01_task-rest_eeg.fif") -> Path:
+    sfreq = 128.0
+    n = int(sfreq * 3)
+    data = np.random.default_rng(2).standard_normal((5, n)) * 1e-5
+    info = mne.create_info(
+        ["Fz", "Cz", "Pz", "EOG", "STI"],
+        sfreq,
+        ["eeg", "eeg", "eeg", "eog", "stim"],
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        raw = mne.io.RawArray(data, info, verbose=False)
+        path = tmp / name
+        raw.save(path, overwrite=True, verbose=False)
+    return path
+
+
+def test_full_ext_preserves_double_suffix() -> None:
+    assert _full_ext(Path("a.fif.gz")) == ".fif.gz"
+    assert _full_ext(Path("a.edf")) == ".edf"
+    assert _full_ext(Path("SUB.EDF")) == ".edf"
+    assert _full_ext(Path("rec.ds")) == ".ds"
+
+
+def test_is_recording_path() -> None:
+    assert is_recording_path(Path("x.fif"))
+    assert is_recording_path(Path("x.fif.gz"))
+    assert is_recording_path(Path("x.edf"))
+    assert is_recording_path(Path("x.vhdr"))
+    assert is_recording_path(Path("x.cnt"))
+    # BrainVision binary / sidecars are opened via .vhdr, never directly.
+    assert not is_recording_path(Path("x.eeg"))
+    assert not is_recording_path(Path("x.vmrk"))
+    assert not is_recording_path(Path("x.json"))
+    assert not is_recording_path(Path("x.tsv"))
+    assert not is_recording_path(Path("x.nii.gz"))
+
+
+def test_read_and_summarize(tmp_path: Path) -> None:
+    path = _make_fif(tmp_path)
+    raw = _read_raw(path, preload=False)
+    meta = _summarize_raw(raw, path)
+    assert meta["n_channels"] == 5
+    assert meta["sfreq"] == 128.0
+    assert meta["ch_type_counts"] == {"eeg": 3, "eog": 1, "stim": 1}
+    assert meta["available_ch_types"] == ["eeg", "eog", "stim"]
+    assert meta["is_ctf"] is False
+    assert meta["duration"] > 0
+    assert meta["name"] == path.name
+
+
+def test_read_preload_materialises(tmp_path: Path) -> None:
+    path = _make_fif(tmp_path)
+    raw = _read_raw(path, preload=True)
+    assert raw.preload is True
+    assert raw.n_times > 0
+
+
+def test_events_sibling_and_parse(tmp_path: Path) -> None:
+    path = _make_fif(tmp_path)
+    # No sibling yet.
+    assert _events_sibling(path) is None
+    # The BIDS events file shares all entities, only the suffix differs.
+    (tmp_path / "sub-01_task-rest_events.tsv").write_text(
+        "onset\tduration\ttrial_type\n0.1\t0\tgo\n0.9\t0\tstop\n"
+    )
+    sib = _events_sibling(path)
+    assert sib is not None
+    assert _read_events_tsv(sib) == [(0.1, "go"), (0.9, "stop")]
+
+
+def test_read_events_tsv_falls_back_to_value(tmp_path: Path) -> None:
+    p = tmp_path / "e_events.tsv"
+    p.write_text("onset\tvalue\n0.0\t1\n1.0\t2\n")
+    assert _read_events_tsv(p) == [(0.0, "1"), (1.0, "2")]

--- a/tests/unit/test_residual_outputs.py
+++ b/tests/unit/test_residual_outputs.py
@@ -1,0 +1,93 @@
+"""Tests for dcm2niix residual/secondary output detection + filtering.
+
+dcm2niix splits a single input series into the real image PLUS derived
+secondary volumes, naming the extras by gluing a collision letter onto the
+``-f`` basename (``..._bold`` -> ``..._bolda``) or with an ``_Eq_`` / ``_ROI``
+/ ``_i<instance>`` marker. Those are not real acquired images and have no
+valid BIDS suffix, so by default the converter drops them. Legitimate
+multi-output (fmap ``_e1``/``_e2``/``_ph``, complex parts, DWI bval/bvec)
+must never be dropped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bidsmgr.converter.backends.dcm2niix_direct import (
+    _is_residual_output,
+    _partition_residuals,
+)
+
+
+BASENAME = "sub-001_task-dmaging_run-1_bold"
+
+
+@pytest.mark.parametrize(
+    "name,is_residual",
+    [
+        # Primary output + its sidecar -> keep.
+        (f"{BASENAME}.nii.gz", False),
+        (f"{BASENAME}.json", False),
+        # The reproduced sina_data residual: glued collision letter -> drop.
+        (f"{BASENAME}a.nii.gz", True),
+        (f"{BASENAME}a.json", True),
+        (f"{BASENAME}b.nii.gz", True),
+        # dcm2niix reslice / scanner secondaries -> drop.
+        (f"{BASENAME}_Eq_1.nii.gz", True),
+        (f"{BASENAME}_Eq_2.json", True),
+        (f"{BASENAME}_ROI1.nii.gz", True),
+        (f"{BASENAME}_ROI.nii.gz", True),
+        (f"{BASENAME}_i00001.nii.gz", True),
+        # Legitimate multi-output siblings -> keep.
+        (f"{BASENAME}_e1.nii.gz", False),
+        (f"{BASENAME}_e2.nii.gz", False),
+        (f"{BASENAME}_ph.nii.gz", False),
+        (f"{BASENAME}_e2_ph.nii.gz", False),
+        (f"{BASENAME}_real.nii.gz", False),
+        (f"{BASENAME}_imaginary.nii.gz", False),
+        (f"{BASENAME}.bval", False),
+        (f"{BASENAME}.bvec", False),
+    ],
+)
+def test_is_residual_output(name: str, is_residual: bool) -> None:
+    assert _is_residual_output(Path(name), BASENAME) is is_residual
+
+
+def test_partition_residuals_splits_keep_and_drop() -> None:
+    staged = [
+        Path(f"{BASENAME}.nii.gz"),
+        Path(f"{BASENAME}.json"),
+        Path(f"{BASENAME}a.nii.gz"),
+        Path(f"{BASENAME}a.json"),
+    ]
+    keep, residual = _partition_residuals(staged, BASENAME)
+    assert {p.name for p in keep} == {f"{BASENAME}.nii.gz", f"{BASENAME}.json"}
+    assert {p.name for p in residual} == {f"{BASENAME}a.nii.gz", f"{BASENAME}a.json"}
+
+
+def test_fmap_multi_output_never_dropped() -> None:
+    fmap_base = "sub-001_acq-fm2_magnitude1"
+    staged = [
+        Path(f"{fmap_base}_e1.nii.gz"),
+        Path(f"{fmap_base}_e1.json"),
+        Path(f"{fmap_base}_e2.nii.gz"),
+        Path(f"{fmap_base}_e2_ph.nii.gz"),
+    ]
+    keep, residual = _partition_residuals(staged, fmap_base)
+    assert residual == []
+    assert len(keep) == 4
+
+
+def test_dwi_sidecars_never_dropped() -> None:
+    dwi_base = "sub-001_dwi"
+    staged = [
+        Path(f"{dwi_base}.nii.gz"),
+        Path(f"{dwi_base}.json"),
+        Path(f"{dwi_base}.bval"),
+        Path(f"{dwi_base}.bvec"),
+    ]
+    keep, residual = _partition_residuals(staged, dwi_base)
+    assert residual == []
+    assert len(keep) == 4

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -1,0 +1,69 @@
+"""Tests for the shared BIDS scaffold helpers (``bidsmgr.cli._scaffold``).
+
+These centralize dataset_description.json creation + ``.bidsignore`` so the
+convert verb and the future project "create dataset" flow stay consistent: the
+BIDS version is sourced from the bundled schema, ``GeneratedBy`` is idempotent,
+and BM's hidden working dirs are exempted from the official validator.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bidsmgr.cli._scaffold import (
+    BIDSIGNORE_LINES,
+    ensure_bidsignore,
+    ensure_dataset_description,
+)
+from bidsmgr.schema import bids_version as schema_bids_version
+
+
+def _dd(root: Path) -> dict:
+    return json.loads((root / "dataset_description.json").read_text())
+
+
+def test_dataset_description_minimal_valid(tmp_path: Path):
+    ensure_dataset_description(tmp_path)
+    dd = _dd(tmp_path)
+    assert dd["Name"] == tmp_path.name
+    assert dd["BIDSVersion"] == schema_bids_version()  # no hardcoded version
+    assert dd["DatasetType"] == "raw"
+    # No generator entry when none is passed (the "create empty dataset" path).
+    assert "GeneratedBy" not in dd
+
+
+def test_dataset_description_records_generated_by_once(tmp_path: Path):
+    stamp = {"Name": "bidsmgr", "Version": "9.9.9", "Description": "x backend"}
+    ensure_dataset_description(tmp_path, generated_by=stamp)
+    ensure_dataset_description(tmp_path, generated_by=stamp)  # re-run
+    gb = _dd(tmp_path)["GeneratedBy"]
+    assert [g for g in gb if g.get("Name") == "bidsmgr"] == [stamp]
+
+
+def test_dataset_description_preserves_user_fields(tmp_path: Path):
+    p = tmp_path / "dataset_description.json"
+    p.write_text(json.dumps({"Name": "My Study", "Authors": ["A. Person"]}))
+    ensure_dataset_description(tmp_path)
+    dd = _dd(tmp_path)
+    assert dd["Name"] == "My Study"          # not overwritten
+    assert dd["Authors"] == ["A. Person"]    # untouched
+    assert dd["BIDSVersion"] == schema_bids_version()  # filled
+
+
+def test_bidsignore_created_with_bm_dirs(tmp_path: Path):
+    ensure_bidsignore(tmp_path)
+    lines = (tmp_path / ".bidsignore").read_text().splitlines()
+    for entry in BIDSIGNORE_LINES:
+        assert entry in lines
+
+
+def test_bidsignore_is_idempotent_and_preserves_user_lines(tmp_path: Path):
+    p = tmp_path / ".bidsignore"
+    p.write_text("derivatives/\n.bidsmgr/\n")  # user already ignored one BM dir
+    ensure_bidsignore(tmp_path)
+    ensure_bidsignore(tmp_path)  # second call must not duplicate
+    lines = p.read_text().splitlines()
+    assert lines.count(".bidsmgr/") == 1
+    assert ".tmp_bidsmgr/" in lines
+    assert "derivatives/" in lines  # user line preserved

--- a/tests/unit/test_scan_auto_dispatch.py
+++ b/tests/unit/test_scan_auto_dispatch.py
@@ -40,17 +40,17 @@ from bidsmgr.inventory.mri_dicom import (
 
 class TestUnifiedColumnContract:
     def test_full_unified_column_layout(self) -> None:
-        """Locked schema: TSV(22) + BIDS_GUESS(8) + ENTITIES(1) +
-        DATASET(1) + PROBE(4) + EXTENDED(3) + EEG_MEG(12) = 51.
+        """Locked schema: TSV(24) + BIDS_GUESS(8) + ENTITIES(1) +
+        DATASET(1) + PROBE(4) + EXTENDED(3) + EEG_MEG(15) = 56.
 
-        The new ``entities`` JSON column is the canonical source of
-        truth for the BIDS basename; ``proposed_basename`` and the
-        ``task``/``run``/``session`` mirror cells are derived from it
-        by ``bidsmgr-rebuild``.
+        TSV gained ``Handedness`` (demographics) + ``companion_files`` (per-row
+        curated-companion links); EEG_MEG gained ``eeg_reference`` /
+        ``eeg_ground`` (per-row overrides) and ``montage_suggestion`` (read-only
+        scan hint). The ``entities`` JSON column is the canonical basename source.
         """
         df = _empty_unified_dataframe()
         cols = _unified_column_order(df)
-        assert len(cols) == 22 + 8 + 1 + 1 + 4 + 3 + 12
+        assert len(cols) == 24 + 8 + 1 + 1 + 4 + 3 + 15
         # ``dataset`` comes after BidsGuess + the new ``entities`` column.
         ds_idx = cols.index("dataset")
         assert ds_idx == len(TSV_COLUMNS) + len(BIDS_GUESS_COLUMNS) + 1
@@ -101,6 +101,12 @@ class _StubProbe:
     datatype: str = "eeg"
     has_positions: bool = False
     fmt: str = "EDF"
+    manufacturer: str = ""
+    model: str = ""
+    subj_sex: str = ""
+    subj_age: str = ""
+    event_codes: tuple[str, ...] = ()
+    montage_suggestion: str = ""
 
 
 def _patch_eeg_probe(monkeypatch, *, datatype: str = "eeg") -> None:

--- a/tests/unit/test_scan_auto_dispatch.py
+++ b/tests/unit/test_scan_auto_dispatch.py
@@ -41,16 +41,17 @@ from bidsmgr.inventory.mri_dicom import (
 class TestUnifiedColumnContract:
     def test_full_unified_column_layout(self) -> None:
         """Locked schema: TSV(24) + BIDS_GUESS(8) + ENTITIES(1) +
-        DATASET(1) + PROBE(4) + EXTENDED(3) + EEG_MEG(15) = 56.
+        DATASET(1) + PROBE(4) + EXTENDED(3) + EEG_MEG(16) = 57.
 
         TSV gained ``Handedness`` (demographics) + ``companion_files`` (per-row
         curated-companion links); EEG_MEG gained ``eeg_reference`` /
-        ``eeg_ground`` (per-row overrides) and ``montage_suggestion`` (read-only
-        scan hint). The ``entities`` JSON column is the canonical basename source.
+        ``eeg_ground`` (per-row overrides) and the read-only scan hints
+        ``montage_suggestion`` + ``manufacturer_suggestion``. The ``entities``
+        JSON column is the canonical basename source.
         """
         df = _empty_unified_dataframe()
         cols = _unified_column_order(df)
-        assert len(cols) == 24 + 8 + 1 + 1 + 4 + 3 + 15
+        assert len(cols) == 24 + 8 + 1 + 1 + 4 + 3 + 16
         # ``dataset`` comes after BidsGuess + the new ``entities`` column.
         ds_idx = cols.index("dataset")
         assert ds_idx == len(TSV_COLUMNS) + len(BIDS_GUESS_COLUMNS) + 1

--- a/tests/unit/test_study_description_warning.py
+++ b/tests/unit/test_study_description_warning.py
@@ -1,0 +1,140 @@
+"""Tests for the multiple-StudyDescription scan heads-up.
+
+``bidsmgr.cli.scan._flag_mixed_study_descriptions`` surfaces a heads-up when one
+scan pooled DICOMs from more than one study. It reuses the existing severity
+system: a one-line summary on the ``bidsmgr.cli.scan`` logger (CLI + GUI Log
+dock) plus a non-fatal note appended to each affected row's ``proposed_issues``
+so the rows read as ``warn`` (warnings chip + Issues dialog). Nothing is excluded
+or rewritten.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pandas as pd
+
+from bidsmgr.cli.scan import (
+    MIXED_STUDY_ISSUE_TOKEN,
+    _flag_mixed_study_descriptions,
+)
+
+# Tokens the GUI inventory model treats as fatal ("err"). The mixed-study note
+# must avoid all of them so the row classifies as a warning, not an error.
+_ERR_TOKENS = ("suspected_abort", "required", "build_basename", "missing")
+
+LOGGER = "bidsmgr.cli.scan"
+
+
+def _warnings(caplog) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def _df(rows: list[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    if "proposed_issues" not in df.columns:
+        df["proposed_issues"] = ""
+    return df
+
+
+def test_flags_rows_and_logs_on_multiple_studies(caplog):
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "StudyA"},
+            {"BIDS_name": "sub-002", "StudyDescription": "StudyB"},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+
+    msgs = " ".join(_warnings(caplog))
+    assert "Multiple distinct DICOM StudyDescriptions" in msgs
+    assert "StudyA" in msgs and "StudyB" in msgs
+
+    # Every affected row gets a non-fatal proposed_issues note.
+    issues = df["proposed_issues"].tolist()
+    assert all(MIXED_STUDY_ISSUE_TOKEN in str(v) for v in issues)
+    # row 0 names its own study and points at the other.
+    assert "StudyA" in issues[0] and "StudyB" in issues[0]
+
+
+def test_note_is_warning_not_error(caplog):
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "StudyA"},
+            {"BIDS_name": "sub-002", "StudyDescription": "StudyB"},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    # The model classifies a proposed_issues note containing any error token as
+    # "err"; the mixed-study note must stay clear of all of them so the row reads
+    # as "warn".
+    for note in df["proposed_issues"]:
+        low = str(note).lower()
+        assert not any(tok in low for tok in _ERR_TOKENS)
+
+
+def test_existing_issues_are_preserved(caplog):
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "StudyA",
+             "proposed_issues": "B0 reroute"},
+            {"BIDS_name": "sub-002", "StudyDescription": "StudyB",
+             "proposed_issues": ""},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    # The prior note is kept; the mixed-study note is appended after it.
+    assert df["proposed_issues"].iloc[0].startswith("B0 reroute")
+    assert MIXED_STUDY_ISSUE_TOKEN in df["proposed_issues"].iloc[0]
+
+
+def test_silent_on_single_study(caplog):
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "OnlyStudy"},
+            {"BIDS_name": "sub-002", "StudyDescription": "OnlyStudy"},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    assert _warnings(caplog) == []
+    assert (df["proposed_issues"] == "").all()
+
+
+def test_silent_without_studydescription_column(caplog):
+    # EEG/MEG-only inventory has no StudyDescription column.
+    df = pd.DataFrame({"BIDS_name": ["sub-001"], "datatype": ["eeg"]})
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    assert _warnings(caplog) == []
+
+
+def test_blank_values_are_ignored(caplog):
+    # Mixed EEG (blank study) + single-study MRI must not trip the heads-up.
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "OneStudy"},
+            {"BIDS_name": "sub-002", "StudyDescription": ""},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    assert _warnings(caplog) == []
+    assert (df["proposed_issues"] == "").all()
+
+
+def test_per_subject_span_is_called_out(caplog):
+    # One subject whose series span two studies is the strongest signal.
+    df = _df(
+        [
+            {"BIDS_name": "sub-001", "StudyDescription": "StudyA"},
+            {"BIDS_name": "sub-001", "StudyDescription": "StudyB"},
+        ]
+    )
+    with caplog.at_level(logging.WARNING, logger=LOGGER):
+        _flag_mixed_study_descriptions(df)
+    msgs = " ".join(_warnings(caplog))
+    assert "subject sub-001 spans 2 StudyDescriptions" in msgs

--- a/tests/unit/test_user_rules.py
+++ b/tests/unit/test_user_rules.py
@@ -1,0 +1,203 @@
+"""Tests for user-configurable scan rules: classifier hints + exclusions.
+
+Covers the pure-data layer (``classifier/user_rules``), the chain priority
+in ``cli/scan._run_classifier_chain`` (a default hint beats the regex
+fallback but loses to dcm2niix BidsGuess; a ``force`` hint beats BidsGuess),
+schema rejection of bad hints, and the row-level exclusion flag.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bidsmgr.classifier import sequence_dict, user_rules as ur
+from bidsmgr.classifier.types import Classification
+from bidsmgr.cli import scan
+from bidsmgr.inventory.types import InventoryRow
+
+
+# ---------------------------------------------------------------------------
+# user_rules: matchers + JSON
+# ---------------------------------------------------------------------------
+
+
+def test_hint_matches_substring_and_regex() -> None:
+    h_sub = ur.UserHint(patterns=("lab_t1",), datatype="anat", suffix="T1w")
+    assert ur.hint_matches(h_sub, "study_LAB_T1_v2")     # case-insensitive
+    assert not ur.hint_matches(h_sub, "t2_space")
+    h_rx = ur.UserHint(patterns=(r"mb\d+",), datatype="func", suffix="bold", match_mode="regex")
+    assert ur.hint_matches(h_rx, "rest_MB6")
+    assert not ur.hint_matches(h_rx, "rest_mb")
+
+
+def test_exclusion_matches_targets() -> None:
+    seq_rule = ur.ExclusionRule(pattern="calib", target="sequence")
+    path_rule = ur.ExclusionRule(pattern="scratch", target="path")
+    assert ur.exclusion_matches(seq_rule, sequence="pre_CALIB_scan", path="")
+    assert not ur.exclusion_matches(seq_rule, sequence="t1", path="scratch/x")
+    assert ur.exclusion_matches(path_rule, sequence="t1", path="data/scratch/x")
+
+
+def test_validate_regex() -> None:
+    assert ur.validate_regex("ok.*") is None
+    assert ur.validate_regex("(") is not None
+
+
+def test_bad_regex_never_raises_in_matcher() -> None:
+    h = ur.UserHint(patterns=("(",), datatype="anat", suffix="T1w", match_mode="regex")
+    assert ur.hint_matches(h, "anything") is False  # degrades, no raise
+
+
+def test_from_json_to_json_round_trip_and_tolerance() -> None:
+    obj = {
+        "user_hints": [
+            {"patterns": ["a", "b"], "datatype": "anat", "suffix": "T1w",
+             "task": "rest", "match_mode": "regex", "force": True},
+            {"patterns": [], "datatype": "anat", "suffix": "T1w"},   # dropped (no patterns)
+            "garbage",                                                # ignored
+        ],
+        "scan_exclusions": [
+            {"pattern": "x", "target": "path", "match_mode": "substring"},
+            {"pattern": "", "target": "sequence"},                    # dropped (no pattern)
+        ],
+    }
+    hints, excl = ur.from_json(obj)
+    assert len(hints) == 1 and len(excl) == 1
+    assert hints[0].force is True and hints[0].task == "rest"
+    # to_json/from_json is stable.
+    again_h, again_e = ur.from_json(ur.to_json(hints, excl))
+    assert again_h == hints and again_e == excl
+
+
+# ---------------------------------------------------------------------------
+# classify_user_hints
+# ---------------------------------------------------------------------------
+
+
+def _row(desc: str) -> InventoryRow:
+    return InventoryRow(source=Path("x"), series_description=desc, n_files=10)
+
+
+def test_classify_user_hints_confidence_and_first_match() -> None:
+    rows = [_row("LABSEQ acquisition")]
+    hints = [
+        ur.UserHint(patterns=("labseq",), datatype="func", suffix="bold", force=False),
+        ur.UserHint(patterns=("labseq",), datatype="anat", suffix="T1w", force=True),
+    ]
+    cls = sequence_dict.classify_user_hints(rows, hints)
+    assert len(cls) == 1
+    # First matching hint (document order) wins -> func/bold, non-force 0.60.
+    assert (cls[0].datatype, cls[0].suffix, cls[0].classifier) == ("func", "bold", "user_hint")
+    assert cls[0].confidence == pytest.approx(0.60)
+
+    forced = sequence_dict.classify_user_hints(rows, [hints[1]])
+    assert forced[0].confidence == pytest.approx(0.95)
+
+
+# ---------------------------------------------------------------------------
+# Chain priority
+# ---------------------------------------------------------------------------
+
+
+def test_default_hint_loses_to_bidsguess(monkeypatch) -> None:
+    row = _row("LABSEQ scan")
+    monkeypatch.setattr(
+        scan.dcm2niix_bidsguess, "classify",
+        lambda rows: [Classification(row_id=row.row_id, classifier="dcm2niix_bidsguess",
+                                     datatype="anat", suffix="T2w", confidence=0.85)],
+    )
+    hints = [ur.UserHint(patterns=("labseq",), datatype="anat", suffix="T1w", force=False)]
+    chosen = scan._run_classifier_chain([row], user_hints=hints)
+    c = chosen[row.row_id.hex]
+    assert (c.datatype, c.suffix) == ("anat", "T2w")   # BidsGuess won
+
+
+def test_force_hint_beats_bidsguess(monkeypatch) -> None:
+    row = _row("LABSEQ scan")
+    monkeypatch.setattr(
+        scan.dcm2niix_bidsguess, "classify",
+        lambda rows: [Classification(row_id=row.row_id, classifier="dcm2niix_bidsguess",
+                                     datatype="anat", suffix="T2w", confidence=0.85)],
+    )
+    hints = [ur.UserHint(patterns=("labseq",), datatype="anat", suffix="T1w", force=True)]
+    chosen = scan._run_classifier_chain([row], user_hints=hints)
+    c = chosen[row.row_id.hex]
+    assert (c.datatype, c.suffix, c.classifier) == ("anat", "T1w", "user_hint")
+
+
+def test_default_hint_beats_regex_fallback(monkeypatch) -> None:
+    # MPRAGE would classify as anat/T1w by the built-in regex; a non-force
+    # hint mapping the same series to anat/T2w must win when BidsGuess is silent.
+    row = _row("my_MPRAGE")
+    monkeypatch.setattr(scan.dcm2niix_bidsguess, "classify", lambda rows: [])
+    hints = [ur.UserHint(patterns=("mprage",), datatype="anat", suffix="T2w", force=False)]
+    chosen = scan._run_classifier_chain([row], user_hints=hints)
+    c = chosen[row.row_id.hex]
+    assert (c.datatype, c.suffix, c.classifier) == ("anat", "T2w", "user_hint")
+
+
+def test_schema_invalid_hint_is_dropped(monkeypatch) -> None:
+    row = _row("my_MPRAGE")
+    monkeypatch.setattr(scan.dcm2niix_bidsguess, "classify", lambda rows: [])
+    # anat/bold is not a valid pair -> hint rejected; falls through to regex.
+    hints = [ur.UserHint(patterns=("mprage",), datatype="anat", suffix="bold")]
+    chosen = scan._run_classifier_chain([row], user_hints=hints)
+    c = chosen[row.row_id.hex]
+    assert c.classifier != "user_hint"
+    assert (c.datatype, c.suffix) == ("anat", "T1w")   # built-in regex result
+
+
+def test_derivatives_hint_rejected(monkeypatch) -> None:
+    row = _row("weird_seq")
+    monkeypatch.setattr(scan.dcm2niix_bidsguess, "classify", lambda rows: [])
+    hints = [ur.UserHint(patterns=("weird_seq",), datatype="derivatives", suffix="TENSOR")]
+    chosen = scan._user_hint_classifications([row], hints)
+    assert chosen == {}   # derivatives not allowed for user hints
+
+
+# ---------------------------------------------------------------------------
+# Exclusions (row-level, reversible)
+# ---------------------------------------------------------------------------
+
+
+def _excl_df() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"sequence": "t1_mprage", "source_folder": "sub-01/anat", "include": 1,
+         "bids_guess_skip": False, "proposed_issues": ""},
+        {"sequence": "AAHead_Scout", "source_folder": "sub-01/loc", "include": 1,
+         "bids_guess_skip": False, "proposed_issues": "existing note"},
+        {"sequence": "rest_bold", "source_folder": "scratch/junk", "include": 1,
+         "bids_guess_skip": False, "proposed_issues": ""},
+    ])
+
+
+def test_apply_user_exclusions_sequence_match() -> None:
+    df = _excl_df()
+    scan._apply_user_exclusions(df, [ur.ExclusionRule(pattern="scout", target="sequence")])
+    # Row 1 (scout) excluded, others untouched.
+    assert df.at[0, "include"] == 1
+    assert df.at[1, "include"] == 0
+    assert bool(df.at[1, "bids_guess_skip"]) is True
+    assert scan.USER_EXCLUDED_ISSUE_TOKEN in df.at[1, "proposed_issues"]
+    assert "existing note" in df.at[1, "proposed_issues"]   # prepended, not clobbered
+    assert df.at[2, "include"] == 1
+    # Reversible: no rows dropped.
+    assert len(df) == 3
+
+
+def test_apply_user_exclusions_path_target_and_regex() -> None:
+    df = _excl_df()
+    scan._apply_user_exclusions(df, [ur.ExclusionRule(pattern=r"scratch/.*", target="path", match_mode="regex")])
+    assert df.at[2, "include"] == 0       # path matched
+    assert df.at[0, "include"] == 1
+    assert df.at[1, "include"] == 1
+
+
+def test_apply_user_exclusions_empty_is_noop() -> None:
+    df = _excl_df()
+    scan._apply_user_exclusions(df, None)
+    scan._apply_user_exclusions(df, [])
+    assert list(df["include"]) == [1, 1, 1]

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -1,0 +1,69 @@
+"""Tests for the scan-version engine (``bidsmgr.project.workspace``).
+
+Each scan of a source folder gets its own version dir under
+``.bidsmgr/project/scans/``, so a second scan never overwrites the first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bidsmgr.project import workspace as ws
+
+
+def _make_version(root: Path, label: str, raw: str) -> Path:
+    vdir = ws.allocate_version_dir(root, label)
+    vdir.mkdir(parents=True)
+    ws.version_inventory(vdir).write_text("BIDS_name\tinclude\n")
+    ws.write_version_meta(vdir, source_label=label, raw_root=raw, status="curating")
+    return vdir
+
+
+def test_allocate_increments_index(tmp_path: Path):
+    root = tmp_path / "ds"
+    v1 = _make_version(root, "first", "/data/a")
+    v2 = ws.allocate_version_dir(root, "second")
+    assert v1.name == "0001__first"
+    assert v2.name == "0002__second"
+
+
+def test_allocate_makes_a_filesystem_safe_slug(tmp_path: Path):
+    root = tmp_path / "ds"
+    v = ws.allocate_version_dir(root, "weird/name:with*chars")
+    # No path separators / illegal chars leak into the version folder name.
+    assert "/" not in v.name and ":" not in v.name and "*" not in v.name
+    assert v.name.startswith("0001__")
+
+
+def test_list_versions_sorted_and_typed(tmp_path: Path):
+    root = tmp_path / "ds"
+    _make_version(root, "alpha", "/data/a")
+    _make_version(root, "beta", "/data/b")
+    versions = ws.list_versions(root)
+    assert [v.index for v in versions] == [1, 2]
+    assert versions[0].source_label == "alpha"
+    assert versions[1].raw_root == "/data/b"
+    assert all(v.status == "curating" for v in versions)
+
+
+def test_incomplete_version_without_inventory_is_skipped(tmp_path: Path):
+    root = tmp_path / "ds"
+    _make_version(root, "good", "/data/a")
+    # An allocated-but-never-finished scan dir (no inventory) is ignored.
+    bad = ws.allocate_version_dir(root, "aborted")
+    bad.mkdir(parents=True)
+    versions = ws.list_versions(root)
+    assert [v.version_id for v in versions] == ["0001__good"]
+
+
+def test_write_version_meta_merges(tmp_path: Path):
+    root = tmp_path / "ds"
+    vdir = _make_version(root, "lab", "/data/a")
+    ws.write_version_meta(vdir, source_label="lab", raw_root="/data/a", status="converted")
+    meta = ws.read_version_meta(vdir)
+    assert meta["status"] == "converted"
+    assert meta["source_label"] == "lab"
+
+
+def test_list_versions_empty_when_no_scans(tmp_path: Path):
+    assert ws.list_versions(tmp_path / "nope") == []


### PR DESCRIPTION
# BIDS Manager: project-first workspace, EEG/MEG metadata enrichment, recording viewers, and incremental conversion (v1.1.4 to v1.2.3)

## Summary

This PR brings `ANCPLabOldenburg/BIDS-Manager:main` from **v1.1.4 up to v1.2.3**.
It is purely additive: the source branch (`karellopez/BIDS-Manager:main`) is a
clean content superset of upstream's current `main` (merge base
`docs(readme): promote install guide`), so nothing existing is removed or
rewritten. Net change across the 14 commits: **128 files, about +18,875 / -1,005
lines**, of which a large share is new tests.

The work turns BIDS Manager from a one-shot "scan, convert, validate" tool into a
**project-first, resumable workspace** with **incremental (merge-aware)
conversion**, gives EEG/MEG the **rich BIDS metadata enrichment** the MRI side
already had, adds **interactive recording and volume viewers in the Editor**, and
makes the scanner robust to **non-image DICOM objects and unsupported
recordings**. All of it stays inside the original architecture: the BIDS schema
is the engine, the only Qt-coupled subtree is `gui/` (plus the `workers/` thread
bridge), and there is no `Pipeline` orchestrator and no `core/` package.

Every core feature was verified end to end on real MRI, EEG, and MEG data
(scan to convert to metadata to validate), not just unit-mocked.

## Highlights

1. Project-first workspace: create or open a BIDS dataset, curate inside it, and
   resume across sessions. Each scan of a source folder becomes its own
   versioned, undoable curation bundle.
2. Incremental, merge-aware conversion: adding a session or datatype to an
   already-converted subject merges in file by file, with an explicit
   `--on-existing {skip,update,replace,error}` policy and per-file backups.
3. EEG/MEG metadata enrichment: a native dataset-defaults-plus-per-recording
   override model fills reference, ground, filters, device, institution, event
   labels, demographics, and phenotype, applied as a post-write step at convert.
4. Editor recording viewer: click an EEG/MEG/iEEG recording to see a metadata
   card, then load an interactive, threaded pyqtgraph time-series viewer with an
   in-app PSD and a BIDS-native event overlay. NIfTI volume viewer and threaded,
   freeze-free TSV loading land alongside it.
5. Scanner robustness: non-image DICOM series (TENSOR maps, spectroscopy,
   PhoenixZIPReport) are detected and excluded instead of failing the converter;
   users can add their own classifier hints and exclusions; unreadable
   recordings become visible, explained rows.
6. A shared, Qt-free orchestration core means the GUI and the new `--project` CLI
   run the exact same engine and cannot drift.

## 1. Project-first workspace model

The unit of work is now a BIDS dataset, not a single inventory TSV.

- New Welcome (Home) tab with self-contained Create, Open, and Recent sections,
  fully themed with a dark/light refresh, and right-click remove or delete of a
  recent project (refuses to delete a folder that is not a BIDS dataset).
- Opening a project soft-locks the converter output to the dataset root, so
  subjects can never be scattered outside the project. With no project open the
  converter is reset and its raw input, BIDS output, and Scan controls are
  disabled with a reason; the Editor stays free since it doubles as a viewer.
- Each scan of a source folder becomes its own version under
  `<root>/.bidsmgr/project/scans/<NNNN>__<slug>/` with an isolated curation
  bundle, so a second scan never overwrites the first table. A header switcher
  changes versions and projects; reopening resumes the latest version and
  replays the edit overlay (cell edits, include toggles, and subject renames).
- Undo and redo of curation ride the project event log: only user edits are
  popped (never a structural event), a redo stack re-applies them, and a fresh
  edit clears the redo stack.
- New `bidsmgr-create` verb scaffolds (or read-only adopts) a dataset workspace,
  writing `dataset_description.json`, a `README`, and a `.bidsignore` that
  exempts the hidden `.bidsmgr/` working directory from the official validator.

Correctness fixes that came with this: `BIDSVersion` is now sourced from the
bundled schema (1.11.1) instead of a hardcoded value that had drifted out of
date across four sites; `GeneratedBy` is written idempotently so re-running
convert no longer accumulates duplicate stamps; and a metadata run with no
`--name` no longer clobbers an existing `dataset_description` `Name`.

## 2. Incremental, merge-aware conversion

Converting into an existing dataset is now safe and additive.

- A brand-new subject still commits via the atomic `os.rename` fast path. An
  existing subject is merged file by file: a staged file with no counterpart on
  disk is moved in (the add), and a colliding file is governed by an explicit
  policy.
- New `--on-existing {skip,update,replace,error}` flag (with `--overwrite` kept
  as an alias for `replace`): `skip` keeps existing data (the safe default),
  `update` overwrites only when content differs, `replace` backs up then
  overwrites, and `error` aborts the run so an accidental clash never merges
  silently. Replaced files are backed up per file under
  `<root>/.bidsmgr/backup/<sub>_<utcstamp>/` so an interrupted merge can be
  reconstructed.
- A new Qt-free `dataset_identity` module compares a scanned subject against the
  on-disk dataset (participants.tsv identity plus existing session dirs) and
  flags a probable same-subject, a confident same-subject (new session vs
  re-scan), or a different subject with a suggested free id. The flag is
  idempotent, so renaming a clashing subject and clicking Re-validate clears the
  stale warning.

Verified on real data: converting `sub-001 ses-pre` then `ses-post` into the same
dataset keeps both sessions and validates with zero errors.

## 3. EEG/MEG recording-metadata enrichment

EEG/MEG recordings gain the rich BIDS sidecar enrichment the MRI side already
had. The model is BIDS Manager native (dataset-wide defaults plus per-recording
overrides); no external format is imported or exported.

- New Qt-free `bidsmgr/recording_meta/` subpackage holds pure-data Pydantic
  models (`RecordingMetaSpec` = dataset defaults plus task protocols, event maps,
  per-row overrides, and phenotype links), with channel types validated against
  the live `bidsschematools` rather than a frozen enum.
- New `fixups/eeg_sidecar.enrich_recording_sidecars` runs after the BIDS write
  (Phase 2): it fills the datatype sidecar (EEG reference/ground scoped to eeg,
  iEEG reference to ieeg, skipped for meg), retypes aux channels in
  channels.tsv, maps event codes to labels in events.tsv and events.json, and
  fills the task sidecar.
- New `fixups/companion` copies curated companion files (events, beh, stim,
  physio, channels, electrodes) into the BIDS tree under the recording prefix.
- New `metadata/demographics` (sex and handedness normalisation, participants
  spreadsheet reader) and `metadata/phenotype` (`phenotype/<measure>.tsv` plus
  `.json`); both merge an optional sibling `.json` codebook so real
  Description, Levels, Units, and MeasurementToolMetadata flow through, and
  arbitrary participants columns (group, IQ, and so on) carry into
  participants.tsv and participants.json.
- A new fully scrollable Dataset-metadata dialog groups fields by where they are
  written: a modality-agnostic region (institution, department, events,
  phenotype, participants spreadsheet) and a modality-specific region (device,
  reference, montage, a MEG-only acquisition group that exposes only the fields
  mne-bids cannot derive). Every field carries an on-hover explanation pulled
  live from the BIDS schema. A per-row Properties panel mirrors the same split.
- Manufacturer is treated as a read-only suggestion (a new
  `manufacturer_suggestion` column), inferred from the header for EEG and from
  the file format for MEG, so the value mne-bids already writes for MEG is never
  overwritten. A best-match montage suggestion is surfaced the same way.
- Optional Force EDF: re-encode EEG/iEEG to EDF on write, which harmonises a
  study to one BIDS-native format and makes a non-BIDS but mne-readable source
  (GDF, EGI) convertible. MEG and NIRS ignore it.

The unified inventory TSV grew from **51 to 57 columns** across this work (added
`Handedness`, `companion_files`, `eeg_reference`, `eeg_ground`,
`montage_suggestion`, `manufacturer_suggestion`). `bidsmgr-convert` dropped
`--line-freq` / `--montage` (resolved from the inventory cell or the dataset
default) and added `--recording-meta PATH`; `bidsmgr-metadata` added
`--participants` and `--phenotype`.

## 4. Editor: recording viewer, volume viewer, and threaded TSV

The Editor center pane now routes by file type to real, interactive viewers.

- EEG/MEG/iEEG recordings open a metadata card first, then a "Load signal"
  button reveals an interactive pyqtgraph time-series viewer (a restyled,
  annotation-free port of the MEEGqc `qc_viewer`): channel-type filter with CTF
  axial-gradiometer handling, individual-channel picker, navigation and channel
  scrollbar, raw vs normalize rendering, HP/LP/notch filtering, and resample.
- An interactive in-app PSD (two tabs: per-channel overlaid and per-type average
  with a standard-deviation band) renders with pyqtgraph and a dB toggle, with
  no matplotlib dependency.
- A BIDS-native event overlay reads the sibling events.tsv plus stim-channel
  find_events and jumps the view to the first event, since triggers often start
  well into a recording.
- All reads, resample, and PSD run on QThread workers, so the GUI never blocks;
  the pyqtgraph view is built lazily only on signal load.
- TSV loading is now always threaded with a spinner page and is freeze-free at
  any size: `_read_tsv` parses with pandas' C engine (which releases the GIL)
  and is bounded, and a new lazy `QAbstractTableModel` renders only visible
  cells. A 74 MB, 2-million-row file reads in roughly 0.08 s; a wide
  8000 x 120 table no longer freezes.

Two validator bugs were fixed in passing: the layer-1 basename check was a silent
no-op (it read a non-existent attribute), and `validate_basename` was missing
`.tsv.gz`, so `*_physio.tsv.gz` was falsely flagged. Strict validation now
genuinely adds findings beyond the non-strict pass.

## 5. Converter per-row PSD and on-by-default settings (v1.2.3)

The final commit adds three GUI touches.

- A per-row "Compute PSD" button in the Converter inspection-table Properties
  panel, directly below the line-frequency field, for EEG/MEG/iEEG/NIRS rows. It
  mirrors the Editor viewer: the recording is read on a background thread, a busy
  spinner shows while it runs, and the same interactive PSD dialog opens on
  completion. It resolves the row's source recording against the project raw
  root and disables itself when the file cannot be located.
- The common-case scan and post-convert options are now on by default, so a
  fresh install converts a complete, validated dataset without opening Settings:
  probe-convert is on, residual volumes are skipped, and the whole post-convert
  chain (metadata with TODO placeholders, validation, strict, and an HTML
  report) is checked.
- The vestigial "Default dataset slug" setting was removed. In the project-first
  model the dataset name always comes from the project folder name, so that GUI
  field had no reachable reader. The CLI slug machinery (`bidsmgr-scan
  --dataset`, the default-slug helper, and convert's grouping of distinct
  dataset values into sibling BIDS roots) is unchanged and still tested.

## 6. Scanner robustness and classifier

- Non-image DICOM detection: a DERIVED object with no Image Pixel module
  (Siemens TENSOR maps, PhoenixZIPReport, spectroscopy frames) cannot be
  converted by dcm2niix and used to fail with rc=2. The scanner now stamps pixel
  presence per file, and any series whose files all lack pixel data is excluded
  with a visible "non-image series" note and a teal row state in the GUI, rather
  than silently failing the converter. Physio rows, which also lack pixel data
  but are convertible, are exempt.
- User-configurable classifier hints and exclusions: a new Qt-free
  `classifier/user_rules` module lets users adapt the MRI classifier to their
  lab's sequence names (substring or regex, default or force priority) and skip
  series they never convert, from a new Settings "Scan rules" tab or the CLI
  `bidsmgr-scan --rules-file`. Hints are schema-revalidated so a bad pair can
  never produce a broken basename. Rules are MRI/DICOM only; EEG/MEG are
  classified by mne channel types.
- Unsupported and non-native recordings: a recognised EEG/MEG extension mne
  cannot read (for example Neuroscan `.cnt`) becomes a visible excluded row with
  an explanation instead of a silent drop; a readable but non-BIDS-native format
  stays included with a pointer to Force EDF.
- Mixed-study awareness: the MRI scanner flags rows whose source pooled multiple
  distinct DICOM StudyDescriptions, routed through the existing warnings system.

Physio also got two real-data fixes: the vendored `bidsphysio`
`plug_missing_data` was rewritten from an O(n^2) loop (which hung for minutes on
a real 22-million-sample ECG) to a single vectorised pass, and multi-rate physio
output detection was corrected.

## 7. GUI and converter ergonomics

- Skip dcm2niix residual outputs by default (the derived single-volume
  duplicates split off a series), with `--keep-residuals` and a Settings toggle
  to keep them; fmap, complex, and DWI multi-output are untouched.
- Stop for Scan and Run: each button toggles to "Stop" while running and the
  other is locked out, with cooperative cancellation that halts at the next safe
  boundary and commits nothing half-written.
- Collapsible and detachable panels throughout the Converter and Editor via a
  reusable wrapper; detached panels are real top-level windows with
  minimize/maximize on Linux and Windows.
- A Manage-columns dialog with a plain-language description per column;
  spreadsheet-style resizable, drag-to-reorder, double-click-to-autofit columns
  with the order persisted.
- A System tab reporting CPU threads/cores and RAM, with the parallel-worker
  spinboxes capped at the detected thread count; the post-convert chain laid out
  as an indented hierarchy with a Restore-defaults button.
- Theme-driven polish: painted-pill status chips that stay rounded at any font
  scale, rounded combo popups and context menus, a header project switcher, and
  a multi-resolution app icon for Linux and Windows title bars.

## 8. CLI surface

```
bidsmgr-create    <dataset_dir>                  [--name NAME] [--description ...]
bidsmgr-project   <dataset_dir>                  [--list]
bidsmgr-scan      <raw_root> [<inv.tsv>]         [--project DS] [--dataset NAME] [-j N] [--probe-convert] [--rules-file JSON]
bidsmgr-rebuild   <inv.tsv>                      [--from {entities,columns}] [--dry-run]
bidsmgr-convert   [<inv.tsv>] [<bids_parent>]    [--project DS] [--version ID] [--dataset NAME] [-j N] [--on-existing {skip,update,replace,error}] [--overwrite] [--force-edf] [--keep-residuals] [--recording-meta PATH] [--raw-root PATH] [--dry-run]
bidsmgr-metadata  [<bids_parent>]                [--project DS] [--version ID] [--inventory-tsv ...] [--participants PATH] [--phenotype PATH ...] [--fill-todos] [--name ...]
bidsmgr-validate  <bids_parent>                  [--strict] [--strict-warn] [--html]
```

Plus the GUI entry `bidsmgr [--theme dark|light] [--project PATH]`, where `PATH`
is now a dataset directory (project-first). The `--project` flag is additive:
positionals become optional only when it is used, and all prior usage is
unchanged.

## 9. Architecture and design guards

The work preserves the project's architectural bets:

- The BIDS schema is the engine. The `schema/` keystone imports nothing and is
  imported by everything.
- `gui/` is the only Qt-coupled subtree; `workers/` is the only other Qt importer
  (the QThread bridge). The new `recording_meta/`, `project/orchestration.py`,
  `classifier/user_rules.py`, `inventory/dataset_identity.py`, and the fixups are
  all Qt-free.
- No `Pipeline` orchestrator and no `core/` package. Project orchestration lives
  in a single Qt-free module (`project/orchestration.py`) that both the GUI and
  the `--project` CLI call, so they cannot drift.
- Vendored code stays under `vendor/` with its original MIT headers.

## 10. Testing and verification

The test suite roughly doubled. Unit test files went from 29 to 50 and GUI test
files from 27 to 35; the current totals are about 714 unit tests plus the GUI
suites, with about 54 real-data tests gated on environment variables. New
coverage includes non-image detection, cancellation, residual outputs, the user
classifier rules, the recording-metadata models and scaffold, the EEG sidecar
and companion fixups, demographics and phenotype, the project orchestration,
workspace versioning, merge-aware commit, dataset identity, the `--project` CLI,
the recording reader and viewer workers, and the threaded TSV model.

Every core feature was verified on real MRI, EEG, and MEG datasets through the
full scan to convert to metadata to validate pipeline, including incremental
re-conversion and the recording viewers (MEG `.fif`, EEG `.edf`, BrainVision
`.vhdr`).

## 11. Compatibility and migration notes

- The unified inventory TSV is now 57 columns (was 51). Older TSVs still convert:
  `bidsmgr-convert` rebuilds entities in memory before reading rows.
- `bidsmgr-convert` no longer accepts `--line-freq` / `--montage` (now resolved
  per row from the inventory cell or the recording-metadata dataset default) and
  gained `--recording-meta`. `bidsmgr-scan` keeps `--line-freq` / `--montage` as
  TSV seeds.
- `--on-existing` defaults to `skip`, so existing data is never lost by default;
  `--overwrite` is preserved as an alias for `replace`.
- The hidden `.bidsmgr/` working directory is exempted from the official
  bids-validator via a written `.bidsignore`, so converted datasets validate
  cleanly.
- `setuptools<81` is no longer pinned (bidsphysio is vendored); `psutil` was
  added for the System tab.

## Commit-by-commit reference (oldest first)

1. `7021420` feat: detect non-image (no-pixel-data) DICOM series plus physio fixes
2. `639fc5f` Merge pull request #243 (non-image detection)
3. `a2a6c04` feat(gui+cli): skip-residuals, stop/cancel, collapsible and detachable panels, column manager, System tab
4. `43aef78` feat(scan): user-configurable classifier hints and series exclusions (GUI and CLI)
5. `da21d08` feat(eeg/meg): dataset and per-recording metadata enrichment
6. `73648a9` feat(metadata): refine recording-metadata UX and BIDS correctness
7. `d2380b3` fix(cli,metadata): schema-sourced BIDSVersion, idempotent stamps, Name preservation; add scaffold and create verb; flag mixed-study scans
8. `2663a09` feat(gui,project): project-first workspace with resumable, versioned curation
9. `7d0039d` feat(convert): merge-aware subject commit for incremental conversion
10. `6b1e546` feat: v1.2.0 incremental-conversion safety, live revalidation, project isolation, live file trees
11. `e5a789c` feat(eeg,metadata): unsupported-format scan notice, force-EDF, phenotype and participants codebooks
12. `9828ec2` feat: project-first CLI (--project), editor undo/redo, project switcher, scanner and GUI fixes
13. `224e556` feat(editor): MEG/EEG time-series viewer, threaded TSV loading, validator fixes, GUI polish (v1.2.2)
14. `1eb230e` feat(gui): per-row Compute-PSD button, on-by-default scan/post-convert settings, remove dead dataset-slug field (v1.2.3)
