### PR TITLE
feat(gui): round hover tooltips and add an Update notes card; bump to…

### DIFF
--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -1,4 +1,4 @@
-"""Round ``QComboBox`` popups application-wide.
+"""Round ``QComboBox`` popups and hover tooltips application-wide.
 
 Two things are needed for a combo dropdown to look like the header project
 menu (rounded corners, no square frame):
@@ -16,9 +16,14 @@ menu (rounded corners, no square frame):
    shows. Geometry is captured and restored around the flag change so the
    popup stays anchored under its combo.
 
-Defensive: any failure is swallowed so a dropdown can never be broken by
-this cosmetic pass. Call :func:`install` once, after the QApplication and
-theme are set up.
+The same filter also rounds hover tooltips: the ``QToolTip`` QSS carries a
+``border-radius`` but its ``QTipLabel`` window otherwise shows square OS
+corners, so it gets the identical frameless + translucent + shadowless
+treatment to stay consistent with the rounded GUI.
+
+Defensive: any failure is swallowed so a dropdown or tooltip can never be
+broken by this cosmetic pass. Call :func:`install` once, after the
+QApplication and theme are set up.
 """
 
 from __future__ import annotations
@@ -32,40 +37,52 @@ log = logging.getLogger(__name__)
 _FLAG = "_bidsmgr_round_popup"
 
 
-class _ComboPopupRounder(QObject):
-    """App event filter that rounds combo-popup container windows."""
+class _PopupRounder(QObject):
+    """App event filter that rounds combo-popup and tooltip windows."""
 
     def eventFilter(self, obj, event):  # noqa: N802 - Qt signature
         try:
-            if (
-                event.type() == QEvent.Type.Show
-                and obj.metaObject().className() == "QComboBoxPrivateContainer"
-                and not obj.property(_FLAG)
-            ):
-                obj.setProperty(_FLAG, True)
-                geo = obj.geometry()
+            if event.type() != QEvent.Type.Show or obj.property(_FLAG):
+                return False
+            cls = obj.metaObject().className()
+            if cls == "QComboBoxPrivateContainer":
                 obj.setObjectName("combo-popup")
-                obj.setWindowFlags(
-                    obj.windowFlags()
-                    | Qt.WindowType.FramelessWindowHint
-                    | Qt.WindowType.NoDropShadowWindowHint
-                )
-                obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-                obj.setGeometry(geo)
-                obj.show()  # re-show so the new window flags take effect
-        except Exception as exc:  # noqa: BLE001 - never break a dropdown
-            log.debug("combo popup round failed: %s", exc)
+                self._round(obj)
+            elif cls == "QTipLabel":
+                # Hover tooltips: same recipe so the QToolTip border-radius
+                # renders without square OS corners, matching the rounded GUI.
+                self._round(obj)
+        except Exception as exc:  # noqa: BLE001 - never break a popup/tooltip
+            log.debug("popup round failed: %s", exc)
         return False
 
+    @staticmethod
+    def _round(obj) -> None:
+        """Make *obj* a frameless, translucent, shadowless top-level window.
 
-_instance: _ComboPopupRounder | None = None
+        Geometry is captured and restored around the flag change so the popup
+        stays exactly where Qt placed it, then re-shown so the flags apply.
+        """
+        obj.setProperty(_FLAG, True)
+        geo = obj.geometry()
+        obj.setWindowFlags(
+            obj.windowFlags()
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.NoDropShadowWindowHint
+        )
+        obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        obj.setGeometry(geo)
+        obj.show()  # re-show so the new window flags take effect
 
 
-def install(app) -> _ComboPopupRounder:
-    """Install the combo-popup rounder on *app* (idempotent)."""
+_instance: _PopupRounder | None = None
+
+
+def install(app) -> _PopupRounder:
+    """Install the combo-popup / tooltip rounder on *app* (idempotent)."""
     global _instance
     if _instance is None:
-        _instance = _ComboPopupRounder(app)
+        _instance = _PopupRounder(app)
         app.installEventFilter(_instance)
     return _instance
 

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -68,6 +68,7 @@ QToolTip {
     background: $surface2;
     color: $text;
     border: 1px solid $border;
+    border-radius: 6px;
     padding: 4px 8px;
     font-size: 11px;
 }

--- a/bidsmgr/gui/welcome_panel.py
+++ b/bidsmgr/gui/welcome_panel.py
@@ -244,6 +244,7 @@ class WelcomePanel(QWidget):
         left.setSpacing(16)
         left.addWidget(self._build_create_card())
         left.addWidget(self._build_resources_card())
+        left.addWidget(self._build_updates_card())
         left.addStretch(1)
         right = QVBoxLayout()
         right.setSpacing(16)
@@ -359,6 +360,18 @@ class WelcomePanel(QWidget):
         lay.addWidget(sample)
         for text, url in _SAMPLE_DATASETS:
             lay.addWidget(self._link_label(text, url))
+        return card
+
+    def _build_updates_card(self) -> QFrame:
+        card, lay = _section_card(
+            "Update notes",
+            "See what changed in each release: new features, fixes, and "
+            "anything worth knowing before you upgrade.",
+        )
+        lay.addWidget(self._link_label(
+            "Read the update notes",
+            "https://ancplaboldenburg.github.io/bids_manager_documentation/updates.html",
+        ))
         return card
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.4.1"
+version = "1.2.4.2"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"

--- a/tests/gui/test_welcome.py
+++ b/tests/gui/test_welcome.py
@@ -147,13 +147,15 @@ def test_resources_card_lists_links(qtbot, isolated_settings) -> None:
     links = [
         l for l in panel.findChildren(QLabel) if l.objectName() == "welcome-link"
     ]
-    # 3 resource links + 4 sample datasets = 7 clickable links, all external.
-    assert len(links) == 7
+    # 3 resource links + 4 sample datasets + 1 update-notes link = 8 clickable
+    # links, all external.
+    assert len(links) == 8
     assert all(l.openExternalLinks() for l in links)
     hrefs = " ".join(l.text() for l in links)
     assert "bids_manager_documentation" in hrefs       # docs site
     assert "github.com/ANCPLabOldenburg" in hrefs       # source
     assert "cloud.uol.de" in hrefs                       # sample data
+    assert "updates.html" in hrefs                       # update notes
     # Raw URLs never show as the visible text — friendly labels only.
     assert ">Documentation website<" in hrefs
     assert ">MEG Elekta sample dataset<" in hrefs


### PR DESCRIPTION
… 1.2.4.2

GUI:
- Round hover tooltips to match the rounded GUI: add a border-radius to the QToolTip QSS and extend the app-wide popup rounder to give the tooltip window (QTipLabel) the same frameless + translucent + shadowless treatment the combo popups and context menus use, so the radius renders without a square OS frame.
- Add a small "Update notes" card to the Welcome home, below "Getting started", linking to the online release notes.

Tests:
- test_welcome: welcome-link count 7 -> 8, plus an updates.html assertion.