### PR TITLE
delegate Editor validation to the standalone bidsval engine (v1.2.3 to v1.2.4)

### DIFF
--- a/bidsmgr/cli/validate.py
+++ b/bidsmgr/cli/validate.py
@@ -9,12 +9,13 @@ it up. Exit code reflects the dataset-wide severity:
 * ``0`` — only ``ok``/``warn`` verdicts (or ``warn`` with ``--strict-warn``).
 * ``1`` — at least one ``err``, OR any ``warn`` when ``--strict-warn``.
 
-The ``--strict`` flag turns on Layer 2 (``bidsschematools.validator``)
-in addition to Layer 1 (schema-driven, always on).
+Validation is delegated to the standalone ``bidsval`` engine via
+``bidsmgr.editor.validator.validate``. The ``--strict`` flag enables
+"deep checks" (read NIfTI headers and file contents; slower) - it maps
+to bidsval's read-headers mode.
 
 Architectural rule: orchestration is straight-line code here; the
-validator itself (``bidsmgr.editor.validator.validate``) is a single
-function returning Pydantic data.
+validator itself is a single function returning Pydantic data.
 """
 
 from __future__ import annotations
@@ -42,6 +43,9 @@ def run_validate_cli(
     dataset: Optional[str] = None,
     strict: bool = False,
     strict_warn: bool = False,
+    schema: Optional[str] = None,
+    max_rows: int = 1000,
+    flag_todos: bool = True,
     write_report: bool = True,
     html_report: bool = False,
 ) -> int:
@@ -64,7 +68,10 @@ def run_validate_cli(
     overall_failed = 0
     for bids_root in bids_roots:
         try:
-            report = validate(bids_root, strict=strict)
+            report = validate(
+                bids_root, strict=strict, schema=schema, max_rows=max_rows,
+                flag_todos=flag_todos,
+            )
         except Exception:
             log.exception("validator raised on %s", bids_root)
             overall_failed += 1
@@ -170,7 +177,7 @@ def _print_summary(bids_root: Path, report: ValidationReport) -> None:
             print(f"    ... and {len(report.dataset_issues) - 20} more")
 
     if report.folder_issues:
-        print(f"  folder-level issues:")
+        print("  folder-level issues:")
         for folder, issues in list(report.folder_issues.items())[:20]:
             for issue in issues[:5]:
                 print(f"    [{issue.severity.value}] {folder}: {issue.message}")
@@ -197,9 +204,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         prog="bidsmgr-validate",
         description=(
-            "Schema-driven validation for a BIDS dataset. Runs Layer 1 "
-            "(bidsmgr.schema-based) by default; add --strict to also "
-            "run Layer 2 (bidsschematools structural validation)."
+            "Schema-driven BIDS validation (delegated to the bidsval engine). "
+            "Runs the fast structural pass by default; add --strict for deep "
+            "checks that also read NIfTI headers and file contents."
         ),
     )
     parser.add_argument(
@@ -213,11 +220,36 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--strict", action="store_true",
         help=(
-            "Also run Layer 2: bidsschematools structural validation. "
-            "Adds path-shape checks against the BIDS spec and is slower "
-            "on large trees."
+            "Deep checks: read NIfTI headers and file contents in addition "
+            "to the structural and metadata checks. More thorough (catches "
+            "unreadable / malformed files), slower on large trees."
         ),
     )
+    parser.add_argument(
+        "--schema", default=None,
+        help=(
+            "BIDS schema version to validate against (e.g. 1.11.1). "
+            "Default: bidsval's bundled schema. bidsval ships several "
+            "versions, so an older dataset can be checked against its own."
+        ),
+    )
+    parser.add_argument(
+        "--max-rows", type=int, default=1000, dest="max_rows",
+        help=(
+            "Maximum number of rows scanned per TSV during column / value "
+            "validation (default 1000). Raise to scan more of long tables."
+        ),
+    )
+    parser.add_argument(
+        "--no-todo-warnings", dest="flag_todos", action="store_false",
+        help=(
+            "Do not flag literal 'TODO' placeholder values as warnings. This "
+            "BIDS Manager convention is on by default (the metadata engine "
+            "writes TODO into missing recommended fields); turn it off for "
+            "exact parity with the standalone bidsval engine."
+        ),
+    )
+    parser.set_defaults(flag_todos=True)
     parser.add_argument(
         "--strict-warn", action="store_true",
         help=(
@@ -262,6 +294,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         dataset=args.dataset,
         strict=args.strict,
         strict_warn=args.strict_warn,
+        schema=args.schema,
+        max_rows=args.max_rows,
+        flag_todos=args.flag_todos,
         write_report=args.write_report,
         html_report=args.html_report,
     )

--- a/bidsmgr/editor/_bidsval_adapter.py
+++ b/bidsmgr/editor/_bidsval_adapter.py
@@ -80,6 +80,7 @@ def to_bm_issue(bv_issue) -> Issue:
         message=_compose_message(bv_issue),
         field=field,
         line=getattr(bv_issue, "line", None),
+        lines=list(getattr(bv_issue, "lines", []) or []),
         fix_label=fix_label,
         fix_action=fix_action,
     )

--- a/bidsmgr/editor/_bidsval_adapter.py
+++ b/bidsmgr/editor/_bidsval_adapter.py
@@ -1,0 +1,233 @@
+"""Map :mod:`bidsval` results into BIDS Manager's ``editor/types`` shapes.
+
+The GUI, workers, HTML report, and CLI all bind to
+:class:`bidsmgr.editor.types.ValidationReport` / ``FileVerdict`` / ``Issue``.
+bidsval returns near-isomorphic pydantic models; this module is the single
+translation layer between the two, plus the BIDS Manager-native supplements
+(``sidecar_fields`` + TODO findings from :mod:`bidsmgr.editor.bidsmgr_checks`).
+
+Severity mapping: bidsval ``error`` / ``warning`` / ``ignore`` ->
+``ERR`` / ``WARN`` / ``OK`` (a clean file, severity ``None``, also maps to ``OK``).
+
+Finding attribution follows bidsval (and the BIDS spec): metadata findings for a
+data file (for example a missing required ``RepetitionTime``) attach to the data
+file (``*_bold.nii.gz``), not to its ``.json`` sidecar. The sidecar form still
+shows which fields are missing because :func:`to_bm_file_verdict` populates
+``sidecar_fields`` on the ``.json`` verdict from the schema.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bidsval import Severity as BvSeverity
+
+from . import bidsmgr_checks as bm
+from .types import (
+    FieldLevel,
+    FileVerdict,
+    Issue,
+    Severity,
+    SidecarField,
+    ValidationReport,
+    rollup_severity,
+)
+
+# bidsval severity -> BIDS Manager severity.
+_SEVERITY: dict[BvSeverity, Severity] = {
+    BvSeverity.ERROR: Severity.ERR,
+    BvSeverity.WARNING: Severity.WARN,
+    BvSeverity.IGNORE: Severity.OK,
+}
+
+
+def to_bm_severity(severity) -> Severity:
+    """Map a bidsval severity (or ``None`` for a clean file) to a BM severity."""
+    if severity is None:
+        return Severity.OK
+    return _SEVERITY.get(severity, Severity.WARN)
+
+
+def _compose_message(bv_issue) -> str:
+    """Build the BM message: bidsval message + its actionable suggestion.
+
+    bidsval splits the *what* (``message``) from the *how to fix it*
+    (``suggestion``); BIDS Manager's ``Issue`` has a single message field, so we
+    join them. Kept plain text (no HTML) so both the rich-text validation pane
+    and the HTML report - which escapes the message - render it correctly.
+    """
+    message = bv_issue.message or bv_issue.code or "validation finding"
+    if bv_issue.suggestion:
+        message = f"{message}  ·  {bv_issue.suggestion}"
+    return message
+
+
+def to_bm_issue(bv_issue) -> Issue:
+    """Translate one bidsval :class:`Issue` into a BM :class:`Issue`.
+
+    The JSON key / column / entity the finding refers to (``sub_code``, or the
+    fix's target field) becomes ``field`` so the Editor's fix button can jump to
+    that row in the sidecar form. The button is only offered when there is a
+    field to jump to.
+    """
+    fix = bv_issue.fix
+    field = (fix.field if (fix and fix.field) else bv_issue.sub_code) or None
+    fix_label = (fix.label or "Fix") if (fix and field) else None
+    fix_action = fix.action if fix else None
+    return Issue(
+        severity=to_bm_severity(bv_issue.severity),
+        rule_id=bv_issue.code,
+        message=_compose_message(bv_issue),
+        field=field,
+        line=getattr(bv_issue, "line", None),
+        fix_label=fix_label,
+        fix_action=fix_action,
+    )
+
+
+def to_bm_file_verdict(bv_verdict, bids_root: Path, *, flag_todos: bool = True) -> FileVerdict:
+    """Translate a bidsval :class:`FileVerdict`, adding the BM-native supplements.
+
+    For ``.json`` files this populates the schema-aware ``sidecar_fields`` the
+    Editor's sidecar form renders and (when ``flag_todos``) appends
+    TODO-placeholder findings. Severity is rolled up from the final issue set so
+    the supplements count. ``flag_todos=False`` gives exact bidsval parity.
+    """
+    rel = Path(bv_verdict.path)
+    abs_path = (Path(bids_root) / rel)
+    datatype, suffix = bm.infer_datatype_suffix(abs_path, Path(bids_root))
+
+    issues = [to_bm_issue(i) for i in bv_verdict.issues]
+    sidecar_fields = []
+    if rel.name.lower().endswith(".json"):
+        if flag_todos:
+            issues.extend(bm.todo_issues_for(abs_path))
+        sidecar_fields = bm.sidecar_fields_for(abs_path, datatype, suffix)
+
+    severity = rollup_severity([i.severity for i in issues])
+    return FileVerdict(
+        path=rel,
+        severity=severity,
+        datatype=datatype,
+        suffix=suffix,
+        issues=issues,
+        sidecar_fields=sidecar_fields,
+    )
+
+
+def to_bm_report(
+    bv_report,
+    bids_root: Path,
+    *,
+    bidsmgr_version: str,
+    generated_at: str,
+    flag_todos: bool = True,
+) -> ValidationReport:
+    """Translate a whole bidsval :class:`ValidationReport`.
+
+    ``folder_issues`` stays empty (bidsval has no folder-scoped findings; the
+    validation pane handles an empty dict). ``counts`` / ``severity`` are rolled
+    up with the same per-file + dataset-issue accounting the GUI's own
+    ``_recompute_report_summary`` uses, so the chips and summary line are stable.
+    """
+    files = [
+        to_bm_file_verdict(fv, bids_root, flag_todos=flag_todos)
+        for fv in bv_report.files
+    ]
+    # Surface each data file's sidecar metadata findings on its editable .json
+    # sibling too (so they show where the user fixes them, and the fix button
+    # jumps to the field). Mirrors are flagged so they are not double-counted.
+    _mirror_sidecar_findings(files)
+    # Make sure every flagged field has a sidecar form row, so the Editor's
+    # highlight / fix can locate it. bidsval flags a broader set of recommended
+    # fields than the schema-derived form rows, so without this only fields that
+    # already had a row (incl. present TODO fields) could be highlighted.
+    _ensure_field_rows(files)
+    dataset_issues = [to_bm_issue(i) for i in bv_report.dataset_issues.issues]
+
+    report = ValidationReport(
+        bids_root=Path(bids_root),
+        bidsmgr_version=bidsmgr_version,
+        bids_version=bv_report.bids_version or "",
+        generated_at=generated_at,
+        files=files,
+        dataset_issues=dataset_issues,
+        folder_issues={},
+    )
+
+    # Counts are PER-FINDING and exclude mirrors (the canonical copy is counted
+    # once), so the GUI chips agree with bidsval's numbers. "ok" is the count of
+    # clean files (a friendly "valid files" tally).
+    counted: list[Issue] = [i for i in dataset_issues if not i.mirrored]
+    for f in files:
+        counted.extend(i for i in f.issues if not i.mirrored)
+    report.severity = rollup_severity([i.severity for i in counted])
+    report.counts = {
+        "ok": sum(1 for f in files if f.severity is Severity.OK),
+        "warn": sum(1 for i in counted if i.severity is Severity.WARN),
+        "err": sum(1 for i in counted if i.severity is Severity.ERR),
+    }
+    return report
+
+
+def _mirror_sidecar_findings(files: list[FileVerdict]) -> None:
+    """Append a mirrored copy of each data file's field-bearing findings onto
+    its sibling ``.json`` verdict (in place).
+
+    A sidecar metadata finding canonically attaches to the data file
+    (``*_bold.nii.gz``); this also surfaces it on the editable ``*_bold.json``
+    so it shows where the user edits and the fix button can jump to the field.
+    Mirrors carry ``mirrored=True`` so they render but are not counted twice.
+    """
+    index = {str(f.path): f for f in files}
+    for f in files:
+        sib = bm.sibling_json(f.path)
+        if sib is None:
+            continue
+        target = index.get(str(sib))
+        if target is None:
+            continue
+        mirrors = [
+            issue.model_copy(update={"mirrored": True})
+            for issue in f.issues
+            if issue.field and not issue.mirrored
+        ]
+        if mirrors:
+            target.issues.extend(mirrors)
+            target.severity = rollup_severity([i.severity for i in target.issues])
+
+
+_LEVEL_RANK = {Severity.ERR: 2, Severity.WARN: 1, Severity.OK: 0}
+
+
+def _ensure_field_rows(files: list[FileVerdict]) -> None:
+    """For every ``.json`` verdict, add a sidecar form row for each field that a
+    finding refers to but that has no row yet (in place).
+
+    The schema-derived rows (``sidecar_fields``) cover only part of what bidsval
+    flags - it warns about a broader set of recommended fields. Without a row a
+    finding's field cannot be scrolled to / highlighted / focused, which is why
+    only already-present (e.g. TODO) fields could be highlighted before. Added
+    rows are missing fields, leveled by the finding's worst severity.
+    """
+    for f in files:
+        if not str(f.path).lower().endswith(".json"):
+            continue
+        existing = {sf.name for sf in f.sidecar_fields}
+        worst: dict[str, Severity] = {}
+        for issue in f.issues:
+            if not issue.field or issue.field in existing:
+                continue
+            if _LEVEL_RANK.get(issue.severity, 0) > _LEVEL_RANK.get(
+                worst.get(issue.field, Severity.OK), 0
+            ):
+                worst[issue.field] = issue.severity
+        for name, sev in worst.items():
+            level = FieldLevel.REQUIRED if sev is Severity.ERR else FieldLevel.RECOMMENDED
+            f.sidecar_fields.append(SidecarField(
+                level=level, name=name, value=None, present=False,
+                value_kind="missing",
+            ))
+
+
+__all__ = ["to_bm_severity", "to_bm_issue", "to_bm_file_verdict", "to_bm_report"]

