### PR TITLE
chore: bump version to 1.2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.4"
+version = "1.2.4.1"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Ships the hardened BIDS-tree copy-path context menu plus the new "Open in Folder" action (PR #175).