--- a/bidsmgr/editor/bidsmgr_checks.py
+++ b/bidsmgr/editor/bidsmgr_checks.py
@@ -1,0 +1,221 @@
+"""BIDS Manager-native validation supplements (Qt-free).
+
+Validation findings come from the standalone :mod:`bidsval` package. These are
+the two things bidsval does not produce that BIDS Manager's Editor still needs:
+
+* :func:`sidecar_fields_for` - the schema-aware *form* data the sidecar editor
+  renders (one row per schema-defined field at a ``(datatype, suffix)`` plus any
+  extra keys the file carries). This is form scaffolding, not a finding; it
+  drives the Editor's sidecar form and the HTML report's schema-audit table.
+* :func:`todo_issues_for` - TODO-placeholder findings. A BIDS Manager
+  convention: the metadata engine writes the literal string ``"TODO"`` into
+  missing recommended fields, and the Editor flags those so the user fills them
+  in. bidsval (correctly) does not know about this convention.
+
+Both are derived straight from :mod:`bidsmgr.schema`, the same keystone the rest
+of the package reads from. No Qt here (architectural rule 2).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .. import schema as schema_mod
+from .types import FieldLevel, Issue, Severity, SidecarField
+
+# Recognised BIDS datatype directory names, used to infer a file's datatype from
+# its path the same way the old in-house validator did.
+_BIDS_DATATYPE_NAMES: tuple[str, ...] = (
+    "anat", "func", "dwi", "fmap", "perf",
+    "meg", "eeg", "ieeg", "beh", "pet", "micr", "nirs",
+)
+
+# Multi-part extensions stripped (longest first) to recover the BIDS suffix.
+_KNOWN_EXTS: tuple[str, ...] = (
+    ".nii.gz", ".tsv.gz", ".nii", ".json", ".tsv", ".bval", ".bvec",
+    ".edf", ".bdf", ".set", ".vhdr", ".fif", ".fif.gz",
+)
+
+
+# Data-file extensions whose metadata lives in a sibling ``.json`` sidecar.
+# Longest-first so multi-part extensions strip correctly. Used to find the
+# editable sidecar for a finding attached to a data file.
+_DATA_EXTS: tuple[str, ...] = (
+    ".nii.gz", ".nii", ".fif.gz", ".fif", ".edf", ".bdf", ".gdf", ".set",
+    ".vhdr", ".cnt", ".con", ".sqd", ".kdf", ".ds", ".mff", ".mef", ".nwb",
+)
+
+
+def _canonical(name: str) -> str:
+    """``EchoTime__fmap`` -> ``EchoTime`` (strip the schema's context suffix)."""
+    return name.split("__", 1)[0]
+
+
+def sibling_json(path: Path) -> Optional[Path]:
+    """The ``.json`` sidecar path for a data file (``*_bold.nii.gz`` ->
+    ``*_bold.json``), or ``None`` if ``path`` is not a recognised data file.
+
+    Purely a name transform - the caller checks whether the sidecar exists.
+    """
+    name = path.name
+    lower = name.lower()
+    for ext in _DATA_EXTS:
+        if lower.endswith(ext):
+            return path.with_name(name[: -len(ext)] + ".json")
+    return None
+
+
+def value_kind(value: object) -> str:
+    """Classify a parsed JSON value for the sidecar form's value column."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if value == "TODO":
+        return "todo"
+    return "string"
+
+
+def infer_datatype_suffix(
+    path: Path, bids_root: Path,
+) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort ``(datatype, suffix)`` for a file from its path + name.
+
+    Datatype is the first recognised datatype directory on the path; suffix is
+    the last underscore-separated token of the basename with no ``-`` (so it is
+    not an entity). Mirrors the old in-house validator so downstream consumers
+    (HTML report typed annotation, sidecar form) see the same values.
+    """
+    try:
+        rel_parts = path.relative_to(bids_root).parts
+    except ValueError:
+        rel_parts = path.parts
+
+    datatype: Optional[str] = None
+    for part in rel_parts:
+        if part in _BIDS_DATATYPE_NAMES:
+            datatype = part
+            break
+
+    stem = path.name
+    for ext in _KNOWN_EXTS:
+        if stem.endswith(ext):
+            stem = stem[: -len(ext)]
+            break
+
+    suffix: Optional[str] = None
+    for tok in reversed(stem.split("_")):
+        if tok and "-" not in tok:
+            suffix = tok
+            break
+    return datatype, suffix
+
+
+def _load_json_object(fp: Path) -> Optional[dict]:
+    """Parse ``fp`` as JSON, returning the object or ``None`` (unreadable / not
+    an object). Errors are bidsval's job to report; here we just need the data."""
+    try:
+        data = json.loads(Path(fp).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def sidecar_fields_for(
+    fp: Path, datatype: Optional[str], suffix: Optional[str],
+) -> list[SidecarField]:
+    """Build the schema-aware sidecar form rows for a JSON file.
+
+    Returns one :class:`SidecarField` per schema-defined field at
+    ``(datatype, suffix)`` (required + recommended + optional + deprecated),
+    each flagged present/missing against the file's actual contents, plus any
+    extra keys the file carries (as OPTIONAL). Returns ``[]`` for non-JSON
+    files or untyped sidecars (the form falls back to a plain on-disk read).
+    """
+    if not str(fp).lower().endswith(".json"):
+        return []
+    if not (datatype and suffix):
+        return []
+    data = _load_json_object(fp)
+    if data is None:
+        return []
+
+    seen: set[str] = set()
+    fields: list[SidecarField] = []
+
+    def _add_level(level: FieldLevel, getter) -> None:
+        try:
+            schema_fields = getter(datatype, suffix)
+        except (KeyError, ValueError, AttributeError):
+            schema_fields = []
+        for fi in schema_fields or []:
+            name = _canonical(fi.name)
+            if name in seen:
+                continue
+            seen.add(name)
+            present = name in data
+            value = data.get(name) if present else None
+            fields.append(SidecarField(
+                level=level, name=name, value=value, present=present,
+                value_kind=value_kind(value) if present else "missing",
+                description=getattr(fi, "description", None),
+            ))
+
+    _add_level(FieldLevel.REQUIRED, schema_mod.required_sidecar_fields)
+    _add_level(FieldLevel.RECOMMENDED, schema_mod.recommended_sidecar_fields)
+    _add_level(FieldLevel.OPTIONAL, schema_mod.optional_sidecar_fields)
+    _add_level(FieldLevel.DEPRECATED, schema_mod.deprecated_sidecar_fields)
+
+    # Keys present in the file but absent from every schema list -> OPTIONAL.
+    for k, v in data.items():
+        if k in seen:
+            continue
+        seen.add(k)
+        fields.append(SidecarField(
+            level=FieldLevel.OPTIONAL, name=k, value=v, present=True,
+            value_kind=value_kind(v),
+        ))
+    return fields
+
+
+def todo_issues_for(fp: Path) -> list[Issue]:
+    """Flag every field whose value is the literal placeholder ``"TODO"``.
+
+    Works on any JSON object (typed sidecar or top-level file such as
+    ``dataset_description.json``). The fix carries the field name so the
+    Editor's fix button jumps straight to that row in the sidecar form.
+    """
+    if not str(fp).lower().endswith(".json"):
+        return []
+    data = _load_json_object(fp)
+    if data is None:
+        return []
+    out: list[Issue] = []
+    for key, value in data.items():
+        if value == "TODO":
+            out.append(Issue(
+                severity=Severity.WARN,
+                rule_id="bidsmgr.todo_placeholder",
+                message=f"field {key!r} contains a TODO placeholder",
+                field=key,
+                fix_label="Set a real value",
+                fix_action="set_field",
+            ))
+    return out
+
+
+__all__ = [
+    "value_kind",
+    "infer_datatype_suffix",
+    "sidecar_fields_for",
+    "todo_issues_for",
+    "sibling_json",
+]

--- a/bidsmgr/editor/types.py
+++ b/bidsmgr/editor/types.py
@@ -65,6 +65,7 @@ class Issue(BaseModel):
     message: str
     field: Optional[str] = None  # JSON key / TSV column when applicable (or entity)
     line: Optional[int] = None   # 1-based row (incl. header) for tabular findings
+    lines: list[int] = Field(default_factory=list)  # all rows a TSV column finding spans
     fix_label: Optional[str] = None
     fix_action: Optional[str] = None
     # A "mirror" of a finding that canonically belongs to a sibling data file

--- a/bidsmgr/editor/types.py
+++ b/bidsmgr/editor/types.py
@@ -63,9 +63,15 @@ class Issue(BaseModel):
     severity: Severity
     rule_id: str
     message: str
-    field: Optional[str] = None  # JSON key when applicable (or BIDS entity)
+    field: Optional[str] = None  # JSON key / TSV column when applicable (or entity)
+    line: Optional[int] = None   # 1-based row (incl. header) for tabular findings
     fix_label: Optional[str] = None
     fix_action: Optional[str] = None
+    # A "mirror" of a finding that canonically belongs to a sibling data file
+    # (a sidecar metadata finding is attached to e.g. ``*_bold.nii.gz`` but
+    # surfaced again on its editable ``*_bold.json`` so it shows where the user
+    # fixes it). Mirrors are shown but NOT counted (the canonical copy is).
+    mirrored: bool = False
 
 
 class SidecarField(BaseModel):

--- a/bidsmgr/editor/validator.py
+++ b/bidsmgr/editor/validator.py
@@ -1,83 +1,59 @@
-"""Schema-driven BIDS validator.
+"""Schema-driven BIDS validation, delegated to the standalone ``bidsval`` engine.
 
-Two layers, both producing the same :class:`Issue` shape:
+BIDS Manager used to carry its own two-layer validator (an in-house schema audit
+plus a ``bidsschematools.validator`` pass behind ``--strict``). Validation is now
+delegated to :mod:`bidsval` - the schema-driven, pydantic-typed, false-positive-
+verified BIDS validator - and this module is a thin adapter that:
 
-* **Layer 1 — schema-driven** (always on, no external deps beyond
-  ``bidsmgr.schema``): per-file sidecar audit, TODO-placeholder
-  detection, IntendedFor URI resolution, basename / entity validation,
-  and dataset-level layout sanity.
-* **Layer 2 — bidsschematools structural** (``--strict`` flag): wraps
-  ``bidsschematools.validator.validate_bids`` and surfaces unrecognised
-  paths and missing mandatory schema rules.
+* runs bidsval and maps its results into the GUI's
+  :class:`bidsmgr.editor.types` shapes (see :mod:`bidsmgr.editor._bidsval_adapter`);
+* adds the two BIDS Manager-native supplements bidsval does not produce - the
+  sidecar-editing form data (``sidecar_fields``) and TODO-placeholder findings
+  (see :mod:`bidsmgr.editor.bidsmgr_checks`).
 
-Both layers emit Pydantic :class:`Issue` records that the CLI prints
-and the GUI binds to its editor pane (``inspector_proto/proto.py`` is
-the visual reference).
+The public signatures are unchanged, so the workers, the Editor panes, the HTML
+report, and ``bidsmgr-validate`` keep working without changes:
 
-Reference: architecture.md §7 (post-conversion) and the editor
-layout described in ``../inspector_proto/data.py``.
+* :func:`validate` - a whole dataset.
+* :func:`validate_file` - one file (the rest of the dataset is indexed for
+  inheritance / existence checks).
+* :func:`validate_folder` - every file under a folder.
+
+``strict`` is mapped to bidsval's ``read_headers`` ("deep checks": read NIfTI
+headers and file contents; slower). ``strict=False`` is the fast structural pass
+used for live revalidation in the Editor. ``schema`` selects the BIDS schema
+version (``None`` = bidsval's bundled default); ``max_rows`` bounds how many TSV
+rows are scanned. Both are threaded from the GUI / CLI settings (the engine never
+reads settings itself - architectural rule).
 """
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import bidsval
+
 import bidsmgr
-from .. import schema as schema_mod
-from ..schema.types import Severity as SchemaSeverity
-from .types import (
-    FieldLevel,
-    FileVerdict,
-    Issue,
-    Severity,
-    SidecarField,
-    ValidationReport,
-    rollup_severity,
-)
+
+from . import _bidsval_adapter as adapter
+from .types import FileVerdict, ValidationReport
 
 log = logging.getLogger(__name__)
 
 
-_BIDS_DATATYPE_NAMES: tuple[str, ...] = (
-    "anat", "func", "dwi", "fmap", "perf",
-    "meg", "eeg", "ieeg", "beh", "pet", "micr", "nirs",
-)
-
-# Files allowed at the dataset root that the validator should not
-# treat as orphans.
-_DATASET_ROOT_FILES: frozenset[str] = frozenset({
-    "dataset_description.json", "participants.tsv", "participants.json",
-    "README", "CHANGES", "LICENSE", "CITATION.cff", "samples.tsv",
-    "samples.json", ".bidsignore",
-})
-
-# Suffixes considered top-level data atoms when validating a sidecar's
-# IntendedFor URIs (the URI must point at one of these).
-_INTENDED_FOR_DATA_EXTS: tuple[str, ...] = (".nii.gz", ".nii")
-
-# bidsschematools rule names sometimes carry ``__<rule>`` to disambiguate
-# context (e.g. ``EchoTime__fmap``). The actual JSON key is the prefix.
-def _canonical(name: str) -> str:
-    return name.split("__", 1)[0]
+def _bidsmgr_version() -> str:
+    return str(getattr(bidsmgr, "__version__", "0.0.0"))
 
 
-# Mutual-exclusion groups for required-field audit. Mirrors
-# ``metadata.engine._REQUIRED_ALTERNATIVES``.
-_REQUIRED_ALTERNATIVES: dict[tuple[str, str], tuple[tuple[str, ...], ...]] = {
-    ("func", "bold"):  (("RepetitionTime", "VolumeTiming"),),
-    ("func", "sbref"): (("RepetitionTime", "VolumeTiming"),),
-    ("func", "cbv"):   (("RepetitionTime", "VolumeTiming"),),
-    ("func", "phase"): (("RepetitionTime", "VolumeTiming"),),
-}
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # ---------------------------------------------------------------------------
-# Public entry point
+# Public entry points
 # ---------------------------------------------------------------------------
 
 
@@ -85,661 +61,115 @@ def validate(
     bids_root: Path,
     *,
     strict: bool = False,
+    schema: Optional[str] = None,
+    max_rows: int = 1000,
+    flag_todos: bool = True,
 ) -> ValidationReport:
     """Validate the BIDS dataset at ``bids_root``.
 
-    Layer 1 (schema-driven) always runs. Layer 2 (bidsschematools
-    structural) runs when ``strict=True`` — it adds path-shape
-    validation against the spec and is slower on large trees.
-
-    The function never raises on invalid datasets; problems land in
-    ``report.files[*].issues``, ``report.folder_issues``, and
-    ``report.dataset_issues``. ``report.severity`` rolls up to the
-    highest severity seen.
+    ``strict=True`` enables "deep checks" (bidsval ``read_headers=True``: open
+    NIfTI image headers; slower). ``flag_todos`` adds the BIDS Manager TODO-
+    placeholder warnings (``False`` gives exact bidsval parity). The function
+    never raises on an invalid dataset - problems land in
+    ``report.files[*].issues`` and ``report.dataset_issues``; ``report.severity``
+    rolls up to the worst.
     """
     bids_root = Path(bids_root).resolve()
     if not bids_root.is_dir():
         raise FileNotFoundError(f"BIDS root not found: {bids_root}")
 
-    report = ValidationReport(
-        bids_root=bids_root,
-        bidsmgr_version=str(getattr(bidsmgr, "__version__", "0.0.0")),
-        bids_version=schema_mod.bids_version() if hasattr(schema_mod, "bids_version") else "",
-        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    bv_report = bidsval.validate(
+        bids_root,
+        schema=schema,
+        read_headers=strict,
+        max_rows=max_rows,
+    )
+    return adapter.to_bm_report(
+        bv_report,
+        bids_root,
+        bidsmgr_version=_bidsmgr_version(),
+        generated_at=_now_iso(),
+        flag_todos=flag_todos,
     )
 
-    # Layer 1 builds the per-file verdicts and dataset / folder issues.
-    file_verdicts: dict[Path, FileVerdict] = {}
-    _layer1_dataset_root(bids_root, file_verdicts, report)
-    _layer1_walk_subjects(bids_root, file_verdicts, report)
 
-    # Layer 2 — structural validation, optional.
-    if strict:
-        _layer2_bidsschematools(bids_root, file_verdicts, report)
+def validate_file(
+    bids_root: Path,
+    file_path: Path,
+    *,
+    schema: Optional[str] = None,
+    max_rows: int = 1000,
+    flag_todos: bool = True,
+) -> FileVerdict:
+    """Validate a single file; the rest of the dataset is indexed for
+    inheritance / existence checks. ``file_path`` must live under ``bids_root``
+    (raises ``ValueError`` otherwise). The returned ``FileVerdict.path`` is
+    relative to ``bids_root`` so it merges cleanly into a dataset-wide report.
 
-    # Promote dict to a sorted list and roll up severities.
-    report.files = [file_verdicts[p] for p in sorted(file_verdicts)]
-    severities: list[Severity] = []
-    for f in report.files:
-        severities.append(f.severity)
-    for issues in report.folder_issues.values():
-        severities.extend(i.severity for i in issues)
-    severities.extend(i.severity for i in report.dataset_issues)
-    report.severity = rollup_severity(severities)
-
-    counts = {"ok": 0, "warn": 0, "err": 0}
-    for sev in severities:
-        counts[sev.value] += 1
-    report.counts = counts
-
-    return report
-
-
-# ---------------------------------------------------------------------------
-# Public partial-validate helpers — used by the GUI's
-# "Validate file" / "Validate folder" toolbar buttons.
-# ---------------------------------------------------------------------------
-
-
-def validate_file(bids_root: Path, file_path: Path) -> FileVerdict:
-    """Run layer-1 per-file checks on a single file and return its verdict.
-
-    Includes:
-    * basename / entity validation against the schema;
-    * sidecar audit for ``.json`` files (required + recommended +
-      optional + deprecated field rollup, TODO placeholder detection).
-
-    Skips layer 2 (``bidsschematools`` structural) — it's a
-    dataset-wide pass that can't sensibly run on a single path in
-    isolation. For full strict validation the user clicks "Validate
-    dataset" with the Strict toggle on.
-
-    ``file_path`` must live under ``bids_root``; raises ``ValueError``
-    otherwise. The returned :class:`FileVerdict.path` is relative to
-    ``bids_root`` so it merges cleanly with a dataset-wide report.
+    Uses the fast structural pass (``read_headers=False``) since this runs live
+    as the user clicks around the Editor tree.
     """
     bids_root = Path(bids_root).resolve()
     file_path = Path(file_path).resolve()
-    rel = file_path.relative_to(bids_root)
-    datatype, suffix = _infer_datatype_suffix(file_path, bids_root)
-    verdict = FileVerdict(path=rel, datatype=datatype, suffix=suffix)
-    _check_filename_entities(file_path, bids_root, datatype, suffix, verdict)
-    if file_path.name.endswith(".json"):
-        _audit_sidecar(file_path, datatype, suffix, bids_root, verdict)
-    return verdict
+    rel = file_path.relative_to(bids_root)  # ValueError if outside the root
+
+    bv_verdict = bidsval.validate_file(
+        bids_root,
+        rel.as_posix(),
+        schema=schema,
+        read_headers=False,
+        max_rows=max_rows,
+    )
+    # bidsval indexes only files it recognises as BIDS data. If the user
+    # selected an existing file bidsval doesn't index (e.g. one nested inside a
+    # directory-recording), it reports FILE_NOT_FOUND - which would be a false
+    # error here. Fall back to a clean verdict so the BM-native supplements
+    # (sidecar_fields + TODO) still render without a spurious finding.
+    if file_path.exists() and any(
+        i.code == "FILE_NOT_FOUND" for i in bv_verdict.issues
+    ):
+        from bidsval import FileVerdict as _BvFileVerdict
+        bv_verdict = _BvFileVerdict(path=rel)
+
+    return adapter.to_bm_file_verdict(bv_verdict, bids_root, flag_todos=flag_todos)
 
 
 def validate_folder(
     bids_root: Path,
     folder_path: Path,
+    *,
+    schema: Optional[str] = None,
+    max_rows: int = 1000,
+    flag_todos: bool = True,
 ) -> list[FileVerdict]:
-    """Run :func:`validate_file` on every file under ``folder_path``.
+    """Validate every file under ``folder_path`` and return one verdict each.
 
-    Walks ``folder_path`` recursively, skipping dotfiles / dot-dirs
-    (``.bidsmgr``, ``.git``, …) the dataset-wide validator also
-    ignores. Returns one :class:`FileVerdict` per file. Like
-    :func:`validate_file`, no dataset-level or folder-level issues are
-    produced — those are reserved for the full dataset pass.
+    Runs one dataset-wide bidsval pass (so each file is validated with full
+    inheritance context) and filters to the files under ``folder_path`` - faster
+    and more correct than rebuilding the file tree once per file. Like
+    :func:`validate_file`, no dataset-level findings are returned (those belong
+    to the full ``validate`` pass).
     """
     bids_root = Path(bids_root).resolve()
     folder_path = Path(folder_path).resolve()
     if not folder_path.is_dir():
         raise NotADirectoryError(folder_path)
+
+    bv_report = bidsval.validate(
+        bids_root,
+        schema=schema,
+        read_headers=False,
+        max_rows=max_rows,
+    )
     out: list[FileVerdict] = []
-    for fp in sorted(folder_path.rglob("*")):
-        if not fp.is_file():
-            continue
-        # Skip anything under a dot-dir (covers .bidsmgr, .git, …).
+    for fv in bv_report.files:
+        abs_path = (bids_root / Path(fv.path)).resolve()
         try:
-            rel_parts = fp.relative_to(bids_root).parts
+            abs_path.relative_to(folder_path)
         except ValueError:
             continue
-        if any(part.startswith(".") for part in rel_parts):
-            continue
-        out.append(validate_file(bids_root, fp))
+        out.append(adapter.to_bm_file_verdict(fv, bids_root, flag_todos=flag_todos))
     return out
 
 
-# ---------------------------------------------------------------------------
-# Layer 1 — dataset-root checks
-# ---------------------------------------------------------------------------
-
-
-def _layer1_dataset_root(
-    bids_root: Path,
-    file_verdicts: dict[Path, FileVerdict],
-    report: ValidationReport,
-) -> None:
-    """Validate dataset-level files and presence of mandatory ones."""
-    # Mandatory: dataset_description.json
-    dd = bids_root / "dataset_description.json"
-    if not dd.exists():
-        report.dataset_issues.append(Issue(
-            severity=Severity.ERR,
-            rule_id="bids.missing_dataset_description",
-            message="dataset_description.json is missing at the BIDS root",
-        ))
-    else:
-        rel = dd.relative_to(bids_root)
-        verdict = FileVerdict(path=rel)
-        try:
-            data = json.loads(dd.read_text())
-        except (OSError, json.JSONDecodeError) as exc:
-            verdict.severity = Severity.ERR
-            verdict.issues.append(Issue(
-                severity=Severity.ERR,
-                rule_id="bids.invalid_json",
-                message=f"could not parse dataset_description.json: {exc}",
-            ))
-        else:
-            if not isinstance(data, dict):
-                verdict.severity = Severity.ERR
-                verdict.issues.append(Issue(
-                    severity=Severity.ERR,
-                    rule_id="bids.invalid_dataset_description",
-                    message="dataset_description.json is not a JSON object",
-                ))
-            else:
-                for required in ("Name", "BIDSVersion"):
-                    if required not in data:
-                        verdict.issues.append(Issue(
-                            severity=Severity.ERR,
-                            rule_id="bids.required_field_missing",
-                            message=f"missing required field {required!r}",
-                            field=required,
-                        ))
-                        verdict.severity = Severity.ERR
-                # Flag literal "TODO" placeholders (warn).
-                for k, v in data.items():
-                    if v == "TODO":
-                        verdict.issues.append(Issue(
-                            severity=Severity.WARN,
-                            rule_id="bidsmgr.todo_placeholder",
-                            message=f"field {k!r} contains TODO placeholder",
-                            field=k,
-                            fix_label="Set a real value",
-                            fix_action="set_field",
-                        ))
-                        if verdict.severity is Severity.OK:
-                            verdict.severity = Severity.WARN
-        file_verdicts[rel] = verdict
-
-    # participants.tsv → every NIfTI subject should appear in it (warn-level).
-    participants = bids_root / "participants.tsv"
-    if participants.exists():
-        rel = participants.relative_to(bids_root)
-        verdict = FileVerdict(path=rel)
-        try:
-            header = participants.read_text().splitlines()[0].split("\t")
-        except (OSError, IndexError):
-            verdict.severity = Severity.ERR
-            verdict.issues.append(Issue(
-                severity=Severity.ERR,
-                rule_id="bids.invalid_tsv",
-                message="participants.tsv could not be read",
-            ))
-        else:
-            if "participant_id" not in header:
-                verdict.severity = Severity.ERR
-                verdict.issues.append(Issue(
-                    severity=Severity.ERR,
-                    rule_id="bids.required_column_missing",
-                    message="participants.tsv missing required column 'participant_id'",
-                    field="participant_id",
-                ))
-        file_verdicts[rel] = verdict
-
-
-# ---------------------------------------------------------------------------
-# Layer 1 — walk every subject / session / datatype
-# ---------------------------------------------------------------------------
-
-
-def _layer1_walk_subjects(
-    bids_root: Path,
-    file_verdicts: dict[Path, FileVerdict],
-    report: ValidationReport,
-) -> None:
-    subjects = sorted(p for p in bids_root.glob("sub-*") if p.is_dir())
-    if not subjects:
-        report.dataset_issues.append(Issue(
-            severity=Severity.WARN,
-            rule_id="bidsmgr.no_subjects",
-            message="no sub-* directories found under the BIDS root",
-        ))
-        return
-
-    for sub_dir in subjects:
-        ses_dirs = sorted(s for s in sub_dir.glob("ses-*") if s.is_dir())
-        if ses_dirs:
-            for ses_dir in ses_dirs:
-                _layer1_walk_subject_root(
-                    ses_dir, sub_dir, ses_dir, bids_root,
-                    file_verdicts, report,
-                )
-        else:
-            _layer1_walk_subject_root(
-                sub_dir, sub_dir, None, bids_root,
-                file_verdicts, report,
-            )
-
-
-def _layer1_walk_subject_root(
-    root: Path,
-    sub_dir: Path,
-    ses_dir: Optional[Path],
-    bids_root: Path,
-    file_verdicts: dict[Path, FileVerdict],
-    report: ValidationReport,
-) -> None:
-    """Walk one sub-XXX[/ses-YYY] folder; one file_verdict per file."""
-    folder_key = str(root.relative_to(bids_root))
-    folder_issues: list[Issue] = []
-
-    # Reject orphan directories that aren't recognised BIDS datatypes.
-    # Skip dotfiles / dot-dirs (.bidsmgr, .git, .DS_Store, …) — they're
-    # bookkeeping, not BIDS content.
-    for child in sorted(root.iterdir()):
-        if not child.is_dir():
-            continue
-        if child.name.startswith("."):
-            continue
-        if child.name not in _BIDS_DATATYPE_NAMES:
-            # Sessions are handled at the level above; here a sub-dir
-            # that's not a datatype is unexpected.
-            folder_issues.append(Issue(
-                severity=Severity.WARN,
-                rule_id="bids.unknown_datatype_dir",
-                message=f"unrecognised datatype directory: {child.name!r}",
-            ))
-
-    # Per-datatype files.
-    for dt_dir in sorted(child for child in root.iterdir()
-                         if child.is_dir() and child.name in _BIDS_DATATYPE_NAMES):
-        for fp in sorted(dt_dir.iterdir()):
-            if not fp.is_file():
-                continue
-            rel = fp.relative_to(bids_root)
-            verdict = file_verdicts.setdefault(rel, FileVerdict(path=rel))
-            datatype, suffix = _infer_datatype_suffix(fp, bids_root)
-            verdict.datatype = datatype
-            verdict.suffix = suffix
-
-            _check_filename_entities(fp, bids_root, datatype, suffix, verdict)
-
-            if fp.name.endswith(".json"):
-                _audit_sidecar(fp, datatype, suffix, bids_root, verdict)
-
-    # Hidden-file noise filter: skip .DS_Store etc. (already excluded by
-    # filtering only datatype dirs above).
-
-    if folder_issues:
-        report.folder_issues[folder_key] = folder_issues
-
-
-# ---------------------------------------------------------------------------
-# Layer 1 — per-file checks
-# ---------------------------------------------------------------------------
-
-
-def _check_filename_entities(
-    fp: Path,
-    bids_root: Path,
-    datatype: Optional[str],
-    suffix: Optional[str],
-    verdict: FileVerdict,
-) -> None:
-    """Validate the BIDS basename (entities + suffix) against the schema."""
-    if not (datatype and suffix):
-        return
-    try:
-        # validate_basename accepts the basename portion of the file name.
-        verdicts = schema_mod.validate_basename(fp.name, datatype)
-    except Exception as exc:  # pragma: no cover - schema bugs should surface
-        verdict.issues.append(Issue(
-            severity=Severity.WARN,
-            rule_id="bidsmgr.schema_error",
-            message=f"schema engine raised on basename {fp.name!r}: {exc}",
-        ))
-        if verdict.severity is Severity.OK:
-            verdict.severity = Severity.WARN
-        return
-
-    for v in verdicts or []:
-        # ValidationVerdict exposes ``is_ok`` (property) + ``severity``
-        # (schema Severity enum) + ``rule_id`` - NOT ``ok``/``kind``. The
-        # old code read the wrong attributes, so ``getattr(v, "ok", True)``
-        # always defaulted to True and basename validation never flagged
-        # anything (a silent no-op). Use the real fields + map the severity.
-        if v.is_ok:
-            continue
-        sev = (
-            Severity.ERR if v.severity == SchemaSeverity.ERROR else Severity.WARN
-        )
-        verdict.issues.append(Issue(
-            severity=sev,
-            rule_id=f"bids.basename.{getattr(v, 'rule_id', 'invalid')}",
-            message=str(getattr(v, "message", v)),
-        ))
-        if sev is Severity.ERR:
-            verdict.severity = Severity.ERR
-        elif verdict.severity is Severity.OK:
-            verdict.severity = Severity.WARN
-
-
-def _audit_sidecar(
-    fp: Path,
-    datatype: Optional[str],
-    suffix: Optional[str],
-    bids_root: Path,
-    verdict: FileVerdict,
-) -> None:
-    """Required+recommended audit, TODO detection, sidecar_fields population.
-
-    Builds :class:`SidecarField` rows for every schema-defined field
-    (so the GUI form has a complete list), plus any extra keys the file
-    actually carries. Issues are appended to ``verdict.issues``.
-    """
-    try:
-        data = json.loads(fp.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        verdict.severity = Severity.ERR
-        verdict.issues.append(Issue(
-            severity=Severity.ERR,
-            rule_id="bids.invalid_json",
-            message=f"could not parse JSON sidecar: {exc}",
-        ))
-        return
-    if not isinstance(data, dict):
-        verdict.severity = Severity.ERR
-        verdict.issues.append(Issue(
-            severity=Severity.ERR,
-            rule_id="bids.invalid_json",
-            message="JSON sidecar is not an object",
-        ))
-        return
-
-    if not (datatype and suffix):
-        # Untyped sidecar (top-level JSON, etc.) — only TODO scan.
-        for k, v in data.items():
-            if v == "TODO":
-                verdict.issues.append(Issue(
-                    severity=Severity.WARN,
-                    rule_id="bidsmgr.todo_placeholder",
-                    message=f"field {k!r} contains TODO placeholder",
-                    field=k,
-                    fix_label="Set a real value",
-                    fix_action="set_field",
-                ))
-                if verdict.severity is Severity.OK:
-                    verdict.severity = Severity.WARN
-        return
-
-    # Pull the field set per level.
-    seen_names: set[str] = set()
-    fields: list[SidecarField] = []
-
-    def _add_level(level: FieldLevel, getter):
-        try:
-            schema_fields = getter(datatype, suffix)
-        except (KeyError, ValueError, AttributeError):
-            schema_fields = []
-        for fi in schema_fields or []:
-            name = _canonical(fi.name)
-            if name in seen_names:
-                continue
-            seen_names.add(name)
-            present = name in data
-            value = data.get(name) if present else None
-            value_kind = _value_kind(value) if present else "missing"
-            fields.append(SidecarField(
-                level=level, name=name, value=value, present=present,
-                value_kind=value_kind,
-                description=getattr(fi, "description", None),
-            ))
-
-    _add_level(FieldLevel.REQUIRED, schema_mod.required_sidecar_fields)
-    _add_level(FieldLevel.RECOMMENDED, schema_mod.recommended_sidecar_fields)
-    _add_level(FieldLevel.OPTIONAL, schema_mod.optional_sidecar_fields)
-    _add_level(FieldLevel.DEPRECATED, schema_mod.deprecated_sidecar_fields)
-
-    # Keys present in the file but not in any schema list — append as OPTIONAL.
-    for k, v in data.items():
-        if k in seen_names:
-            continue
-        seen_names.add(k)
-        fields.append(SidecarField(
-            level=FieldLevel.OPTIONAL, name=k, value=v, present=True,
-            value_kind=_value_kind(v),
-        ))
-
-    verdict.sidecar_fields = fields
-
-    # Required-field audit, with mutual-exclusivity respected.
-    required_names: set[str] = {
-        f.name for f in fields if f.level is FieldLevel.REQUIRED
-    }
-    for alternatives in _REQUIRED_ALTERNATIVES.get((datatype, suffix), ()):
-        if any(alt in data for alt in alternatives):
-            required_names -= set(alternatives)
-    for name in sorted(required_names):
-        if name not in data:
-            verdict.issues.append(Issue(
-                severity=Severity.ERR,
-                rule_id="bids.required_sidecar_field_missing",
-                message=f"missing required field {name!r}",
-                field=name,
-                fix_label=f"Add {name}",
-                fix_action="add_required_field",
-            ))
-            verdict.severity = Severity.ERR
-
-    # Recommended audit (advisory).
-    recommended_names: list[str] = [
-        f.name for f in fields if f.level is FieldLevel.RECOMMENDED
-    ]
-    for name in recommended_names:
-        if name not in data:
-            verdict.issues.append(Issue(
-                severity=Severity.WARN,
-                rule_id="bids.recommended_sidecar_field_missing",
-                message=f"missing recommended field {name!r}",
-                field=name,
-                fix_label=f"Add {name}",
-                fix_action="add_recommended_field",
-            ))
-            if verdict.severity is Severity.OK:
-                verdict.severity = Severity.WARN
-
-    # TODO placeholder detection.
-    for k, v in data.items():
-        if v == "TODO":
-            verdict.issues.append(Issue(
-                severity=Severity.WARN,
-                rule_id="bidsmgr.todo_placeholder",
-                message=f"field {k!r} contains TODO placeholder",
-                field=k,
-                fix_label="Set a real value",
-                fix_action="set_field",
-            ))
-            if verdict.severity is Severity.OK:
-                verdict.severity = Severity.WARN
-
-    # IntendedFor URIs must resolve.
-    intended = data.get("IntendedFor")
-    if isinstance(intended, list):
-        for entry in intended:
-            if not isinstance(entry, str):
-                continue
-            target = _resolve_intended_for(entry, fp, bids_root)
-            if target is not None and not target.exists():
-                verdict.issues.append(Issue(
-                    severity=Severity.ERR,
-                    rule_id="bids.intended_for_unresolved",
-                    message=f"IntendedFor entry does not resolve: {entry}",
-                    field="IntendedFor",
-                ))
-                verdict.severity = Severity.ERR
-
-
-# ---------------------------------------------------------------------------
-# Layer 2 — bidsschematools structural
-# ---------------------------------------------------------------------------
-
-
-def _layer2_bidsschematools(
-    bids_root: Path,
-    file_verdicts: dict[Path, FileVerdict],
-    report: ValidationReport,
-) -> None:
-    """Run ``bidsschematools.validator.validate_bids`` and translate findings.
-
-    Layer 2 is structural: it checks whether each on-disk path matches a
-    BIDS schema regex, and whether mandatory schema rules are
-    satisfied. JSON content is NOT inspected here (layer 1 does that).
-    """
-    try:
-        import bidsschematools
-        from bidsschematools.validator import validate_bids
-    except ImportError:
-        report.dataset_issues.append(Issue(
-            severity=Severity.WARN,
-            rule_id="bidsmgr.bst_unavailable",
-            message="bidsschematools not installed; --strict layer skipped",
-        ))
-        return
-
-    # bidsschematools logs "No BIDS reference root provided." at WARNING.
-    # That's expected for our usage; quiet its logger for the duration.
-    bst_logger = logging.getLogger(getattr(bidsschematools, "__name__", "bidsschematools"))
-    prev_level = bst_logger.level
-    bst_logger.setLevel(logging.ERROR)
-    try:
-        try:
-            out = validate_bids([str(bids_root)], suppress_errors=True)
-        except Exception as exc:
-            report.dataset_issues.append(Issue(
-                severity=Severity.WARN,
-                rule_id="bidsmgr.bst_failed",
-                message=f"bidsschematools validate_bids raised: {exc}",
-            ))
-            return
-    finally:
-        bst_logger.setLevel(prev_level)
-
-    matched: set[str] = {it["path"] for it in out.get("itemwise", []) if it.get("match")}
-    all_paths: list[str] = list(out.get("path_listing", []))
-
-    for raw in sorted(set(all_paths) - matched):
-        try:
-            rel = Path(raw).resolve().relative_to(bids_root)
-        except ValueError:
-            continue
-        # Skip dotfiles bidsschematools may have included anyway.
-        if any(part.startswith(".") for part in rel.parts):
-            continue
-        verdict = file_verdicts.setdefault(rel, FileVerdict(path=rel))
-        verdict.issues.append(Issue(
-            severity=Severity.WARN,
-            rule_id="bids.unknown_path",
-            message="path does not match any BIDS schema rule",
-        ))
-        if verdict.severity is Severity.OK:
-            verdict.severity = Severity.WARN
-
-    # Mandatory rules with no satisfying path → dataset-level error.
-    rule_to_match = {it["regex"]: it["match"] for it in out.get("itemwise", [])
-                     if it.get("match")}
-    for rule in out.get("schema_tracking", []):
-        if not rule.get("mandatory"):
-            continue
-        if rule["regex"] not in rule_to_match:
-            report.dataset_issues.append(Issue(
-                severity=Severity.ERR,
-                rule_id="bids.missing_mandatory_path",
-                message=(
-                    f"no path satisfies mandatory schema rule: "
-                    f"{rule['regex']}"
-                ),
-            ))
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _value_kind(value: object) -> str:
-    if value is None:
-        return "null"
-    if isinstance(value, bool):
-        return "bool"
-    if isinstance(value, (int, float)):
-        return "number"
-    if isinstance(value, list):
-        return "array"
-    if isinstance(value, dict):
-        return "object"
-    if value == "TODO":
-        return "todo"
-    if isinstance(value, str):
-        return "string"
-    return "string"
-
-
-def _infer_datatype_suffix(
-    json_path: Path, bids_root: Path,
-) -> tuple[Optional[str], Optional[str]]:
-    try:
-        rel_parts = json_path.relative_to(bids_root).parts
-    except ValueError:
-        return None, None
-
-    datatype: Optional[str] = None
-    for part in rel_parts:
-        if part in _BIDS_DATATYPE_NAMES:
-            datatype = part
-            break
-
-    stem = json_path.name
-    for ext in (".nii.gz", ".nii", ".json", ".tsv", ".tsv.gz", ".bval", ".bvec"):
-        if stem.endswith(ext):
-            stem = stem[: -len(ext)]
-            break
-
-    suffix: Optional[str] = None
-    for tok in reversed(stem.split("_")):
-        if tok and "-" not in tok:
-            suffix = tok
-            break
-    return datatype, suffix
-
-
-_BIDS_URI_RE = re.compile(r"^bids::(?P<rel>.+)$")
-
-
-def _resolve_intended_for(entry: str, sidecar: Path, bids_root: Path) -> Optional[Path]:
-    """Return the absolute Path the IntendedFor entry points at.
-
-    Supports two forms (BIDS spec):
-    * ``bids::sub-X[/ses-Y]/datatype/file`` (1.6+ URI form, recommended).
-    * legacy relative path: ``ses-Y/func/...`` (relative to the subject root).
-    """
-    m = _BIDS_URI_RE.match(entry.strip())
-    if m:
-        return (bids_root / m.group("rel")).resolve()
-
-    # Legacy relative form: relative to the subject directory.
-    rel = entry.strip()
-    if not rel:
-        return None
-    # Walk up to sub-XXX (sidecar's first ancestor named sub-*).
-    sub = sidecar.parent
-    while sub.parent != sub and not sub.name.startswith("sub-"):
-        sub = sub.parent
-    if not sub.name.startswith("sub-"):
-        return None
-    return (sub / rel).resolve()
-
-
-__all__ = ["validate"]
+__all__ = ["validate", "validate_file", "validate_folder"]

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -32,7 +32,12 @@ KEYS = {
     "active_view":        "ui/active_view",          # "converter" | "editor"
     "editor_bids_root":   "editor/bids_root",        # last BIDS root opened in the Editor view
     "editor_sidecar_view": "editor/sidecar_view",    # "bids" | "tree"
-    "editor_strict_validate": "editor/strict_validate",  # layer 2 (bidsschematools) on/off
+    "editor_strict_validate": "editor/strict_validate",  # "deep checks": bidsval read_headers on/off
+    # Validation engine (bidsval) knobs, controllable from Settings.
+    "validate_schema_version": "validate/schema_version",  # "" = bidsval bundled default
+    "validate_max_rows": "validate/max_rows",              # TSV rows scanned per table
+    "validate_show": "validate/show",                      # which severities the Editor lists
+    "validate_flag_todos": "validate/flag_todos",          # flag literal TODO placeholders
     "nifti_crosshair_color": "editor/nifti_crosshair_color",   # hex string e.g. "#4FC3F7"
     "nifti_crosshair_thickness": "editor/nifti_crosshair_thickness",  # px, 1..5
     # Scan defaults
@@ -88,10 +93,24 @@ class AppSettings:
     editor_bids_root: Optional[str] = None
     # Which sidecar pane layout is active for JSON files.
     editor_sidecar_view: str = "bids"  # "bids" | "tree"
-    # When True, "Validate dataset" runs ``bidsschematools.validator``
-    # (the official Python BIDS validator) in addition to bidsmgr's
-    # schema-driven layer 1 checks.
+    # "Deep checks" toggle for the Editor's "Validate dataset". When True the
+    # validator (bidsval) reads NIfTI headers and file contents (slower, more
+    # thorough); when False it runs the fast structural pass used for live
+    # revalidation. (Historically this enabled a second bidsschematools pass;
+    # validation is now a single engine and the toggle maps to read_headers.)
     editor_strict_validate: bool = False
+    # Validation engine (bidsval) knobs. ``validate_schema_version`` selects the
+    # BIDS schema version to validate against ("" = bidsval's bundled default);
+    # ``validate_max_rows`` bounds how many rows of each TSV are scanned;
+    # ``validate_show`` filters which severities the Editor's Validation pane
+    # lists ("error_warning" | "error" | "warning").
+    validate_schema_version: str = ""
+    validate_max_rows: int = 1000
+    validate_show: str = "error_warning"
+    # Flag literal "TODO" placeholder values as warnings (a BIDS Manager
+    # convention: the metadata engine writes TODO into missing recommended
+    # fields). On by default; off gives exact bidsval parity.
+    validate_flag_todos: bool = True
     # NIfTI viewer crosshair style. Persisted so the user's chosen
     # colour + thickness survives across sessions.
     nifti_crosshair_color: str = "#4FC3F7"
@@ -226,6 +245,23 @@ class AppSettings:
             s.value(KEYS["editor_strict_validate"]),
             out.editor_strict_validate,
         )
+        out.validate_schema_version = _as_str(
+            s.value(KEYS["validate_schema_version"]),
+            out.validate_schema_version,
+        )
+        out.validate_max_rows = _as_int(
+            s.value(KEYS["validate_max_rows"]), out.validate_max_rows,
+        )
+        if out.validate_max_rows < 1:
+            out.validate_max_rows = 1000
+        out.validate_show = _as_str(
+            s.value(KEYS["validate_show"]), out.validate_show,
+        )
+        if out.validate_show not in ("error_warning", "error", "warning"):
+            out.validate_show = "error_warning"
+        out.validate_flag_todos = _as_bool(
+            s.value(KEYS["validate_flag_todos"]), out.validate_flag_todos,
+        )
         out.nifti_crosshair_color = _as_str(
             s.value(KEYS["nifti_crosshair_color"]),
             out.nifti_crosshair_color,
@@ -326,9 +362,13 @@ class AppSettings:
             ("post_validate_strict",     self.post_validate_strict),
             ("post_validate_html",       self.post_validate_html),
             ("editor_strict_validate",   self.editor_strict_validate),
+            ("validate_flag_todos",      self.validate_flag_todos),
         ):
             s.setValue(KEYS[key], "1" if val else "0")
         s.setValue(KEYS["convert_on_existing"], self.convert_on_existing)
+        s.setValue(KEYS["validate_schema_version"], self.validate_schema_version)
+        s.setValue(KEYS["validate_max_rows"], int(self.validate_max_rows))
+        s.setValue(KEYS["validate_show"], self.validate_show)
         s.setValue(KEYS["skipped_update_version"], self.skipped_update_version)
         s.setValue(KEYS["font_scale"], float(self.font_scale))
         s.setValue(KEYS["header_logo"], self.header_logo)

--- a/bidsmgr/gui/converter_panel.py
+++ b/bidsmgr/gui/converter_panel.py
@@ -1747,6 +1747,9 @@ class ConverterPanel(QWidget):
         worker = ValidateWorker(
             bids_parent,
             strict=s.post_validate_strict,
+            schema=s.validate_schema_version or None,
+            max_rows=s.validate_max_rows,
+            flag_todos=s.validate_flag_todos,
             html_report=s.post_validate_html,
             parent=self,
         )

--- a/bidsmgr/gui/editor_issues_dialog.py
+++ b/bidsmgr/gui/editor_issues_dialog.py
@@ -210,9 +210,18 @@ class EditorIssuesDialog(QDialog):
         else:
             for f in matched:
                 abs_path = self._absolute(f.path)
+                # Show only the issues matching the clicked chip's severity
+                # (an "err" file also carries warnings - don't list those under
+                # the error chip). Skip mirrors so a finding isn't shown twice.
+                shown = [
+                    i for i in f.issues
+                    if (i.severity.value if isinstance(i.severity, Severity)
+                        else str(i.severity)) == severity
+                    and not getattr(i, "mirrored", False)
+                ]
                 card = _FileCard(
                     path=abs_path,
-                    issues=f.issues,
+                    issues=shown,
                     severity=severity,
                     datatype=f.datatype,
                     suffix=f.suffix,
@@ -243,11 +252,25 @@ class EditorIssuesDialog(QDialog):
     ) -> list[FileVerdict]:
         out: list[FileVerdict] = []
         for f in report.files:
-            sev = (
-                f.severity.value if isinstance(f.severity, Severity)
-                else str(f.severity)
-            )
-            if sev == severity:
+            if severity == "ok":
+                # "valid" chip: files with no findings at all.
+                fsev = (
+                    f.severity.value if isinstance(f.severity, Severity)
+                    else str(f.severity)
+                )
+                if fsev == "ok":
+                    out.append(f)
+                continue
+            # err / warn chips: every file that CONTAINS an issue of that
+            # severity (an err+warn file appears under BOTH chips, showing the
+            # matching subset). Matching by file-rollup hid an err file's
+            # warnings from the warnings chip entirely. Skip mirrors.
+            if any(
+                (i.severity.value if isinstance(i.severity, Severity)
+                 else str(i.severity)) == severity
+                and not getattr(i, "mirrored", False)
+                for i in f.issues
+            ):
                 out.append(f)
         # Sort by parent dir then name for predictable layout.
         out.sort(key=lambda f: (str(f.path.parent), f.path.name))

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -825,13 +825,10 @@ class EditorPanel(QWidget):
             self.select_file_in_tree(path)
             verdict = self._verdict_for(path)
             if verdict is not None and field:
-                # Highlight the specific bad cell(s) for this column (a column
-                # can be flagged at several rows). ``line`` is 1-based incl.
-                # header; the viewer resolves it to a cell.
-                items = [
-                    (i.field, i.line, i.severity.value)
-                    for i in verdict.issues if i.field == field
-                ]
+                # Highlight every bad cell for this column. A column finding
+                # carries all offending rows in ``lines`` (the viewer resolves
+                # each 1-based row to a cell).
+                items = self._tsv_highlight_items(verdict.issues, field=field)
                 if items:
                     self._tsv_viewer.highlight_findings(items)
             return
@@ -863,11 +860,7 @@ class EditorPanel(QWidget):
             verdict = self._verdict_for(path)
             if verdict is None:
                 return
-            items = [
-                (i.field, i.line, i.severity.value)
-                for i in verdict.issues
-                if i.field and i.severity in allowed
-            ]
+            items = self._tsv_highlight_items(verdict.issues, allowed=allowed)
             if not items:
                 return
             if path != self._tsv_viewer.current_file():
@@ -898,6 +891,27 @@ class EditorPanel(QWidget):
         if target != self._sidecar_form.current_file():
             self.select_file_in_tree(target)
         self._sidecar_form.highlight_fields(mapping)
+
+    @staticmethod
+    def _tsv_highlight_items(issues, *, field=None, allowed=None) -> list:
+        """Flatten TSV findings to ``(column, line, severity)`` items, one per
+        offending row. A column finding lists every bad row in ``lines``; we
+        expand them all so each bad cell is highlighted (falls back to ``line``
+        for column-level findings without rows)."""
+        items: list = []
+        for issue in issues:
+            if not issue.field:
+                continue
+            if field is not None and issue.field != field:
+                continue
+            if allowed is not None and issue.severity not in allowed:
+                continue
+            rows = issue.lines or (
+                [issue.line] if issue.line is not None else [None]
+            )
+            for ln in rows:
+                items.append((issue.field, ln, issue.severity.value))
+        return items
 
     def _verdict_for(self, path: Path) -> Optional[FileVerdict]:
         """The :class:`FileVerdict` in the current report for ``path`` (matched

--- a/bidsmgr/gui/editor_panel.py
+++ b/bidsmgr/gui/editor_panel.py
@@ -120,6 +120,9 @@ class EditorPanel(QWidget):
         self._center_stack.currentChanged.connect(self._sync_undo_redo)
         self._validation_pane = ValidationPane()
         self._validation_pane.fix_requested.connect(self._on_fix_requested)
+        self._validation_pane.highlight_all_requested.connect(
+            self._on_highlight_all_requested
+        )
         # The BIDS tree folds to the left, the validation pane to the right,
         # and the center viewer grows into the freed space. The viewer is
         # not collapsible (it's the main surface) but IS detachable so the
@@ -180,8 +183,10 @@ class EditorPanel(QWidget):
         if self._report_worker is not None and self._report_worker.isRunning():
             return  # debounce concurrent runs
         self._set_busy(True, "Validating dataset…")
+        schema, max_rows, flag_todos = self._validation_engine_opts()
         worker = ReportWorker(
-            root, strict=self._strict_btn.isChecked(), parent=self,
+            root, strict=self._strict_btn.isChecked(),
+            schema=schema, max_rows=max_rows, flag_todos=flag_todos, parent=self,
         )
         worker.progress.connect(self._on_progress)
         worker.finished_with_report.connect(self._on_report_ready)
@@ -203,7 +208,11 @@ class EditorPanel(QWidget):
         )():
             return
         self._set_busy(True, f"Validating {target.name}…")
-        worker = FileReportWorker(root, target, parent=self)
+        schema, max_rows, flag_todos = self._validation_engine_opts()
+        worker = FileReportWorker(
+            root, target, schema=schema, max_rows=max_rows,
+            flag_todos=flag_todos, parent=self,
+        )
         self._wire_partial_worker(worker)
         self._partial_worker = worker
         worker.start()
@@ -221,7 +230,11 @@ class EditorPanel(QWidget):
         )():
             return
         self._set_busy(True, f"Validating {target.name}/…")
-        worker = FolderReportWorker(root, target, parent=self)
+        schema, max_rows, flag_todos = self._validation_engine_opts()
+        worker = FolderReportWorker(
+            root, target, schema=schema, max_rows=max_rows,
+            flag_todos=flag_todos, parent=self,
+        )
         self._wire_partial_worker(worker)
         self._partial_worker = worker
         worker.start()
@@ -307,29 +320,31 @@ class EditorPanel(QWidget):
         self._validate_dataset_btn.clicked.connect(self.start_dataset_validation)
         lay.addWidget(self._validate_dataset_btn)
 
-        # Strict-validation toggle — when on, "Validate dataset" also
-        # runs ``bidsschematools.validator.validate_bids`` (the official
-        # Python BIDS validator) on top of bidsmgr's schema-driven
-        # layer 1 checks. State persists via AppSettings.
+        # Deep-checks toggle — when on, "Validate dataset" reads NIfTI
+        # headers and file contents (slower, more thorough); when off it
+        # runs the fast structural pass used for live revalidation. Maps
+        # to the validator's read-headers mode. State persists via
+        # AppSettings (the ``editor_strict_validate`` key, kept for
+        # back-compat).
         from .app_settings import AppSettings
-        self._strict_btn = QPushButton("  Strict BIDS")
+        self._strict_btn = QPushButton("  Deep checks")
         self._strict_btn.setObjectName("tb-btn-toggle")
         icons.apply_button(self._strict_btn, "strict")
         self._strict_btn.setCheckable(True)
         self._strict_btn.setChecked(AppSettings.load().editor_strict_validate)
         self._strict_btn.setToolTip(
-            "Strict BIDS validation\n\n"
-            "When ON, “Validate dataset” adds a second pass with the "
-            "official Python BIDS validator (bidsschematools). It "
-            "checks every on-disk path against the BIDS schema regexes "
-            "and surfaces files that don't match a recognised pattern "
-            "or violate mandatory structural rules.\n\n"
-            "When OFF, only bidsmgr's schema-driven layer 1 runs — "
-            "per-(datatype, suffix) sidecar audit, IntendedFor "
-            "resolution, basename / entity checks, dataset-level "
-            "layout. Faster on large trees.\n\n"
-            "Tip: leave this OFF while editing and flip it ON once "
-            "before a final review."
+            "Deep validation checks\n\n"
+            "When ON, “Validate dataset” also opens NIfTI image headers to "
+            "catch truncated or corrupt .nii / .nii.gz files. This is the "
+            "only extra file read, and the only thing this toggle changes.\n\n"
+            "When OFF, the validator runs the fast structural pass — file "
+            "naming, entities, sidecar fields, TSV columns, associations. "
+            "This is the mode used for live revalidation as you edit.\n\n"
+            "Note: EEG / MEG / iEEG recordings are validated from their "
+            "sidecars + channels.tsv and are never opened, so this toggle "
+            "has no effect on a recordings-only dataset.\n\n"
+            "Tip: leave this OFF while editing and flip it ON once before "
+            "a final review."
         )
         self._strict_btn.toggled.connect(self._on_strict_toggled)
         lay.addWidget(self._strict_btn)
@@ -369,6 +384,38 @@ class EditorPanel(QWidget):
     def _on_strict_toggled(self, checked: bool) -> None:
         from .app_settings import AppSettings
         AppSettings.remember_editor_strict_validate(checked)
+
+    @staticmethod
+    def _allowed_severities() -> set:
+        """Severities the Editor displays, from the ``validate_show`` setting.
+
+        Applied uniformly to the tree dots, the status chips, and the
+        Validation pane so "errors only" / "warnings only" hides the rest
+        everywhere (not just in the pane list).
+        """
+        from .app_settings import AppSettings
+        show = AppSettings.load().validate_show
+        if show == "error":
+            return {Severity.ERR}
+        if show == "warning":
+            return {Severity.WARN}
+        return {Severity.ERR, Severity.WARN}
+
+    @staticmethod
+    def _validation_engine_opts() -> tuple[Optional[str], int, bool]:
+        """Resolve the bidsval schema + max-rows + flag-todos knobs from settings.
+
+        Threaded into every validation worker so the engine never reads
+        settings itself (it stays Qt-free). ``schema`` is ``None`` for
+        bidsval's bundled default.
+        """
+        from .app_settings import AppSettings
+        s = AppSettings.load()
+        return (
+            s.validate_schema_version or None,
+            int(s.validate_max_rows),
+            bool(s.validate_flag_todos),
+        )
 
     # ------------------------------------------------------------------
     # Open-root flow
@@ -547,21 +594,24 @@ class EditorPanel(QWidget):
 
     @staticmethod
     def _recompute_report_summary(report: ValidationReport) -> None:
-        """Reset ``severity`` and ``counts`` after files were mutated."""
-        severities = []
-        for f in report.files:
-            severities.append(f.severity)
+        """Reset ``severity`` and ``counts`` after files were mutated.
+
+        Counts are PER-FINDING (every error/warning issue), matching the
+        adapter + bidsval; ``ok`` is the number of clean files.
+        """
+        all_issues = [i for i in report.dataset_issues if not i.mirrored]
         for issues in report.folder_issues.values():
-            severities.extend(i.severity for i in issues)
-        severities.extend(i.severity for i in report.dataset_issues)
-        counts = {"ok": 0, "warn": 0, "err": 0}
-        for sev in severities:
-            val = sev.value if isinstance(sev, Severity) else str(sev)
-            counts[val] = counts.get(val, 0) + 1
-        report.counts = counts
-        if any(s is Severity.ERR for s in severities):
+            all_issues.extend(i for i in issues if not i.mirrored)
+        for f in report.files:
+            all_issues.extend(i for i in f.issues if not i.mirrored)
+        report.counts = {
+            "ok": sum(1 for f in report.files if f.severity is Severity.OK),
+            "warn": sum(1 for i in all_issues if i.severity is Severity.WARN),
+            "err": sum(1 for i in all_issues if i.severity is Severity.ERR),
+        }
+        if any(i.severity is Severity.ERR for i in all_issues):
             report.severity = Severity.ERR
-        elif any(s is Severity.WARN for s in severities):
+        elif any(i.severity is Severity.WARN for i in all_issues):
             report.severity = Severity.WARN
         else:
             report.severity = Severity.OK
@@ -580,10 +630,19 @@ class EditorPanel(QWidget):
         root = self.current_root()
         if root is None:
             return
+        allowed = self._allowed_severities()
         severities: dict[Path, str] = {}
         for fv in report.files:
-            sev = fv.severity
-            value = sev.value if isinstance(sev, Severity) else str(sev)
+            # Badge = worst ALLOWED issue on the file; clean / filtered-out
+            # files get the green "ok" dot. So "errors only" leaves only error
+            # files red and everything else green.
+            issues = [i for i in fv.issues if i.severity in allowed]
+            if any(i.severity is Severity.ERR for i in issues):
+                value = "err"
+            elif any(i.severity is Severity.WARN for i in issues):
+                value = "warn"
+            else:
+                value = "ok"
             absolute = (root / fv.path).resolve() if not fv.path.is_absolute() \
                 else fv.path
             severities[absolute] = value
@@ -591,11 +650,15 @@ class EditorPanel(QWidget):
 
     def _update_chips(self, report: ValidationReport) -> None:
         counts = report.counts
+        allowed = self._allowed_severities()
         self._chip_ok.setText(f"{counts.get('ok', 0)} valid")
         self._chip_warn.setText(f"{counts.get('warn', 0)} warnings")
         self._chip_err.setText(f"{counts.get('err', 0)} errors")
-        for chip in (self._chip_ok, self._chip_warn, self._chip_err):
-            chip.setVisible(True)
+        # The "Show findings" filter hides the chips for severities it excludes
+        # (so "errors only" doesn't surface a warnings counter). "valid" stays.
+        self._chip_ok.setVisible(True)
+        self._chip_warn.setVisible(Severity.WARN in allowed)
+        self._chip_err.setVisible(Severity.ERR in allowed)
 
     def _hide_chips(self) -> None:
         for chip in (self._chip_ok, self._chip_warn, self._chip_err):
@@ -746,13 +809,116 @@ class EditorPanel(QWidget):
     def _on_fix_requested(self, path: Path, field: str) -> None:
         """A user clicked a ValMessage's fix button.
 
-        First land on the file (if it isn't already the bound one),
-        then ask the sidecar pane to focus the named field.
+        Navigate to where the problem is actually edited, then highlight it:
+
+        * a TSV column finding -> open the ``.tsv`` and select that column;
+        * a sidecar field finding -> open the ``.json`` and focus that field.
+          When the finding sits on a data file (``*_bold.nii.gz``, where bidsval
+          attaches sidecar metadata findings), redirect to its editable
+          ``*_bold.json`` sibling so the field can be focused.
         """
-        if path is not None and path != self._sidecar_form.current_file():
+        if path is None:
+            return
+        name = path.name.lower()
+
+        if name.endswith(".tsv") or name.endswith(".tsv.gz"):
             self.select_file_in_tree(path)
-        if field:
+            verdict = self._verdict_for(path)
+            if verdict is not None and field:
+                # Highlight the specific bad cell(s) for this column (a column
+                # can be flagged at several rows). ``line`` is 1-based incl.
+                # header; the viewer resolves it to a cell.
+                items = [
+                    (i.field, i.line, i.severity.value)
+                    for i in verdict.issues if i.field == field
+                ]
+                if items:
+                    self._tsv_viewer.highlight_findings(items)
+            return
+
+        if name.endswith(".json"):
+            target = path
+        else:
+            from ..editor.bidsmgr_checks import sibling_json
+            sib = sibling_json(path)
+            target = sib if (sib is not None and sib.exists()) else path
+
+        if target != self._sidecar_form.current_file():
+            self.select_file_in_tree(target)
+        if field and target.name.lower().endswith(".json"):
             self._sidecar_form.focus_field(field)
+
+    def _on_highlight_all_requested(self, path: Path) -> None:
+        """Highlight every shown error/warning field (JSON) or cell (TSV) for
+        ``path`` in the editor. For a data file, the editable target is its
+        ``.json`` sibling (where the sidecar fields live)."""
+        if path is None or self._report is None:
+            return
+        name = path.name.lower()
+        allowed = self._allowed_severities()
+
+        # TSV: highlight each finding's specific cell (or whole column when the
+        # finding has no row), so the bad values are pinpointed, not the column.
+        if name.endswith(".tsv") or name.endswith(".tsv.gz"):
+            verdict = self._verdict_for(path)
+            if verdict is None:
+                return
+            items = [
+                (i.field, i.line, i.severity.value)
+                for i in verdict.issues
+                if i.field and i.severity in allowed
+            ]
+            if not items:
+                return
+            if path != self._tsv_viewer.current_file():
+                self.select_file_in_tree(path)
+            self._tsv_viewer.highlight_findings(items)
+            return
+
+        # JSON sidecar (or a data file -> its editable .json sibling).
+        if name.endswith(".json"):
+            target = path
+        else:
+            from ..editor.bidsmgr_checks import sibling_json
+            sib = sibling_json(path)
+            target = sib if (sib is not None and sib.exists()) else path
+        verdict = self._verdict_for(target)
+        if verdict is None:
+            return
+        rank = {"err": 2, "warn": 1}
+        mapping: dict[str, str] = {}
+        for issue in verdict.issues:
+            if not issue.field or issue.severity not in allowed:
+                continue
+            sv = issue.severity.value
+            if rank.get(sv, 0) > rank.get(mapping.get(issue.field, ""), 0):
+                mapping[issue.field] = sv
+        if not mapping:
+            return
+        if target != self._sidecar_form.current_file():
+            self.select_file_in_tree(target)
+        self._sidecar_form.highlight_fields(mapping)
+
+    def _verdict_for(self, path: Path) -> Optional[FileVerdict]:
+        """The :class:`FileVerdict` in the current report for ``path`` (matched
+        on the absolute path), or ``None``."""
+        report = self._report
+        root = self.current_root()
+        if report is None or root is None:
+            return None
+        try:
+            target_abs = str(path.resolve())
+        except OSError:
+            target_abs = str(path)
+        for fv in report.files:
+            cand = fv.path if fv.path.is_absolute() else (root / fv.path)
+            try:
+                cand_abs = str(cand.resolve())
+            except OSError:
+                cand_abs = str(cand)
+            if cand_abs == target_abs:
+                return fv
+        return None
 
     # ------------------------------------------------------------------
 

--- a/bidsmgr/gui/settings_dialog.py
+++ b/bidsmgr/gui/settings_dialog.py
@@ -21,7 +21,6 @@ from PyQt6.QtWidgets import (
     QComboBox,
     QDialog,
     QDialogButtonBox,
-    QDoubleSpinBox,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -95,6 +94,7 @@ class SettingsDialog(QDialog):
         tabs.addTab(self._build_scan_tab(), "Scan")
         tabs.addTab(self._build_scan_rules_tab(), "Scan rules")
         tabs.addTab(self._build_convert_tab(), "Convert + post-convert")
+        tabs.addTab(self._build_validation_tab(), "Validation")
         v.addWidget(tabs, 1)
 
         # Save / Cancel / Restore defaults.
@@ -568,11 +568,16 @@ class SettingsDialog(QDialog):
         pv.addWidget(_indented(self._post_metadata_fill_todos))
 
         self._post_run_validate = QCheckBox(
-            "Validate dataset (schema + bidsschematools structural)"
+            "Validate dataset (bidsval schema-driven validation)"
         )
         pv.addWidget(self._post_run_validate)
         self._post_validate_strict = QCheckBox(
-            "Strict: treat warnings as errors (--strict)"
+            "Deep checks: read NIfTI headers and file contents (slower)"
+        )
+        self._post_validate_strict.setToolTip(
+            "When on, validation reads NIfTI headers and file contents in "
+            "addition to the structural checks. More thorough, slower on "
+            "large trees. Maps to the validator's read-headers mode."
         )
         self._post_validate_html = QCheckBox(
             "Write a self-contained validation_report.html (--html)"
@@ -588,6 +593,88 @@ class SettingsDialog(QDialog):
         )
 
         v.addWidget(post)
+        v.addStretch(1)
+        return w
+
+    def _build_validation_tab(self) -> QWidget:
+        """Validation-engine (bidsval) knobs.
+
+        The Editor's "Deep checks" toggle (read NIfTI headers / file contents)
+        lives in the Editor toolbar, not here, because it is a per-run choice.
+        These two are dataset-wide preferences worth persisting.
+        """
+        w = QWidget()
+        v = QVBoxLayout(w)
+
+        box = QGroupBox("Validation engine (bidsval)")
+        form = QFormLayout(box)
+
+        # BIDS schema version. bidsval bundles several; "" = its default.
+        self._validate_schema = QComboBox()
+        self._validate_schema.addItem("Bundled default (recommended)", userData="")
+        try:
+            import bidsval
+            for ver in bidsval.available_versions():
+                self._validate_schema.addItem(f"BIDS schema {ver}", userData=ver)
+        except Exception:
+            pass
+        self._validate_schema.setToolTip(
+            "Validate against this BIDS schema version. bidsval bundles "
+            "several versions; the bundled default tracks the BIDS release "
+            "BIDS Manager ships with. Picking an older version validates a "
+            "dataset against that version's rules."
+        )
+        form.addRow("BIDS schema version:", self._validate_schema)
+
+        self._validate_max_rows = QSpinBox()
+        self._validate_max_rows.setRange(1, 10_000_000)
+        self._validate_max_rows.setSingleStep(1000)
+        self._validate_max_rows.setToolTip(
+            "Maximum number of rows scanned per TSV during column / value "
+            "validation. Large tables are bounded to keep validation fast; "
+            "raise this to scan more of very long tables."
+        )
+        form.addRow("Max TSV rows scanned:", self._validate_max_rows)
+
+        # Which severities the Editor's Validation pane lists. The tree badges
+        # and chips always reflect the full picture; this only filters the
+        # findings list so you can focus on errors (or warnings).
+        self._validate_show = QComboBox()
+        for label, value in (
+            ("Errors and warnings", "error_warning"),
+            ("Errors only",         "error"),
+            ("Warnings only",       "warning"),
+        ):
+            self._validate_show.addItem(label, userData=value)
+        self._validate_show.setToolTip(
+            "Filter which findings the Editor's Validation pane lists. The "
+            "tree badges and the error / warning counters always show the "
+            "full picture; this only narrows the list so you can focus."
+        )
+        form.addRow("Show findings:", self._validate_show)
+
+        self._validate_flag_todos = QCheckBox(
+            "Flag 'TODO' placeholder values as warnings"
+        )
+        self._validate_flag_todos.setToolTip(
+            "A BIDS Manager convention: the metadata engine writes the literal "
+            "string 'TODO' into missing recommended fields so you can find and "
+            "fill them. On by default. Turn it off for exact parity with the "
+            "standalone bidsval engine (which does not know this convention)."
+        )
+        form.addRow("TODO placeholders:", self._validate_flag_todos)
+
+        v.addWidget(box)
+
+        note = QLabel(
+            "The Editor's \"Deep checks\" toggle (read NIfTI headers and file "
+            "contents) lives in the Editor toolbar, since it is a per-run "
+            "choice. Validation results are written into the project's "
+            "<bids_root>/.bidsmgr/ folder, never into the BIDS tree."
+        )
+        note.setStyleSheet("color: #8b949e;")
+        note.setWordWrap(True)
+        v.addWidget(note)
         v.addStretch(1)
         return w
 
@@ -645,6 +732,14 @@ class SettingsDialog(QDialog):
         self._post_run_validate.setChecked(s.post_run_validate)
         self._post_validate_strict.setChecked(s.post_validate_strict)
         self._post_validate_html.setChecked(s.post_validate_html)
+
+        # Validation engine.
+        sidx = self._validate_schema.findData(s.validate_schema_version)
+        self._validate_schema.setCurrentIndex(sidx if sidx >= 0 else 0)
+        self._validate_max_rows.setValue(max(1, int(s.validate_max_rows)))
+        shidx = self._validate_show.findData(s.validate_show)
+        self._validate_show.setCurrentIndex(shidx if shidx >= 0 else 0)
+        self._validate_flag_todos.setChecked(s.validate_flag_todos)
 
         # Scan rules: rebuild both editable tables from the persisted lists
         # (clear first so Restore-defaults empties them).
@@ -709,6 +804,11 @@ class SettingsDialog(QDialog):
         s.post_run_validate = self._post_run_validate.isChecked()
         s.post_validate_strict = self._post_validate_strict.isChecked()
         s.post_validate_html = self._post_validate_html.isChecked()
+
+        s.validate_schema_version = self._validate_schema.currentData() or ""
+        s.validate_max_rows = self._validate_max_rows.value()
+        s.validate_show = self._validate_show.currentData() or "error_warning"
+        s.validate_flag_todos = self._validate_flag_todos.isChecked()
 
         s.save()
         self.accept()

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -1047,7 +1047,7 @@ QLabel#val-field {
     padding: 1px 6px;
 }
 QLabel#val-body  { color: $text; font-size: 11px; }
-QPushButton#val-fix {
+QPushButton#val-fix, QPushButton#val-highlight-all {
     background: $accent_bg;
     color: $accent;
     border: 1px solid $accent_border;
@@ -1055,7 +1055,7 @@ QPushButton#val-fix {
     padding: 1px 7px;
     font-size: 10px;
 }
-QPushButton#val-fix:hover { background: $accent; color: $primary_btn_text; }
+QPushButton#val-fix:hover, QPushButton#val-highlight-all:hover { background: $accent; color: $primary_btn_text; }
 
 /* ---------- Scrollbars ---------- */
 QScrollBar:vertical {

--- a/bidsmgr/gui/widgets/json_tree_view.py
+++ b/bidsmgr/gui/widgets/json_tree_view.py
@@ -56,6 +56,18 @@ log = logging.getLogger(__name__)
 # (and ignored for descendants) so the delegate can paint a colour bar.
 LEVEL_ROLE = Qt.ItemDataRole.UserRole + 5
 
+# Per-item findings highlight severity ("err" / "warn" / "focus"), stored on
+# top-level items so ``drawRow`` can tint the row (a QSS-styled tree ignores an
+# item's background brush, so we paint it ourselves, like the level bar).
+HIGHLIGHT_ROLE = Qt.ItemDataRole.UserRole + 6
+
+# Semi-transparent row tints; low alpha so the text stays readable over them.
+_HL_TINT: dict[str, "QColor"] = {
+    "err":   QColor(207, 34, 46, 78),
+    "warn":  QColor(191, 135, 0, 86),
+    "focus": QColor(79, 195, 247, 78),
+}
+
 # Map our short level codes to the palette token used for the bar.
 _LEVEL_TO_TOKEN: dict[str, str] = {
     "req": "error",
@@ -185,6 +197,14 @@ class JsonTreeView(QTreeWidget):
         super().drawRow(painter, options, index)
         if index.parent().isValid():
             return
+        # Findings highlight overlay (under the level bar, over the row text as a
+        # low-alpha tint) so it shows even though the tree is QSS-styled.
+        hl = index.data(HIGHLIGHT_ROLE)
+        hcolor = _HL_TINT.get(hl) if hl else None
+        if hcolor is not None:
+            painter.save()
+            painter.fillRect(options.rect, hcolor)
+            painter.restore()
         level = index.data(LEVEL_ROLE)
         token = _LEVEL_TO_TOKEN.get(level) if level else None
         if not token:
@@ -247,6 +267,19 @@ class JsonTreeView(QTreeWidget):
         finally:
             self._suppress = False
         self.resizeColumnToContents(0)
+
+    def set_highlights(self, severities: dict[str, str]) -> None:
+        """Tint top-level rows whose key is in ``severities`` ({name: sev});
+        clear the rest. Used by the Editor's fix / highlight-all actions."""
+        for i in range(self.topLevelItemCount()):
+            item = self.topLevelItem(i)
+            item.setData(0, HIGHLIGHT_ROLE, severities.get(item.text(0)) or None)
+        self.viewport().update()
+
+    def clear_highlights(self) -> None:
+        for i in range(self.topLevelItemCount()):
+            self.topLevelItem(i).setData(0, HIGHLIGHT_ROLE, None)
+        self.viewport().update()
 
     def to_dict(self) -> OrderedDict[str, Any]:
         """Read the tree back into a Python object (top-level dict).

--- a/bidsmgr/gui/widgets/sidecar_form_pane.py
+++ b/bidsmgr/gui/widgets/sidecar_form_pane.py
@@ -783,7 +783,7 @@ class SidecarFormPane(QWidget):
         if not name or self._json_cache is None:
             return False
         if self._view_mode == "tree":
-            return self._focus_field_in_tree(name)
+            return self._focus_field_in_tree(name, severity)
         return self._focus_field_in_form(name, severity)
 
     def highlight_fields(self, severities: dict[str, str]) -> int:
@@ -805,12 +805,15 @@ class SidecarFormPane(QWidget):
                     first = row
         if first is not None:
             self._scroll_widget_visible(first)
+        # Mirror onto the Tree view so the highlight shows in either mode.
+        self._tree_view.set_highlights(severities)
         return n
 
     def clear_field_highlights(self) -> None:
-        """Remove all row highlights."""
+        """Remove all row highlights (BIDS form + Tree view)."""
         for row in self._rows:
             row.set_highlight(None)
+        self._tree_view.clear_highlights()
 
     def _focus_field_in_form(self, name: str, severity: Optional[str] = None) -> bool:
         self.clear_field_highlights()
@@ -833,10 +836,13 @@ class SidecarFormPane(QWidget):
                 return True
         return False
 
-    def _focus_field_in_tree(self, name: str) -> bool:
+    def _focus_field_in_tree(self, name: str, severity: Optional[str] = None) -> bool:
         for i in range(self._tree_view.topLevelItemCount()):
             item = self._tree_view.topLevelItem(i)
             if item.text(0) == name:
+                # Tint this row (clears the others) so the jump is visible in
+                # the Tree view too.
+                self._tree_view.set_highlights({name: severity or "focus"})
                 self._tree_view.setCurrentItem(item)
                 self._tree_view.scrollToItem(item)
                 # Start editing the Value cell so the user can type

--- a/bidsmgr/gui/widgets/sidecar_form_pane.py
+++ b/bidsmgr/gui/widgets/sidecar_form_pane.py
@@ -771,34 +771,60 @@ class SidecarFormPane(QWidget):
     # View-mode toggle + tree handlers
     # ----------------------------------------------------------------------
 
-    def focus_field(self, name: str) -> bool:
-        """Scroll to and focus the editor for the field named ``name``.
+    def focus_field(self, name: str, severity: Optional[str] = None) -> bool:
+        """Scroll to, focus, and highlight the field named ``name``.
 
-        Works in both views — the BIDS form jumps to and focuses the
-        matching :class:`SidecarRow`; the Tree view selects the
-        matching top-level row and begins editing its Value cell.
-        Returns ``True`` if a matching field was found.
+        Works in both views — the BIDS form jumps to and highlights the
+        matching :class:`SidecarRow`; the Tree view selects the matching
+        top-level row and begins editing its Value cell. ``severity``
+        (``"err"`` / ``"warn"``) tints the row in that colour; ``None`` uses
+        the neutral focus tint. Returns ``True`` if a matching field was found.
         """
         if not name or self._json_cache is None:
             return False
         if self._view_mode == "tree":
             return self._focus_field_in_tree(name)
-        return self._focus_field_in_form(name)
+        return self._focus_field_in_form(name, severity)
 
-    def _focus_field_in_form(self, name: str) -> bool:
+    def highlight_fields(self, severities: dict[str, str]) -> int:
+        """Highlight every field in ``severities`` (``{name: "err"|"warn"}``).
+
+        Clears any prior highlights first, tints each matching row in its
+        severity colour, and scrolls the first one into view. Returns the
+        number of rows highlighted. Only meaningful in the BIDS form view.
+        """
+        self.clear_field_highlights()
+        first = None
+        n = 0
+        for row in self._rows:
+            sev = severities.get(row.key)
+            if sev:
+                row.set_highlight(sev)
+                n += 1
+                if first is None:
+                    first = row
+        if first is not None:
+            self._scroll_widget_visible(first)
+        return n
+
+    def clear_field_highlights(self) -> None:
+        """Remove all row highlights."""
+        for row in self._rows:
+            row.set_highlight(None)
+
+    def _focus_field_in_form(self, name: str, severity: Optional[str] = None) -> bool:
+        self.clear_field_highlights()
         for row in self._rows:
             if row.key == name:
-                # Scroll the row into view inside the QScrollArea
-                # parent. ``ensureWidgetVisible`` walks up to find the
-                # nearest scroll area for us.
+                row.set_highlight(severity or "focus")
+                # Scroll the row into view inside the QScrollArea parent.
                 editor = row.editor()
                 if editor is not None:
                     self._scroll_widget_visible(editor)
                     editor.setFocus(Qt.FocusReason.OtherFocusReason)
-                    # ``QLineEdit`` highlights its content on focus
-                    # when ``setFocus`` is called this way — gives the
-                    # user a clear visual cue + lets them type to
-                    # overwrite.
+                    # ``QLineEdit`` highlights its content on focus when
+                    # ``setFocus`` is called this way - a clear visual cue +
+                    # lets the user type to overwrite.
                     if hasattr(editor, "selectAll"):
                         editor.selectAll()
                 else:

--- a/bidsmgr/gui/widgets/sidecar_row.py
+++ b/bidsmgr/gui/widgets/sidecar_row.py
@@ -189,6 +189,14 @@ class SidecarRow(QFrame):
     # Public API
     # ------------------------------------------------------------------
 
+    # Semi-transparent row tints for highlighting findings. Chosen to read on
+    # both the dark and light palettes (low alpha over either background).
+    _HIGHLIGHT_BG: dict[str, str] = {
+        "err":   "rgba(207, 34, 46, 0.22)",
+        "warn":  "rgba(191, 135, 0, 0.26)",
+        "focus": "rgba(79, 195, 247, 0.22)",
+    }
+
     @property
     def key(self) -> str:
         return self._key
@@ -196,6 +204,18 @@ class SidecarRow(QFrame):
     @property
     def value_kind(self) -> str:
         return self._value_kind
+
+    def set_highlight(self, severity: Optional[str]) -> None:
+        """Tint the row to flag a finding (``"err"`` / ``"warn"`` / ``"focus"``)
+        or clear it (``None``). Scoped to ``#sc-row`` so it only paints this
+        row's background, leaving the level bar + value styling intact."""
+        color = self._HIGHLIGHT_BG.get(severity or "")
+        if color:
+            self.setStyleSheet(
+                f"QFrame#sc-row {{ background: {color}; border-radius: 4px; }}"
+            )
+        else:
+            self.setStyleSheet("")
 
     def editor(self) -> Optional[QWidget]:
         """Return the inline editor widget (or ``None`` for read-only rows)."""

--- a/bidsmgr/gui/widgets/tsv_viewer_pane.py
+++ b/bidsmgr/gui/widgets/tsv_viewer_pane.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Optional
 
 from PyQt6.QtCore import QAbstractTableModel, QModelIndex, Qt, pyqtSignal
+from PyQt6.QtGui import QBrush, QColor
 from PyQt6.QtWidgets import (
     QAbstractItemView,
     QFrame,
@@ -40,6 +41,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QPushButton,
     QStackedLayout,
+    QStyledItemDelegate,
     QTableView,
     QVBoxLayout,
     QWidget,
@@ -153,15 +155,37 @@ class _TsvTableModel(QAbstractTableModel):
     # Emitted on any user cell edit (the pane uses it for dirty tracking).
     cellEdited = pyqtSignal()
 
+    # Cell/column-highlight tints (semi-transparent; read on dark + light).
+    _HL_BRUSH: dict[str, QColor] = {
+        "err":   QColor(207, 34, 46, 120),
+        "warn":  QColor(191, 135, 0, 130),
+        "focus": QColor(79, 195, 247, 110),
+    }
+
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self._header: list[str] = []
         self._rows: list[list[str]] = []
+        # Findings highlighting: specific bad cells {(row, col): severity} take
+        # priority; whole columns {col: severity} cover column-level findings.
+        self._hl_cells: dict[tuple, str] = {}
+        self._hl_cols: dict[int, str] = {}
+
+    def set_highlights(self, cells: dict, cols: dict) -> None:
+        """Set ``{(row, col): sev}`` cells + ``{col: sev}`` columns and repaint."""
+        self._hl_cells = dict(cells)
+        self._hl_cols = dict(cols)
+        if self.rowCount() and self.columnCount():
+            top = self.index(0, 0)
+            bottom = self.index(self.rowCount() - 1, self.columnCount() - 1)
+            self.dataChanged.emit(top, bottom, [Qt.ItemDataRole.BackgroundRole])
 
     # --- data ----------------------------------------------------------
     def set_table(self, header, rows) -> None:
         """Replace the whole table (load / restore). Rectangular-padded."""
         self.beginResetModel()
+        self._hl_cells = {}
+        self._hl_cols = {}
         self._header = [str(h) for h in header]
         w = len(self._header)
         self._rows = []
@@ -193,6 +217,11 @@ class _TsvTableModel(QAbstractTableModel):
             if 0 <= r < len(self._rows) and 0 <= c < len(self._rows[r]):
                 return self._rows[r][c]
             return ""
+        if role == Qt.ItemDataRole.BackgroundRole:
+            sev = self._hl_cells.get((index.row(), index.column())) \
+                or self._hl_cols.get(index.column())
+            color = self._HL_BRUSH.get(sev) if sev else None
+            return QBrush(color) if color is not None else None
         return None
 
     def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):  # noqa: N802
@@ -258,6 +287,26 @@ class _TsvTableModel(QAbstractTableModel):
             self.endRemoveColumns()
 
 
+class _HighlightDelegate(QStyledItemDelegate):
+    """Paints the model's ``BackgroundRole`` brush behind a cell.
+
+    A QSS ``::item`` rule makes ``QTableView`` ignore the model's background
+    brush (the style draws the item), so findings highlights set on the model
+    never showed. This delegate fills the cell with the brush first, then lets
+    the default painter draw the (transparent-background) text + border on top.
+    Selected cells keep the selection colour (the brush is skipped then).
+    """
+
+    def paint(self, painter, option, index):  # noqa: N802
+        brush = index.data(Qt.ItemDataRole.BackgroundRole)
+        from PyQt6.QtWidgets import QStyle
+        if brush is not None and not (option.state & QStyle.StateFlag.State_Selected):
+            painter.save()
+            painter.fillRect(option.rect, brush)
+            painter.restore()
+        super().paint(painter, option, index)
+
+
 class TsvViewerPane(QWidget):
     """Editable table view for BIDS ``.tsv`` files."""
 
@@ -291,6 +340,10 @@ class TsvViewerPane(QWidget):
         # disabled so we never drop the tail rows).
         self._truncated_on_load: bool = False
         self._dirty = False
+        # Findings to highlight once the table is loaded: a list of
+        # ``(column_name, line, severity)`` set by the Editor's fix /
+        # highlight-all buttons. Applied on ``loaded`` (parsing is threaded).
+        self._pending_findings: list = []
         # Undo/redo of in-memory table edits (snapshot = (header, rows)).
         from .edit_history import SnapshotHistory
         self._history = SnapshotHistory()
@@ -376,9 +429,14 @@ class TsvViewerPane(QWidget):
         self._model = _TsvTableModel(self)
         self._model.cellEdited.connect(self._on_cell_edited)
         self._table.setModel(self._model)
+        # Paint findings highlights ourselves (QSS ::item styling otherwise makes
+        # the view ignore the model's background brush).
+        self._table.setItemDelegate(_HighlightDelegate(self._table))
         sel_model = self._table.selectionModel()
         if sel_model is not None:
             sel_model.currentChanged.connect(self._sync_delete_button_state)
+        # Apply any deferred findings highlight once the (threaded) load lands.
+        self.loaded.connect(lambda _p: self._apply_pending_highlights())
 
         self._empty_hint = QLabel(
             "Select a TSV file in the BIDS tree to view it."
@@ -437,6 +495,53 @@ class TsvViewerPane(QWidget):
     def is_dirty(self) -> bool:
         return self._dirty
 
+    def highlight_findings(self, items) -> None:
+        """Highlight TSV findings and scroll to the first.
+
+        ``items`` is a list of ``(column_name, line, severity)`` where ``line``
+        is the finding's 1-based row (including the header) or ``None`` for a
+        whole-column finding. Deferred until the (threaded) load lands, so the
+        Editor can call it right after switching to the TSV.
+        """
+        self._pending_findings = list(items or [])
+        self._apply_pending_highlights()
+
+    def clear_highlights(self) -> None:
+        self._pending_findings = []
+        self._model.set_highlights({}, {})
+
+    def _apply_pending_highlights(self) -> None:
+        items = self._pending_findings
+        if not items:
+            return
+        header = self._model.header()
+        if not header:
+            return  # not loaded yet - stay pending
+        nrows = self._model.rowCount()
+        cells: dict = {}
+        cols: dict = {}
+        first = None
+        for name, line, sev in items:
+            if name not in header:
+                continue
+            c = header.index(name)
+            if line is not None:
+                r = line - 2  # line is 1-based incl. header; data row 0 == line 2
+                if 0 <= r < nrows:
+                    cells[(r, c)] = sev
+                    if first is None:
+                        first = (r, c)
+            else:
+                cols[c] = sev
+                if first is None:
+                    first = (0, c)
+        if not cells and not cols:
+            return  # nothing resolved (e.g. not a column) - stay pending
+        self._model.set_highlights(cells, cols)
+        if first is not None:
+            self._table.scrollTo(self._model.index(*first))
+        self._pending_findings = []
+
     def set_file(
         self,
         path: Optional[Path],
@@ -455,6 +560,9 @@ class TsvViewerPane(QWidget):
         self._current_file = path
         self._current_root = root
         self._history.clear()
+        # A new selection invalidates any deferred highlight from a prior fix
+        # click (the Editor re-sets it after this returns when relevant).
+        self._pending_findings = []
         if path is None:
             self._reset_model()
             self._original_header = []

--- a/bidsmgr/gui/widgets/validation_pane.py
+++ b/bidsmgr/gui/widgets/validation_pane.py
@@ -40,6 +40,7 @@ from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QPushButton,
     QScrollArea,
     QVBoxLayout,
     QWidget,
@@ -130,6 +131,9 @@ class ValidationPane(QWidget):
     """
 
     fix_requested = pyqtSignal(object, str)  # (Path | None, field_name)
+    # Emitted by the File section's "Highlight in editor" button: highlight
+    # every shown error/warning field (JSON) or column (TSV) for this file.
+    highlight_all_requested = pyqtSignal(object)  # (Path | None)
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
@@ -212,8 +216,29 @@ class ValidationPane(QWidget):
     # Internals
     # ----------------------------------------------------------------------
 
+    @staticmethod
+    def _allowed_severities() -> set:
+        """Which severities to list, from the ``validate_show`` setting.
+
+        The tree badges + chips always show the full picture; this only
+        narrows the findings list so the user can focus on errors (or
+        warnings). Read fresh each render so a Settings change takes effect
+        on the next validation / file selection.
+        """
+        try:
+            from ...gui.app_settings import AppSettings
+            show = AppSettings.load().validate_show
+        except Exception:
+            show = "error_warning"
+        if show == "error":
+            return {Severity.ERR}
+        if show == "warning":
+            return {Severity.WARN}
+        return {Severity.ERR, Severity.WARN}
+
     def _render(self) -> None:
         """Tear down + rebuild the three sections from current state."""
+        self._allowed = self._allowed_severities()
         # Drop existing section widgets. ``setParent(None)`` is the
         # critical detach — otherwise the deleteLater is deferred and
         # the old sections paint over the new ones briefly.
@@ -289,6 +314,7 @@ class ValidationPane(QWidget):
             file_issues,
             empty_text=empty_text,
             target_file=self._current_file,
+            highlight_button=True,
         )
 
         # Section 4: schema audit (only when the current file has one).
@@ -305,14 +331,20 @@ class ValidationPane(QWidget):
         *,
         empty_text: str,
         target_file: Optional[Path] = None,
+        highlight_button: bool = False,
     ) -> None:
+        # Apply the "Show findings" severity filter (errors only / warnings
+        # only / both). The count chip + empty state reflect the filtered list.
+        allowed = getattr(self, "_allowed", {Severity.ERR, Severity.WARN})
+        issues = [i for i in issues if i.severity in allowed]
+
         section = QFrame()
         section.setObjectName("val-section")
         sl = QVBoxLayout(section)
         sl.setContentsMargins(0, 0, 0, 0)
         sl.setSpacing(6)
 
-        # Header row: title + count chip.
+        # Header row: title + (optional) highlight button + count chip.
         head = QHBoxLayout()
         head.setSpacing(10)
         head.setContentsMargins(0, 0, 0, 0)
@@ -320,6 +352,21 @@ class ValidationPane(QWidget):
         title_l.setObjectName("val-section-title")
         head.addWidget(title_l)
         head.addStretch(1)
+        # "Highlight in editor" — only on the File section, only when there are
+        # field/column findings to point at.
+        if highlight_button and target_file is not None and any(i.field for i in issues):
+            hl_btn = QPushButton("Highlight in editor")
+            # Distinct object name so it is not mistaken for a per-finding fix
+            # button (it carries the same styling token plus its own).
+            hl_btn.setObjectName("val-highlight-all")
+            hl_btn.setToolTip(
+                "Highlight every shown error / warning field (JSON) or column "
+                "(TSV) for this file in the editor."
+            )
+            hl_btn.clicked.connect(
+                lambda _=False, p=target_file: self.highlight_all_requested.emit(p)
+            )
+            head.addWidget(hl_btn)
         count_l = Chip(str(len(issues)), _count_chip_kind(issues))
         head.addWidget(count_l)
         sl.addLayout(head)

--- a/bidsmgr/workers/file_report.py
+++ b/bidsmgr/workers/file_report.py
@@ -49,11 +49,18 @@ class FileReportWorker(QThread):
         self,
         bids_root: Path,
         file_path: Path,
+        *,
+        schema: str | None = None,
+        max_rows: int = 1000,
+        flag_todos: bool = True,
         parent=None,
     ) -> None:
         super().__init__(parent)
         self._bids_root = Path(bids_root)
         self._file_path = Path(file_path)
+        self._schema = schema or None
+        self._max_rows = max_rows
+        self._flag_todos = flag_todos
 
     def run(self) -> None:
         from ..editor.validator import validate_file
@@ -69,7 +76,11 @@ class FileReportWorker(QThread):
             self.progress.emit(
                 f"Validating {self._file_path.relative_to(self._bids_root)}"
             )
-            verdict = validate_file(self._bids_root, self._file_path)
+            verdict = validate_file(
+                self._bids_root, self._file_path,
+                schema=self._schema, max_rows=self._max_rows,
+                flag_todos=self._flag_todos,
+            )
             self.progress.emit(
                 f"Validation done — severity {verdict.severity.value}"
             )
@@ -94,11 +105,18 @@ class FolderReportWorker(QThread):
         self,
         bids_root: Path,
         folder_path: Path,
+        *,
+        schema: str | None = None,
+        max_rows: int = 1000,
+        flag_todos: bool = True,
         parent=None,
     ) -> None:
         super().__init__(parent)
         self._bids_root = Path(bids_root)
         self._folder_path = Path(folder_path)
+        self._schema = schema or None
+        self._max_rows = max_rows
+        self._flag_todos = flag_todos
 
     def run(self) -> None:
         from ..editor.validator import validate_folder
@@ -115,7 +133,11 @@ class FolderReportWorker(QThread):
                 f"Validating folder "
                 f"{self._folder_path.relative_to(self._bids_root)}"
             )
-            verdicts = validate_folder(self._bids_root, self._folder_path)
+            verdicts = validate_folder(
+                self._bids_root, self._folder_path,
+                schema=self._schema, max_rows=self._max_rows,
+                flag_todos=self._flag_todos,
+            )
             self.progress.emit(
                 f"Folder validation done — {len(verdicts)} files checked"
             )

--- a/bidsmgr/workers/report.py
+++ b/bidsmgr/workers/report.py
@@ -49,11 +49,17 @@ class ReportWorker(QThread):
         bids_root: Path,
         *,
         strict: bool = False,
+        schema: str | None = None,
+        max_rows: int = 1000,
+        flag_todos: bool = True,
         parent=None,
     ) -> None:
         super().__init__(parent)
         self._bids_root = Path(bids_root)
         self._strict = strict
+        self._schema = schema or None
+        self._max_rows = max_rows
+        self._flag_todos = flag_todos
 
     def run(self) -> None:
         from ..editor import validate
@@ -67,7 +73,13 @@ class ReportWorker(QThread):
 
         try:
             self.progress.emit(f"Validating {self._bids_root}")
-            report = validate(self._bids_root, strict=self._strict)
+            report = validate(
+                self._bids_root,
+                strict=self._strict,
+                schema=self._schema,
+                max_rows=self._max_rows,
+                flag_todos=self._flag_todos,
+            )
             self.progress.emit(
                 f"Validation done: {report.counts.get('ok', 0)} ok, "
                 f"{report.counts.get('warn', 0)} warn, "

--- a/bidsmgr/workers/validate.py
+++ b/bidsmgr/workers/validate.py
@@ -39,6 +39,9 @@ class ValidateWorker(QThread):
         *,
         strict: bool = False,
         strict_warn: bool = False,
+        schema: str | None = None,
+        max_rows: int = 1000,
+        flag_todos: bool = True,
         html_report: bool = False,
         parent=None,
     ) -> None:
@@ -46,6 +49,9 @@ class ValidateWorker(QThread):
         self._target = Path(target)
         self._strict = strict
         self._strict_warn = strict_warn
+        self._schema = schema or None
+        self._max_rows = max_rows
+        self._flag_todos = flag_todos
         self._html_report = html_report
 
     def run(self) -> None:
@@ -64,6 +70,9 @@ class ValidateWorker(QThread):
                 self._target,
                 strict=self._strict,
                 strict_warn=self._strict_warn,
+                schema=self._schema,
+                max_rows=self._max_rows,
+                flag_todos=self._flag_todos,
                 html_report=self._html_report,
             )
             verdict = "clean" if rc == 0 else f"errored (rc={rc})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,13 @@ dependencies = [
     "bidsschematools>=1.0,<=1.2.2",
     "ancpbids>=0.3,<=0.3.1",
 
+    # BIDS validation engine. The Editor validator + ``bidsmgr-validate`` delegate
+    # to bidsval (schema-driven, pydantic-typed, false-positive-verified against
+    # the reference validator). It pulls only deps BIDS Manager already ships
+    # (bidsschematools, pydantic, nibabel, pandas, mne), so the footprint barely
+    # changes. 0.0.x is pre-1.0; allow patch releases, not a 0.1 minor bump.
+    "bidsval>=0.0.2,<0.1.0",
+
     # GUI.
     "pyqt6>=6.5,<=6.11.0",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.3"
+version = "1.2.4"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"

--- a/tests/gui/test_editor_validate.py
+++ b/tests/gui/test_editor_validate.py
@@ -296,9 +296,9 @@ def test_strict_toggle_drives_report_worker_strict_flag(
     captured: dict = {}
     real_init = report_mod.ReportWorker.__init__
 
-    def _spy_init(self, bids_root, *, strict=False, parent=None):
+    def _spy_init(self, bids_root, *, strict=False, parent=None, **kw):
         captured["strict"] = strict
-        return real_init(self, bids_root, strict=strict, parent=parent)
+        return real_init(self, bids_root, strict=strict, parent=parent, **kw)
 
     monkeypatch.setattr(report_mod.ReportWorker, "__init__", _spy_init)
 
@@ -323,9 +323,9 @@ def test_strict_toggle_off_passes_strict_false(
     captured: dict = {}
     real_init = report_mod.ReportWorker.__init__
 
-    def _spy_init(self, bids_root, *, strict=False, parent=None):
+    def _spy_init(self, bids_root, *, strict=False, parent=None, **kw):
         captured["strict"] = strict
-        return real_init(self, bids_root, strict=strict, parent=parent)
+        return real_init(self, bids_root, strict=strict, parent=parent, **kw)
 
     monkeypatch.setattr(report_mod.ReportWorker, "__init__", _spy_init)
 
@@ -338,17 +338,18 @@ def test_strict_toggle_off_passes_strict_false(
 
 
 def test_strict_button_has_tooltip(qapp, isolated_settings) -> None:
-    """Hovering the Strict toggle must surface explanatory text — a
-    user-facing description of what the second pass adds."""
+    """Hovering the Deep-checks toggle must surface explanatory text — a
+    user-facing description of what the deeper pass adds + when to use it."""
     from bidsmgr.gui.editor_panel import EditorPanel as _EP
 
     panel = _EP()
+    assert panel._strict_btn.text().strip() == "Deep checks"
     tip = panel._strict_btn.toolTip()
     assert tip
-    assert "bidsschematools" in tip
-    # Should mention the official Python BIDS validator and a hint
-    # about when to use it.
-    assert "official" in tip.lower()
+    # The deep pass reads file headers / contents; the tip should say so
+    # and hint at when to flip it on.
+    assert "header" in tip.lower()
+    assert "review" in tip.lower()
 
 
 def test_validate_report_severity_values_round_trip(qapp) -> None:

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -1,8 +1,19 @@
 """Unit tests for ``bidsmgr.editor.validator``.
 
-Synthetic BIDS trees, no real DICOMs, no dcm2niix. Each test builds a
-minimal directory shape with hand-written JSON and asserts on the
-:class:`ValidationReport` Pydantic structure that the GUI will consume.
+Validation is delegated to the standalone ``bidsval`` engine; this module is a
+thin adapter (``bidsmgr.editor._bidsval_adapter``) that maps bidsval's results
+into the GUI's :class:`bidsmgr.editor.types` shapes and adds the two BIDS
+Manager-native supplements bidsval does not produce: the sidecar form data
+(``sidecar_fields``) and TODO-placeholder findings.
+
+These tests assert on *behaviour* (severities, the report shape the GUI consumes,
+the supplements) rather than on bidsval's exact rule codes, so they stay robust
+across bidsval releases. Synthetic BIDS trees, no real DICOMs.
+
+Note on attribution: bidsval (and the BIDS spec) attach a data file's metadata
+findings to the data file itself (``*_bold.nii.gz``), not to its ``.json``
+sidecar. The sidecar form still shows which fields are missing because the
+adapter populates ``sidecar_fields`` on the ``.json`` verdict.
 """
 
 from __future__ import annotations
@@ -19,7 +30,7 @@ from bidsmgr.editor import (
     rollup_severity,
     validate,
 )
-from bidsmgr.editor.validator import _resolve_intended_for, _value_kind
+from bidsmgr.editor.bidsmgr_checks import infer_datatype_suffix, value_kind
 
 
 # ---------------------------------------------------------------------------
@@ -29,18 +40,13 @@ from bidsmgr.editor.validator import _resolve_intended_for, _value_kind
 
 def _write_pair(folder: Path, basename: str, *, sidecar: dict | None = None) -> None:
     folder.mkdir(parents=True, exist_ok=True)
-    (folder / f"{basename}.nii.gz").write_bytes(b"\x1f\x8b")
+    # A tiny non-empty payload so the data file is not flagged EMPTY_FILE.
+    (folder / f"{basename}.nii.gz").write_bytes(b"\x1f\x8b\x08\x00stub")
     (folder / f"{basename}.json").write_text(json.dumps(sidecar or {}, indent=2))
 
 
 def _make_dd(root: Path, *, name: str | None = None, extra: dict | None = None) -> Path:
-    """Write a minimal valid dataset_description.json."""
-    body = {
-        "Name": name or root.name,
-        "BIDSVersion": "1.10.0",
-        "DatasetType": "raw",
-        "GeneratedBy": [{"Name": "bidsmgr", "Version": "0.0.1"}],
-    }
+    body = {"Name": name or root.name, "BIDSVersion": "1.10.0"}
     if extra:
         body.update(extra)
     p = root / "dataset_description.json"
@@ -52,117 +58,61 @@ def _make_minimal_bids(tmp_path: Path) -> Path:
     root = tmp_path / "study"
     root.mkdir()
     _make_dd(root)
-
     sub = root / "sub-001"
-    _write_pair(sub / "anat", "sub-001_T1w",
-                sidecar={"AcquisitionTime": "120000"})
+    _write_pair(sub / "anat", "sub-001_T1w")
     _write_pair(sub / "func", "sub-001_task-rest_bold",
-                sidecar={"AcquisitionTime": "120500",
-                         "TaskName": "rest",
-                         "RepetitionTime": 2.0})
+                sidecar={"TaskName": "rest", "RepetitionTime": 2.0})
+    (sub / "func" / "sub-001_task-rest_events.tsv").write_text("onset\tduration\n0\t1\n")
     return root
 
 
 # ---------------------------------------------------------------------------
-# Top-level shape
+# Top-level shape (the contract the GUI binds to)
 # ---------------------------------------------------------------------------
 
 
 class TestValidateBasics:
     def test_returns_pydantic_report(self, tmp_path: Path) -> None:
-        root = _make_minimal_bids(tmp_path)
-        report = validate(root)
+        report = validate(_make_minimal_bids(tmp_path))
         assert isinstance(report, ValidationReport)
         assert report.bidsmgr_version
-        assert report.bids_version
+        assert report.bids_version          # filled from bidsval's schema
         assert report.generated_at
-        assert report.bids_root == root.resolve()
+        assert report.bids_root == (tmp_path / "study").resolve()
 
-    def test_minimal_dataset_has_no_errors(self, tmp_path: Path) -> None:
-        """A minimal valid dataset has no ERR-level issues. Some
-        recommended fields are still missing (no real DICOM-derived
-        metadata to fill), so severity is WARN, not OK — that's the
-        expected behavior on a hand-built fixture.
-        """
-        root = _make_minimal_bids(tmp_path)
-        report = validate(root)
-        assert report.counts["err"] == 0
-        # Required-field violations should be zero on this fixture.
+    def test_counts_have_the_three_keys(self, tmp_path: Path) -> None:
+        report = validate(_make_minimal_bids(tmp_path))
+        assert set(report.counts) >= {"ok", "warn", "err"}
+        assert all(isinstance(v, int) for v in report.counts.values())
+
+    def test_files_use_relative_paths(self, tmp_path: Path) -> None:
+        report = validate(_make_minimal_bids(tmp_path))
+        assert report.files  # at least one file walked
         for f in report.files:
-            assert all(
-                i.rule_id != "bids.required_sidecar_field_missing"
-                for i in f.issues
-            ), [(i.rule_id, i.message) for i in f.issues]
+            assert not f.path.is_absolute()
+            assert isinstance(f.severity, Severity)
 
     def test_raises_when_root_missing(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             validate(tmp_path / "no-such-dir")
 
-    def test_files_use_relative_paths(self, tmp_path: Path) -> None:
-        root = _make_minimal_bids(tmp_path)
-        report = validate(root)
-        for f in report.files:
-            # Path is relative to bids_root, never absolute.
-            assert not f.path.is_absolute()
-
 
 # ---------------------------------------------------------------------------
-# Dataset-root checks
+# Dataset-level checks
 # ---------------------------------------------------------------------------
 
 
-class TestDatasetRoot:
+class TestDatasetLevel:
     def test_missing_dataset_description_is_error(self, tmp_path: Path) -> None:
         root = tmp_path / "study"
         root.mkdir()
-        (root / "sub-001" / "anat").mkdir(parents=True)
         _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
         report = validate(root)
         assert report.severity is Severity.ERR
         assert any(
-            i.rule_id == "bids.missing_dataset_description"
+            "dataset_description" in i.message.lower()
             for i in report.dataset_issues
-        )
-
-    def test_invalid_json_dataset_description(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        (root / "dataset_description.json").write_text("{not json")
-        (root / "sub-001" / "anat").mkdir(parents=True)
-        _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
-        report = validate(root)
-        assert report.severity is Severity.ERR
-        dd_verdict = next(f for f in report.files if f.path.name == "dataset_description.json")
-        assert dd_verdict.severity is Severity.ERR
-
-    def test_dataset_description_missing_required_field(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        (root / "dataset_description.json").write_text(
-            json.dumps({"Name": "x"})  # no BIDSVersion
-        )
-        (root / "sub-001" / "anat").mkdir(parents=True)
-        _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
-        report = validate(root)
-        dd = next(f for f in report.files if f.path.name == "dataset_description.json")
-        assert dd.severity is Severity.ERR
-        assert any(i.field == "BIDSVersion" for i in dd.issues)
-
-    def test_dataset_description_todo_placeholder_is_warning(
-        self, tmp_path: Path,
-    ) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root, extra={"License": "TODO"})
-        (root / "sub-001" / "anat").mkdir(parents=True)
-        _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
-        report = validate(root)
-        dd = next(f for f in report.files if f.path.name == "dataset_description.json")
-        assert dd.severity is Severity.WARN
-        assert any(
-            i.rule_id == "bidsmgr.todo_placeholder" and i.field == "License"
-            for i in dd.issues
-        )
+        ), [(i.rule_id, i.message) for i in report.dataset_issues]
 
     def test_no_subjects_emits_dataset_warning(self, tmp_path: Path) -> None:
         root = tmp_path / "study"
@@ -170,234 +120,123 @@ class TestDatasetRoot:
         _make_dd(root)
         report = validate(root)
         assert any(
-            i.rule_id == "bidsmgr.no_subjects" for i in report.dataset_issues
-        )
+            "sub-" in i.message or "subject" in i.message.lower()
+            for i in report.dataset_issues
+        ), [(i.rule_id, i.message) for i in report.dataset_issues]
 
 
 # ---------------------------------------------------------------------------
-# Per-file sidecar audit + sidecar_fields population
+# Per-file findings + sidecar_fields supplement
 # ---------------------------------------------------------------------------
 
 
-class TestSidecarAudit:
-    def test_missing_required_field_is_error(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        # bold without RepetitionTime → schema flags as error.
-        _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
-                    sidecar={"TaskName": "rest"})  # no RepetitionTime
-        report = validate(root)
-        bold = next(
-            f for f in report.files if f.path.name.endswith("_bold.json")
-        )
-        assert bold.severity is Severity.ERR
-        assert any(
-            i.rule_id == "bids.required_sidecar_field_missing"
-            and i.field == "RepetitionTime"
-            for i in bold.issues
-        )
-
-    def test_repetition_time_satisfies_volume_timing_alternative(
-        self, tmp_path: Path,
-    ) -> None:
-        """Mutual-exclusivity: RepetitionTime present → no VolumeTiming flag."""
+class TestSidecarBehaviour:
+    def test_missing_required_field_flags_the_data_file(self, tmp_path: Path) -> None:
+        """A bold without RepetitionTime is an error on the data file, with the
+        offending field surfaced so the Editor's fix button can jump to it."""
         root = tmp_path / "study"
         root.mkdir()
         _make_dd(root)
         _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
-                    sidecar={"TaskName": "rest", "RepetitionTime": 2.0})
-        report = validate(root)
-        bold = next(
-            f for f in report.files if f.path.name.endswith("_bold.json")
+                    sidecar={"TaskName": "rest"})  # no RepetitionTime
+        (root / "sub-001" / "func" / "sub-001_task-rest_events.tsv").write_text(
+            "onset\tduration\n0\t1\n"
         )
-        assert all(
-            i.field != "VolumeTiming" for i in bold.issues
-        ), [(i.field, i.message) for i in bold.issues]
-
-    def test_canonical_field_names_in_messages(self, tmp_path: Path) -> None:
-        """fmap/phase2 wants ``EchoTime`` (the schema reports it as
-        ``EchoTime__fmap``). User-facing message must use the clean name.
-        """
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        _write_pair(root / "sub-001" / "fmap", "sub-001_phase2", sidecar={})
         report = validate(root)
-        phase = next(
-            f for f in report.files if f.path.name.endswith("_phase2.json")
+        data_file = next(
+            f for f in report.files if f.path.name.endswith("_bold.nii.gz")
         )
-        # No rule-decorated names anywhere.
-        for issue in phase.issues:
-            assert "__" not in issue.message
-            if issue.field:
-                assert "__" not in issue.field
-
-    def test_recommended_missing_is_warning(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        # dwi has recommended fields but no required ones.
-        _write_pair(root / "sub-001" / "dwi", "sub-001_dwi", sidecar={})
-        report = validate(root)
-        dwi = next(f for f in report.files if f.path.name.endswith("_dwi.json"))
-        assert dwi.severity is Severity.WARN
-        assert any(
-            i.rule_id == "bids.recommended_sidecar_field_missing"
-            for i in dwi.issues
-        )
+        assert data_file.severity is Severity.ERR
+        assert any(i.field == "RepetitionTime" for i in data_file.issues), \
+            [(i.rule_id, i.field) for i in data_file.issues]
 
     def test_sidecar_fields_populated_with_levels(self, tmp_path: Path) -> None:
-        """Every schema-defined field appears as a SidecarField row with
-        the right level."""
+        """The .json verdict carries the schema-aware form rows (present/missing
+        flagged per level) even though the metadata findings sit on the data
+        file."""
         root = tmp_path / "study"
         root.mkdir()
         _make_dd(root)
         _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
                     sidecar={"TaskName": "rest", "RepetitionTime": 2.0,
                              "MyCustom": 42})
+        (root / "sub-001" / "func" / "sub-001_task-rest_events.tsv").write_text(
+            "onset\tduration\n0\t1\n"
+        )
         report = validate(root)
-        bold = next(
+        bold_json = next(
             f for f in report.files if f.path.name.endswith("_bold.json")
         )
-        names = {sf.name: sf for sf in bold.sidecar_fields}
-        # Required fields present → level=REQUIRED, present=True.
+        names = {sf.name: sf for sf in bold_json.sidecar_fields}
+        assert names, "expected schema-aware sidecar_fields on the .json verdict"
         assert names["TaskName"].level is FieldLevel.REQUIRED
         assert names["TaskName"].present is True
         assert names["TaskName"].value == "rest"
-        # Custom keys appear as OPTIONAL.
+        # A custom key the schema doesn't know appears as OPTIONAL.
         assert names["MyCustom"].level is FieldLevel.OPTIONAL
         assert names["MyCustom"].value_kind == "number"
-        # Recommended fields that are missing still appear as rows.
-        assert "Instructions" in names
-        assert names["Instructions"].present is False
-        assert names["Instructions"].value_kind == "missing"
+        # At least one schema field is missing (a recommended row, not present).
+        assert any(not sf.present for sf in bold_json.sidecar_fields)
 
 
 class TestTodoPlaceholders:
-    def test_todo_in_sidecar_is_warning(self, tmp_path: Path) -> None:
+    def test_todo_in_sidecar_is_warning_on_the_json(self, tmp_path: Path) -> None:
         root = tmp_path / "study"
         root.mkdir()
         _make_dd(root)
         _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
                     sidecar={"TaskName": "rest", "RepetitionTime": 2.0,
                              "Instructions": "TODO"})
+        (root / "sub-001" / "func" / "sub-001_task-rest_events.tsv").write_text(
+            "onset\tduration\n0\t1\n"
+        )
         report = validate(root)
-        bold = next(
+        bold_json = next(
             f for f in report.files if f.path.name.endswith("_bold.json")
         )
-        assert bold.severity is Severity.WARN
-        todo_issues = [
-            i for i in bold.issues if i.rule_id == "bidsmgr.todo_placeholder"
+        todos = [
+            i for i in bold_json.issues if i.rule_id == "bidsmgr.todo_placeholder"
         ]
-        assert len(todo_issues) == 1
-        assert todo_issues[0].field == "Instructions"
+        assert len(todos) == 1
+        assert todos[0].field == "Instructions"
+        assert todos[0].severity is Severity.WARN
+        assert bold_json.severity is Severity.WARN
 
-
-class TestIntendedForResolution:
-    def test_unresolved_uri_is_error(self, tmp_path: Path) -> None:
+    def test_todo_in_dataset_description(self, tmp_path: Path) -> None:
         root = tmp_path / "study"
         root.mkdir()
-        _make_dd(root)
-        _write_pair(root / "sub-001" / "fmap", "sub-001_phasediff",
-                    sidecar={
-                        "EchoTime1": 0.005,
-                        "EchoTime2": 0.007,
-                        "IntendedFor": [
-                            "bids::sub-001/func/does-not-exist_bold.nii.gz",
-                        ],
-                    })
-        # add a func sibling so that fmap can theoretically point there
-        _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
-                    sidecar={"TaskName": "rest", "RepetitionTime": 2.0})
-        report = validate(root)
-        phasediff = next(
-            f for f in report.files if f.path.name.endswith("_phasediff.json")
-        )
-        assert phasediff.severity is Severity.ERR
-        assert any(
-            i.rule_id == "bids.intended_for_unresolved" for i in phasediff.issues
-        )
-
-    def test_resolvable_uri_is_ok(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        _write_pair(root / "sub-001" / "func", "sub-001_task-rest_bold",
-                    sidecar={"TaskName": "rest", "RepetitionTime": 2.0})
-        _write_pair(root / "sub-001" / "fmap", "sub-001_phasediff",
-                    sidecar={
-                        "EchoTime1": 0.005,
-                        "EchoTime2": 0.007,
-                        "IntendedFor": [
-                            "bids::sub-001/func/sub-001_task-rest_bold.nii.gz",
-                        ],
-                    })
-        report = validate(root)
-        phasediff = next(
-            f for f in report.files if f.path.name.endswith("_phasediff.json")
-        )
-        assert all(
-            i.rule_id != "bids.intended_for_unresolved" for i in phasediff.issues
-        )
-
-    def test_resolve_helper_handles_uri_form(self, tmp_path: Path) -> None:
-        bids = tmp_path / "study"
-        sidecar = bids / "sub-1" / "fmap" / "sub-1_phasediff.json"
-        target = bids / "sub-1" / "func" / "sub-1_task-rest_bold.nii.gz"
-        result = _resolve_intended_for(
-            "bids::sub-1/func/sub-1_task-rest_bold.nii.gz", sidecar, bids,
-        )
-        assert result == target
-
-    def test_resolve_helper_handles_legacy_relative(self, tmp_path: Path) -> None:
-        bids = tmp_path / "study"
-        sidecar = bids / "sub-1" / "ses-pre" / "fmap" / "sub-1_ses-pre_phasediff.json"
-        target = bids / "sub-1" / "ses-pre" / "func" / "sub-1_ses-pre_task-rest_bold.nii.gz"
-        # Legacy: relative to subject root.
-        result = _resolve_intended_for(
-            "ses-pre/func/sub-1_ses-pre_task-rest_bold.nii.gz", sidecar, bids,
-        )
-        assert result == target
-
-
-# ---------------------------------------------------------------------------
-# Layout checks
-# ---------------------------------------------------------------------------
-
-
-class TestLayoutChecks:
-    def test_unknown_datatype_dir_is_warning(self, tmp_path: Path) -> None:
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        # Standard subject + a stray "raw_dicoms" directory that isn't
-        # a known BIDS datatype.
+        _make_dd(root, extra={"License": "TODO"})
         _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
-        (root / "sub-001" / "raw_dicoms").mkdir()
-
         report = validate(root)
-        assert "sub-001" in report.folder_issues
-        assert any(
-            i.rule_id == "bids.unknown_datatype_dir"
-            for i in report.folder_issues["sub-001"]
+        dd = next(
+            f for f in report.files if f.path.name == "dataset_description.json"
         )
-
-    def test_dot_directories_are_silent(self, tmp_path: Path) -> None:
-        """Dot-prefixed dirs (.bidsmgr, .git) are not flagged as orphan."""
-        root = tmp_path / "study"
-        root.mkdir()
-        _make_dd(root)
-        _write_pair(root / "sub-001" / "anat", "sub-001_T1w")
-        # Add bookkeeping dirs that the validator should ignore.
-        (root / "sub-001" / ".bidsmgr").mkdir()
-        (root / "sub-001" / ".git").mkdir()
-        report = validate(root)
-        assert "sub-001" not in report.folder_issues
+        assert any(
+            i.rule_id == "bidsmgr.todo_placeholder" and i.field == "License"
+            for i in dd.issues
+        )
 
 
 # ---------------------------------------------------------------------------
-# Severity rollup
+# Deep checks (the repurposed ``strict`` flag -> read_headers)
+# ---------------------------------------------------------------------------
+
+
+class TestDeepChecks:
+    def test_strict_runs_without_crashing(self, tmp_path: Path) -> None:
+        report = validate(_make_minimal_bids(tmp_path), strict=True)
+        assert isinstance(report, ValidationReport)
+        assert set(report.counts) >= {"ok", "warn", "err"}
+
+    def test_schema_version_is_threaded(self, tmp_path: Path) -> None:
+        """An explicit schema selection is honoured (the report records the
+        BIDS version validated against)."""
+        report = validate(_make_minimal_bids(tmp_path), schema="1.11.0")
+        assert report.bids_version == "1.11.0"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -428,39 +267,16 @@ class TestValueKind:
         ({"a": 1}, "object"),
     ])
     def test_classification(self, value, expected) -> None:
-        assert _value_kind(value) == expected
+        assert value_kind(value) == expected
 
 
-# ---------------------------------------------------------------------------
-# Layer 2 — bidsschematools structural
-# ---------------------------------------------------------------------------
+class TestInferDatatypeSuffix:
+    def test_anat_t1w(self, tmp_path: Path) -> None:
+        root = tmp_path / "ds"
+        fp = root / "sub-001" / "anat" / "sub-001_T1w.nii.gz"
+        assert infer_datatype_suffix(fp, root) == ("anat", "T1w")
 
-
-class TestStrictMode:
-    def test_strict_runs_layer_2_without_raising(self, tmp_path: Path) -> None:
-        """Layer 2 runs without crashing on a well-formed dataset."""
-        root = _make_minimal_bids(tmp_path)
-        report = validate(root, strict=True)
-        # No bidsschematools-specific failures expected on a minimal tree.
-        assert all(
-            i.rule_id != "bidsmgr.bst_failed" for i in report.dataset_issues
-        )
-
-    def test_strict_off_does_not_emit_bst_issues(self, tmp_path: Path) -> None:
-        """Without --strict, no bidsschematools-derived issue ids appear."""
-        root = _make_minimal_bids(tmp_path)
-        report = validate(root, strict=False)
-        bst_rule_ids = {
-            "bids.unknown_path",
-            "bids.missing_mandatory_path",
-            "bidsmgr.bst_unavailable",
-            "bidsmgr.bst_failed",
-        }
-        for f in report.files:
-            for i in f.issues:
-                assert i.rule_id not in bst_rule_ids
-        for issue_list in report.folder_issues.values():
-            for i in issue_list:
-                assert i.rule_id not in bst_rule_ids
-        for i in report.dataset_issues:
-            assert i.rule_id not in bst_rule_ids
+    def test_func_bold_json(self, tmp_path: Path) -> None:
+        root = tmp_path / "ds"
+        fp = root / "sub-001" / "func" / "sub-001_task-rest_bold.json"
+        assert infer_datatype_suffix(fp, root) == ("func", "bold")


### PR DESCRIPTION
# BIDS Manager: delegate Editor validation to the standalone bidsval engine (v1.2.3 to v1.2.4)

## Summary

This PR brings `ANCPLabOldenburg/BIDS-Manager:main` from **v1.2.3 up to v1.2.4**.
It replaces BIDS Manager's in-house Editor validator with the standalone
**`bidsval`** package (schema-driven, pydantic-typed, false-positive-verified
against the official Deno reference validator) behind a thin adapter, so the GUI,
the workers, and the CLI keep their existing signatures while gaining bidsval's
broader coverage and actionable, fix-oriented guidance. A second validation
engine leaves the codebase.

Net change across the **3 commits**: **22 files, about +1,459 / -1,079 lines**.
The large deletion count is the old two-layer validator being removed:
`editor/validator.py` shrinks from a full engine to a thin adapter, and two new
focused modules take its place. The source branch
(`karellopez/BIDS-Manager:main`) is a clean content superset of upstream's
current `main` (merge base at v1.2.3, PR #170), so nothing else is rewritten.

The work stays inside the original architecture: the BIDS schema is the engine,
`editor/` remains Qt-free, `gui/` (plus the `workers/` thread bridge) is the only
Qt-coupled subtree, and there is no `Pipeline` orchestrator and no `core/`
package. One engine now backs both the Editor and the `bidsmgr-validate` CLI, so
they cannot drift.

## Highlights

1. Validation is delegated to `bidsval` (PyPI `bidsval`, repo
   `karellopez/bidsval`): a pure-Python, schema-driven validator that interprets
   the BIDS schema directly and is verified to never emit a false positive versus
   the Deno reference. BIDS Manager keeps only the two supplements bidsval does
   not produce.
2. The Editor's fix button now navigates to where you actually edit the problem:
   a JSON sidecar field, a data-file finding redirected to its `.json` sibling,
   or the specific offending TSV cell, with the field or cell tinted by severity.
3. A new "Highlight in editor" action tints every shown error or warning at once,
   across the schema form, the JSON Tree view, and TSV tables (including every
   bad cell in a flagged column, not just the first).
4. `strict` is repurposed to "Deep checks": the slow pass now reads NIfTI image
   headers and file contents (bidsval `read_headers`), while the fast structural
   pass powers live revalidation on edit.
5. A new Settings to Validation tab exposes the schema version, the max TSV rows
   scanned, a severity display filter, and a TODO-placeholder toggle, all
   threaded through every validation worker so the engine stays Qt-free.

## 1. Why delegate, and what bidsval is

The 0.x post-mortem warned against carrying bespoke reimplementations of things
the BIDS schema already describes. The in-house Editor validator had grown into a
second, partial validation engine (a hand-written layer 1 plus a
`bidsschematools.validate_bids` layer 2) that BIDS Manager had to maintain and
that still diverged from the reference validator in both directions.

`bidsval` is a standalone, pure-Python, schema-driven, pydantic-typed BIDS
validator (PyPI `bidsval`, repo `karellopez/bidsval`). It interprets the same
BIDS schema BIDS Manager already builds on, runs in-process (no Deno binary), and
is developed under a strict invariant: skip any rule it cannot determine, and
never emit a false positive versus the Deno reference. Delegating to it removes a
whole engine from BIDS Manager and upgrades coverage and message quality in one
move.

## 2. Engine: a thin adapter plus two BM-native supplements

- `editor/validator.py` is now a thin adapter. Its public API is unchanged:
  `validate(bids_root, *, strict=False, schema=None, max_rows=1000)`,
  `validate_file`, and `validate_folder` call `bidsval.validate` / `validate_file`
  and map the results into the GUI's `editor/types` shapes. The old two-layer
  validator and the `bidsschematools.validate_bids` pass are gone.
- New `editor/_bidsval_adapter.py` translates bidsval `Issue` objects into the
  Editor's `Finding` / `FileReport` shapes. Each bidsval `suggestion` (the "how to
  fix" text) is appended to the message. Metadata findings attach to the data file
  (`*_bold.nii.gz`) per the bidsval and BIDS data-file-centric model, and the
  adapter mirrors each data file's field-bearing findings onto its editable
  `.json` sibling (`Issue.mirrored=True`, so they are shown but not
  double-counted).
- New `editor/bidsmgr_checks.py` holds the two supplements bidsval does not
  produce: the schema-aware sidecar form fields (required, recommended, optional
  rows so the Editor can render and locate every field) and the BM-convention
  TODO-placeholder findings (the metadata engine writes literal `TODO` into
  missing recommended fields).
- Counts are now per-finding (every error or warning issue, matching bidsval),
  not per-file. `strict` is repurposed: `strict=True` runs bidsval `read_headers`
  (read NIfTI image headers and file contents, slower, "Deep checks"), while
  `strict=False` is the fast structural pass used for live revalidation.

## 3. Editor GUI: fix navigation and highlighting

- The "Strict BIDS" toggle is relabeled "Deep checks" (it reads NIfTI headers).
  The AppSettings key `editor_strict_validate` is kept for back-compat.
- The fix button navigates to where the problem is edited and tints it: a JSON
  field (focus the schema form row and tint it by severity), a data-file finding
  redirected to its `.json` sibling, and a TSV finding to the specific bad cell.
- A new "Highlight in editor" button in the Validation pane highlights every shown
  error or warning at once: form rows tint by severity, and TSV cells tint via a
  model background role painted by a highlight delegate (a QSS item rule otherwise
  drops the model brush).
- The JSON Tree view now highlights too. It custom-paints its rows, so a plain
  item brush was dropped; `json_tree_view.drawRow` now paints a severity-tinted
  row overlay driven by a highlight role, wired through the sidecar form's
  `highlight_fields` / `focus_field` / `clear_field_highlights`.
- TSV highlighting covers every bad cell in a column, not just the first. bidsval
  reports one finding per column (matching the Deno reference) but now carries all
  offending rows; `editor/types.Issue` gains a `lines` field, the adapter maps it,
  and the Editor expands a finding to all its rows. It falls back to the single
  `line` when an older bidsval without `lines` is installed.
- The severity display filter (`validate_show`) now applies to the tree dots, the
  status chips, and the Validation pane list together. The Issues dialog (opened
  from a status chip) lists every file that contains an issue of the clicked
  severity and shows only that severity's issues, skipping mirrors.

## 4. Settings: a Validation tab

A new Settings to Validation tab exposes:

- BIDS schema version bidsval validates against (blank uses bidsval's bundled
  default).
- Max TSV rows scanned per table (default 1000).
- A show-findings severity filter (`error_warning` / `error` / `warning`).
- A flag-TODO-placeholders toggle (on by default; turn it off for exact bidsval
  parity, since TODO flagging is a BM convention).

All four are threaded into every validation worker, so the engine stays Qt-free.

## 5. CLI

`bidsmgr-validate` delegates through the same adapter (one engine for the GUI and
the CLI) and gains `--schema`, `--max-rows`, and `--no-todo-warnings`; `--strict`
now means deep checks (read NIfTI headers). The post-convert chain passes the same
knobs. `html_report.render_html` and the `editor/types` GUI contract are
unchanged.

## 6. Packaging

- Adds the runtime dependency `bidsval>=0.0.2,<0.1.0`.
- Bumps the package version to `1.2.4`.

## 7. Architecture and design guards

- `editor/` stays Qt-free: the adapter and both supplement modules are pure Python
  and are shared by the GUI, the workers, and the CLI. bidsval is an ordinary
  external dependency.
- `gui/` remains the only Qt-coupled subtree, with `workers/` as the only other Qt
  importer (the QThread bridge). Settings knobs are passed as parameters into the
  workers rather than read from QSettings inside the engine.
- No new `core/` package and no `Pipeline` orchestrator. One validation engine now
  serves both the Editor and the CLI, so they cannot diverge.

## 8. Testing and verification

- `tests/unit/test_validator.py` is rewritten to the bidsval-backed behavior, and
  the Editor deep-checks toggle tests are updated. The unit suite (about 705
  tests) plus the targeted Editor, sidecar form and tree, TSV, validation, and
  settings GUI suites pass; ruff is clean on the changed files.
- Highlighting was confirmed by rendering the Editor with the theme applied (the
  Tree-view row overlay and the TSV cell tint both require the palette to be live).

## 9. Compatibility and migration notes

- New runtime dependency `bidsval>=0.0.2,<0.1.0` (installs from PyPI). A plain
  `pip install bids-manager` pulls it in.
- `--strict` (and the Editor's former "Strict BIDS" toggle) changed meaning: it is
  now "Deep checks" (reads NIfTI headers and file contents) rather than the old
  `bidsschematools.validate_bids` layer 2. The fast structural pass is the default
  and drives live revalidation. The `editor_strict_validate` settings key is kept.
- Finding counts are now per-finding (were per-file); this can change the numbers
  shown on the status chips for the same dataset. Mirrored sidecar findings are
  shown against the `.json` sibling but are not double-counted.
- New AppSettings keys: `validate_schema_version`, `validate_max_rows`,
  `validate_show`, `validate_flag_todos`. For exact bidsval parity (errors and
  warnings equal `bidsval` alone), turn off TODO flagging via the setting or
  `bidsmgr-validate --no-todo-warnings`.
- The `bidsval` `Issue.lines` field (all offending TSV cells in a column) is used
  when present and degrades gracefully to the single `line` on an older bidsval.

## Commit-by-commit reference (oldest first)

1. `bbd5b1b` feat(editor,validate): delegate validation to the bidsval engine plus Editor fix/highlight UX
2. `2ebd18e` feat(editor): highlight findings in the Tree view plus every bad TSV cell
3. `e0118f8` chore: bump version to 1.2.4
