### PR TITLE
GPU 3-D volume rendering, worker-pool robustness, and rounded-popup fixes (v1.2.4.2 to v1.2.5.1)

### DIFF
--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -495,14 +495,38 @@ def _phase1_parallel_dcm2niix(
                     raise OperationCancelled("conversion cancelled by user")
                 out.append(_phase1_one(backends, t, staging))
         else:
-            parallel_backend = "threading" if len(parallel_tasks) < 4 else "loky"
-            gen = Parallel(
-                n_jobs=n_jobs, backend=parallel_backend, return_as="generator",
-            )(delayed(_phase1_one)(backends, t, staging) for t in parallel_tasks)
-            for res in gen:
-                out.append(res)
-                if is_cancelled(cancel_check):
-                    raise OperationCancelled("conversion cancelled by user")
+            from ..util.parallel import preferred_backend, run_parallel
+
+            # Few tasks aren't worth a process pool; otherwise use the fastest
+            # backend that works here (see bidsmgr.util.parallel — loky's
+            # workers die on Windows + Python 3.14).
+            if len(parallel_tasks) < 4:
+                parallel_backend = "threading"
+            else:
+                parallel_backend = preferred_backend() or "loky"
+
+            # Collect into a fresh list rather than straight into ``out``: a
+            # retry on the threading backend re-runs every task, and appending
+            # to ``out`` would leave the first attempt's partial results behind
+            # as duplicates.
+            def _collect(gen):
+                collected: list[ConvertResult] = []
+                for res in gen:
+                    collected.append(res)
+                    if is_cancelled(cancel_check):
+                        raise OperationCancelled("conversion cancelled by user")
+                return collected
+
+            out.extend(run_parallel(
+                lambda: (
+                    delayed(_phase1_one)(backends, t, staging)
+                    for t in parallel_tasks
+                ),
+                n_jobs=n_jobs,
+                consume=_collect,
+                backend=parallel_backend,
+                return_as="generator",
+            ))
 
     return out
 

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -47,7 +47,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 import pandas as pd
-from joblib import Parallel, delayed
+from joblib import delayed  # pools are built by bidsmgr.util.parallel
 
 import bidsmgr
 

--- a/bidsmgr/cli/convert.py
+++ b/bidsmgr/cli/convert.py
@@ -497,9 +497,9 @@ def _phase1_parallel_dcm2niix(
         else:
             from ..util.parallel import preferred_backend, run_parallel
 
-            # Few tasks aren't worth a process pool; otherwise use the fastest
-            # backend that works here (see bidsmgr.util.parallel — loky's
-            # workers die on Windows + Python 3.14).
+            # Few tasks aren't worth a process pool; otherwise take the fast
+            # one unless bidsmgr.util.parallel has already seen a pool die in
+            # this session (run_parallel falls back and remembers).
             if len(parallel_tasks) < 4:
                 parallel_backend = "threading"
             else:

--- a/bidsmgr/gui/app_settings.py
+++ b/bidsmgr/gui/app_settings.py
@@ -1,4 +1,4 @@
-"""Typed wrapper over ``QSettings`` for cross-platform persistence.
+r"""Typed wrapper over ``QSettings`` for cross-platform persistence.
 
 ``QSettings`` stores values per-platform in the right native location:
 

--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -31,8 +31,8 @@ from __future__ import annotations
 import logging
 import sys
 
-from PyQt6.QtCore import QEvent, QObject, QRectF, Qt
-from PyQt6.QtGui import QPainterPath, QRegion
+from PyQt6.QtCore import QEvent, QObject, Qt
+from PyQt6.QtGui import QRegion
 
 log = logging.getLogger(__name__)
 
@@ -104,15 +104,35 @@ def _mask(obj, radius: int = _RADIUS) -> None:
     No-op on macOS, where the translucent window already composites clean
     antialiased corners. Elsewhere this removes the corner pixels from the
     window so an uncomposited desktop cannot paint them black.
+
+    The region is assembled from two overlapping rectangles (a plus/cross
+    shape) plus four ``Ellipse`` corner regions. That is the precise way to
+    build a rounded-rect ``QRegion``: the earlier ``QPainterPath`` ->
+    ``toFillPolygon().toPolygon()`` route flattened the arcs to a coarse,
+    integer-rounded polygon, so a few desktop pixels still peeked through the
+    corners as black on uncomposited Windows / X11. Rectangles + ellipses give
+    exact corners with none of that residue.
     """
     if not _NEEDS_MASK:
         return
     rect = obj.rect()
-    if rect.width() <= 0 or rect.height() <= 0:
+    w, h = rect.width(), rect.height()
+    if w <= 0 or h <= 0:
         return
-    path = QPainterPath()
-    path.addRoundedRect(QRectF(rect), float(radius), float(radius))
-    obj.setMask(QRegion(path.toFillPolygon().toPolygon()))
+    x, y = rect.x(), rect.y()
+    r = max(0, min(radius, w // 2, h // 2))
+    if r == 0:
+        obj.clearMask()
+        return
+    d = 2 * r
+    Ellipse = QRegion.RegionType.Ellipse
+    region = QRegion(x + r, y, w - d, h)             # full-height centre band
+    region = region.united(QRegion(x, y + r, w, h - d))  # full-width centre band
+    region = region.united(QRegion(x, y, d, d, Ellipse))                  # top-left
+    region = region.united(QRegion(x + w - d, y, d, d, Ellipse))          # top-right
+    region = region.united(QRegion(x, y + h - d, d, d, Ellipse))          # bottom-left
+    region = region.united(QRegion(x + w - d, y + h - d, d, d, Ellipse))  # bottom-right
+    obj.setMask(region)
 
 
 _instance: _PopupRounder | None = None

--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -38,9 +38,23 @@ log = logging.getLogger(__name__)
 
 _FLAG = "_bidsmgr_round_popup"
 
-# Corner radius of the rounded popups. Keep in sync with the ``border-radius``
-# of ``QToolTip`` / ``QComboBox QAbstractItemView`` in theme.qss.
-_RADIUS = 6
+# Painted corner radius of each rounded surface, mirroring the ``border-radius``
+# in theme.qss: 6px for ``QToolTip`` but 8px for ``QComboBox QAbstractItemView``
+# and ``QMenu#rounded-menu``. They differ, so the mask must use the right base
+# per surface (a 6px mask on an 8px popup would leave the 6..8 corner ring
+# unclipped and black).
+_TOOLTIP_RADIUS = 6
+_POPUP_RADIUS = 8
+
+# The mask is specified in logical pixels and Qt rescales it to device pixels.
+# On HiDPI / fractionally-scaled Windows and X11 that rescale can land the
+# mask's arc a device pixel or two INSIDE the painted border-radius arc,
+# leaving a thin ring of the translucent (black) corner unclipped - the
+# "still a bit of black" sliver. Cutting the mask a couple of logical pixels
+# ROUNDER makes it a strict subset of the painted shape, so every pixel the
+# mask keeps is painted and none of the black corner survives. The only cost
+# is a cosmetically negligible clip of the outermost corner border.
+_MASK_CUSHION = 2
 
 # A translucent window only yields clean rounded corners where the platform
 # COMPOSITES it. macOS always does, so the corners there are transparent and
@@ -74,7 +88,9 @@ class _PopupRounder(QObject):
                 # Same recipe for both so the QSS border-radius renders
                 # without a square OS frame behind it.
                 self._round(obj)
-            _mask(obj)
+            # Tooltips paint at 6px, combo popups at 8px - mask each to match.
+            base = _TOOLTIP_RADIUS if cls == "QTipLabel" else _POPUP_RADIUS
+            _mask(obj, base)
         except Exception as exc:  # noqa: BLE001 - never break a popup/tooltip
             log.debug("popup round failed: %s", exc)
         return False
@@ -98,8 +114,13 @@ class _PopupRounder(QObject):
         obj.show()  # re-show so the new window flags take effect
 
 
-def _mask(obj, radius: int = _RADIUS) -> None:
-    """Clip *obj*'s window to a rounded rectangle.
+def _mask(obj, radius: int) -> None:
+    """Clip *obj*'s window to a rounded rectangle a touch rounder than the paint.
+
+    *radius* is the surface's PAINTED ``border-radius``; the mask itself is cut
+    at ``radius + _MASK_CUSHION`` so it stays a strict subset of the painted
+    shape (see ``_MASK_CUSHION``) and no black corner sliver can survive DPR
+    rescaling.
 
     No-op on macOS, where the translucent window already composites clean
     antialiased corners. Elsewhere this removes the corner pixels from the
@@ -120,7 +141,7 @@ def _mask(obj, radius: int = _RADIUS) -> None:
     if w <= 0 or h <= 0:
         return
     x, y = rect.x(), rect.y()
-    r = max(0, min(radius, w // 2, h // 2))
+    r = max(0, min(radius + _MASK_CUSHION, w // 2, h // 2))
     if r == 0:
         obj.clearMask()
         return
@@ -164,7 +185,7 @@ def round_menu(menu) -> None:
     # Same uncomposited-desktop guard as the tooltips: mask once the menu has
     # been laid out, so its corners can't paint black on Windows / X11.
     if _NEEDS_MASK:
-        menu.aboutToShow.connect(lambda m=menu: _mask(m, _RADIUS))
+        menu.aboutToShow.connect(lambda m=menu: _mask(m, _POPUP_RADIUS))
 
 
 __all__ = ["install", "round_menu"]

--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -29,12 +29,27 @@ QApplication and theme are set up.
 from __future__ import annotations
 
 import logging
+import sys
 
-from PyQt6.QtCore import QEvent, QObject, Qt
+from PyQt6.QtCore import QEvent, QObject, QRectF, Qt
+from PyQt6.QtGui import QPainterPath, QRegion
 
 log = logging.getLogger(__name__)
 
 _FLAG = "_bidsmgr_round_popup"
+
+# Corner radius of the rounded popups. Keep in sync with the ``border-radius``
+# of ``QToolTip`` / ``QComboBox QAbstractItemView`` in theme.qss.
+_RADIUS = 6
+
+# A translucent window only yields clean rounded corners where the platform
+# COMPOSITES it. macOS always does, so the corners there are transparent and
+# antialiased. On Windows and on X11/Wayland sessions without a compositor the
+# pixels outside the rounded border are left unpainted and come out BLACK —
+# the "picky black background" behind the rounded tooltip. Masking cuts those
+# pixels out of the window entirely so nothing can show through; the trade-off
+# is aliased (hard) edges, which is why macOS keeps the nicer translucent path.
+_NEEDS_MASK = sys.platform != "darwin"
 
 
 class _PopupRounder(QObject):
@@ -42,16 +57,24 @@ class _PopupRounder(QObject):
 
     def eventFilter(self, obj, event):  # noqa: N802 - Qt signature
         try:
-            if event.type() != QEvent.Type.Show or obj.property(_FLAG):
+            etype = event.type()
+            # Resize matters as much as Show: Qt REUSES one QTipLabel for every
+            # tooltip and just re-texts/resizes it, often without a fresh Show.
+            # A mask left at the previous tooltip's size would stop clipping
+            # the corners of a narrower one (black corners return) or clip the
+            # content of a wider one.
+            if etype not in (QEvent.Type.Show, QEvent.Type.Resize):
                 return False
             cls = obj.metaObject().className()
-            if cls == "QComboBoxPrivateContainer":
-                obj.setObjectName("combo-popup")
+            if cls not in ("QComboBoxPrivateContainer", "QTipLabel"):
+                return False
+            if etype == QEvent.Type.Show and not obj.property(_FLAG):
+                if cls == "QComboBoxPrivateContainer":
+                    obj.setObjectName("combo-popup")
+                # Same recipe for both so the QSS border-radius renders
+                # without a square OS frame behind it.
                 self._round(obj)
-            elif cls == "QTipLabel":
-                # Hover tooltips: same recipe so the QToolTip border-radius
-                # renders without square OS corners, matching the rounded GUI.
-                self._round(obj)
+            _mask(obj)
         except Exception as exc:  # noqa: BLE001 - never break a popup/tooltip
             log.debug("popup round failed: %s", exc)
         return False
@@ -73,6 +96,23 @@ class _PopupRounder(QObject):
         obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         obj.setGeometry(geo)
         obj.show()  # re-show so the new window flags take effect
+
+
+def _mask(obj, radius: int = _RADIUS) -> None:
+    """Clip *obj*'s window to a rounded rectangle.
+
+    No-op on macOS, where the translucent window already composites clean
+    antialiased corners. Elsewhere this removes the corner pixels from the
+    window so an uncomposited desktop cannot paint them black.
+    """
+    if not _NEEDS_MASK:
+        return
+    rect = obj.rect()
+    if rect.width() <= 0 or rect.height() <= 0:
+        return
+    path = QPainterPath()
+    path.addRoundedRect(QRectF(rect), float(radius), float(radius))
+    obj.setMask(QRegion(path.toFillPolygon().toPolygon()))
 
 
 _instance: _PopupRounder | None = None
@@ -101,6 +141,10 @@ def round_menu(menu) -> None:
         | Qt.WindowType.NoDropShadowWindowHint
     )
     menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+    # Same uncomposited-desktop guard as the tooltips: mask once the menu has
+    # been laid out, so its corners can't paint black on Windows / X11.
+    if _NEEDS_MASK:
+        menu.aboutToShow.connect(lambda m=menu: _mask(m, _RADIUS))
 
 
 __all__ = ["install", "round_menu"]

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -1211,3 +1211,14 @@ QWidget#nifti-canvas {
     background: #000000;
     border: none;
 }
+
+/* 3-D controls column — opaque so the black image canvas behind it never
+ * shows through (the scrollbar gutter used to read as a black stripe). The
+ * viewport is named from Python because a stylesheet can't select it. */
+QWidget#nifti-ctrl-slot,
+QScrollArea#nifti-ctrl-scroll,
+QWidget#nifti-ctrl-viewport,
+QWidget#nifti-3d-controls {
+    background: $surface2;
+    border: none;
+}

--- a/bidsmgr/gui/theme.qss
+++ b/bidsmgr/gui/theme.qss
@@ -1200,3 +1200,14 @@ QListWidget#welcome-recent::item:selected {
     background: $accent_bg;
     color: $accent;
 }
+
+/* ---------- NIfTI viewer image canvas ----------
+ * The visualization area only (2-D slice panels + the 3-D render pages).
+ * Pure black so scans read like a lightbox and match the GL clear colour;
+ * deliberately NOT #pane-dark, which other panels share. Child pages are
+ * plain QWidgets that paint no background, so this shows through. */
+QStackedWidget#nifti-canvas,
+QWidget#nifti-canvas {
+    background: #000000;
+    border: none;
+}

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -36,7 +36,8 @@ from typing import Optional
 
 import numpy as np
 from PyQt6.QtCore import Qt, QPoint, pyqtSignal
-from PyQt6.QtGui import QSurfaceFormat, QImage, QPainter, QColor, QFont
+from PyQt6.QtGui import (QSurfaceFormat, QImage, QPainter, QColor, QFont,
+                         QInputDevice)
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -670,6 +671,7 @@ class RaycastGLWidget(QOpenGLWidget):
         self._target = np.zeros(3, np.float32)
         self._last: Optional[QPoint] = None
         self._drag = "rotate"
+        self._wheel_accum = 0.0   # mouse-wheel sub-notch accumulator
 
         self.effect = EFFECT_FX[EFFECTS[DEFAULTS["effect"]]]   # shader fx of default
         self.thresh_lo = DEFAULTS["lo"] / 1000.0
@@ -1107,17 +1109,40 @@ class RaycastGLWidget(QOpenGLWidget):
 
     def wheelEvent(self, ev) -> None:
         ad, pd = ev.angleDelta(), ev.pixelDelta()
-        # Unified scroll magnitude in "notches": a mouse-wheel notch is ±1, a
-        # trackpad's many tiny events are fractional — so BOTH the zoom and the
-        # slice navigator scale with it and neither is hyper-sensitive. A mouse
-        # Shift+scroll is remapped to a *horizontal* scroll by many platforms,
-        # so read both axes (and pixelDelta as a trackpad fallback).
-        a = ad.y() or ad.x()
-        steps = (a / 120.0) if a != 0 else ((pd.y() or pd.x()) / 320.0)
+        # A real mouse wheel and a trackpad need different handling, and Linux
+        # (libinput/Wayland) muddies it — a mouse there can report its scroll
+        # as pixelDelta and/or fine-grained sub-notch angleDelta, which a
+        # magnitude-only path scales to nearly nothing (so the wheel "does not
+        # work"). Tell them apart by the pointing DEVICE type (Qt6):
+        #   * mouse  -> ONE discrete step per notch, accumulating sub-notch
+        #               deltas (angle in 1/8-degree units, else pixels).
+        #   * trackpad -> smooth, magnitude-scaled (never hyper-sensitive).
+        # A mouse Shift+scroll is remapped to a horizontal scroll by many
+        # platforms, so both axes are read.
+        trackpad = False
+        try:
+            dev = ev.pointingDevice()
+            trackpad = (dev is not None
+                        and dev.type() == QInputDevice.DeviceType.TouchPad)
+        except Exception:  # noqa: BLE001 - be safe on odd backends
+            trackpad = not pd.isNull()
+        if not trackpad:
+            angle = ad.y() or ad.x()
+            if angle != 0:
+                raw, thresh = float(angle), 120.0        # 1/8-degree, 120 = notch
+            else:
+                raw, thresh = float(pd.y() or pd.x()), 50.0
+            self._wheel_accum += raw
+            n = int(self._wheel_accum / thresh)          # whole notches
+            self._wheel_accum -= n * thresh
+            steps = float(n)
+        else:
+            raw = pd.y() or pd.x() or ad.y() or ad.x()
+            steps = raw / 300.0                          # trackpad: smooth
         if steps == 0.0:
             return
         if (ev.modifiers() & Qt.KeyboardModifier.ShiftModifier) and self.clip_active:
-            self.nudge_clip_pos(0.02 * steps)          # slice navigator
+            self.nudge_clip_pos(0.03 * steps)            # slice navigator
             return
         self._dist = float(np.clip(self._dist * (0.9 ** steps), 0.5, 12.0))  # zoom
         self.update()

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -36,8 +36,7 @@ from typing import Optional
 
 import numpy as np
 from PyQt6.QtCore import Qt, QPoint, pyqtSignal
-from PyQt6.QtGui import (QSurfaceFormat, QImage, QPainter, QColor, QFont,
-                         QInputDevice)
+from PyQt6.QtGui import QSurfaceFormat, QImage, QPainter, QColor, QFont
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -671,7 +670,6 @@ class RaycastGLWidget(QOpenGLWidget):
         self._target = np.zeros(3, np.float32)
         self._last: Optional[QPoint] = None
         self._drag = "rotate"
-        self._wheel_accum = 0.0   # mouse-wheel sub-notch accumulator
 
         self.effect = EFFECT_FX[EFFECTS[DEFAULTS["effect"]]]   # shader fx of default
         self.thresh_lo = DEFAULTS["lo"] / 1000.0
@@ -1109,40 +1107,22 @@ class RaycastGLWidget(QOpenGLWidget):
 
     def wheelEvent(self, ev) -> None:
         ad, pd = ev.angleDelta(), ev.pixelDelta()
-        # A real mouse wheel and a trackpad need different handling, and Linux
-        # (libinput/Wayland) muddies it — a mouse there can report its scroll
-        # as pixelDelta and/or fine-grained sub-notch angleDelta, which a
-        # magnitude-only path scales to nearly nothing (so the wheel "does not
-        # work"). Tell them apart by the pointing DEVICE type (Qt6):
-        #   * mouse  -> ONE discrete step per notch, accumulating sub-notch
-        #               deltas (angle in 1/8-degree units, else pixels).
-        #   * trackpad -> smooth, magnitude-scaled (never hyper-sensitive).
-        # A mouse Shift+scroll is remapped to a horizontal scroll by many
-        # platforms, so both axes are read.
-        trackpad = False
-        try:
-            dev = ev.pointingDevice()
-            trackpad = (dev is not None
-                        and dev.type() == QInputDevice.DeviceType.TouchPad)
-        except Exception:  # noqa: BLE001 - be safe on odd backends
-            trackpad = not pd.isNull()
-        if not trackpad:
-            angle = ad.y() or ad.x()
-            if angle != 0:
-                raw, thresh = float(angle), 120.0        # 1/8-degree, 120 = notch
-            else:
-                raw, thresh = float(pd.y() or pd.x()), 50.0
-            self._wheel_accum += raw
-            n = int(self._wheel_accum / thresh)          # whole notches
-            self._wheel_accum -= n * thresh
-            steps = float(n)
-        else:
-            raw = pd.y() or pd.x() or ad.y() or ad.x()
-            steps = raw / 300.0                          # trackpad: smooth
+        # Magnitude in "notches": a mouse-wheel notch is ±1, a trackpad's many
+        # tiny events are fractional — so zoom and slice-nav both scale with it
+        # and neither is hyper-sensitive.
+        a = ad.y() or ad.x()
+        steps = (a / 120.0) if a != 0 else ((pd.y() or pd.x()) / 320.0)
         if steps == 0.0:
             return
-        if (ev.modifiers() & Qt.KeyboardModifier.ShiftModifier) and self.clip_active:
-            self.nudge_clip_pos(0.03 * steps)            # slice navigator
+        # Slice navigator when the clip plane is active. Shift+wheel is the
+        # gesture, but X11 / macOS commonly remap Shift+vertical-wheel to a
+        # *horizontal* scroll and drop the Shift flag — so a purely horizontal
+        # scroll over the render also navigates the slice.
+        shift = bool(ev.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        horizontal = ((ad.x() != 0 and ad.y() == 0)
+                      or (pd.x() != 0 and pd.y() == 0))
+        if self.clip_active and (shift or horizontal):
+            self.nudge_clip_pos(0.02 * steps)            # slice navigator
             return
         self._dist = float(np.clip(self._dist * (0.9 ** steps), 0.5, 12.0))  # zoom
         self.update()

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -3,42 +3,40 @@
 Companion to :class:`bidsmgr.gui.widgets.NiftiViewerPane`. Renders the
 current volume with a single-pass OpenGL ray-caster — the technique
 MRIcroGL uses — with only the dependencies BIDS-Manager already ships
-(PyQt6 + PyOpenGL). No VTK, no WebGL, no new wheels.
+(PyQt6 + PyOpenGL). Cross-platform (macOS / Windows / Linux): the context
+is a portable OpenGL 3.3 core profile and every GL call goes through
+PyOpenGL, with no platform-specific paths.
 
-Rendering effects (``uEffect``), à la MRIcroGL's shader menu:
-    * **Surface** — matcap-lit iso-surface compositing (``Default.glsl``).
-    * **MIP**     — maximum-intensity projection (``MIP.glsl``).
-    * **Glass**   — translucent surface with a Fresnel rim (``Glass.glsl``).
-    * **X-ray**   — integrated attenuation (additive, see-through).
-    * **Edges**   — gradient-magnitude silhouettes (``Edges.glsl``).
+Effects (``uEffect``), matching MRIcroGL's Render menu — approximations of
+its ``Default`` / ``Matte`` / ``Glass`` / ``MIP`` / ``Edges`` /
+``OpacityPeeling`` / ``Shell`` / ``Tomography`` shaders using on-the-fly
+gradients:
+    0 Default · 1 Matte · 2 Glass · 3 X-ray · 4 MIP · 5 Edges ·
+    6 Opacity peeling · 7 Opacity peeling 2 · 8 Shell · 9 Topography
 
-Lighting is a **matcap** (material-capture) texture sampled by the
-view-space gradient normal — MRIcroGL's approach. Several studio materials
-are generated procedurally (Shiny White, Clay, Matte, Titanium, Gold, Blue).
+Lighting: matcap materials for the surface effects (Default/Topography/
+Edges) plus Phong ambient/diffuse/specular/shininess with a positionable
+light for the rest. An oblique clip plane (azimuth/elevation/depth/
+thickness) slices the volume; for the surface effects the exposed face is
+drawn as a smooth intensity cross-section *with depth* (dark structures
+such as the ventricles show volume, not a flat cut), while the transparent
+effects (Glass/X-ray/MIP/Edges) just clip.
 
-**Clip plane** (MRIcroGL ``applyClip``): an oblique plane set by Azimuth /
-Elevation / Depth / Thickness. Where the plane cuts through tissue the
-exposed face is drawn as a smooth *intensity slice* (like a 2-D cross-
-section) rather than a noisy interior iso-surface — the key to MRIcroGL's
-clean cut look.
+An orientation cube (S/I·A/P·L/R) is drawn in the corner (toggle with "O").
 
-Robustness: the GL context is created lazily and every GL entry point is
-guarded, so a missing driver / headless ``offscreen`` platform degrades to
-an inert widget instead of crashing. The last volume is retained so the
-render survives context loss (window detach / re-attach → ``initializeGL``
-re-runs and re-uploads it).
-
-Interaction: left-drag orbit · right/middle-drag pan · wheel zoom.
+GPU gate: :func:`gpu_available` reports whether an OpenGL 3.3 core context
+backed by real hardware exists; the pane hides all 3-D options when not.
 """
 
 from __future__ import annotations
 
+import ctypes
 import logging
 from typing import Optional
 
 import numpy as np
 from PyQt6.QtCore import Qt, QPoint
-from PyQt6.QtGui import QSurfaceFormat
+from PyQt6.QtGui import QSurfaceFormat, QImage, QPainter, QColor, QFont
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -56,12 +54,7 @@ log = logging.getLogger(__name__)
 
 
 def request_gl_format() -> QSurfaceFormat:
-    """Return (and register as default) an OpenGL 3.3 core surface format.
-
-    macOS only exposes the modern ``#version 330`` shading language through
-    a *core-profile* context; the compatibility profile is stuck at 2.1.
-    Register this before the ``QApplication`` is built. Safe to call twice.
-    """
+    """Return (and register as default) a portable OpenGL 3.3 core format."""
     fmt = QSurfaceFormat()
     fmt.setVersion(3, 3)
     fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
@@ -70,29 +63,113 @@ def request_gl_format() -> QSurfaceFormat:
     return fmt
 
 
+_GPU_CACHE: Optional[bool] = None
+
+
+def gpu_available() -> bool:
+    """True when an OpenGL 3.3-core context on real hardware is reachable.
+
+    Cross-platform probe (macOS/Windows/Linux): create a throwaway offscreen
+    context, confirm it reports >= 3.3, and reject known software rasterisers
+    (llvmpipe / softpipe / Microsoft GDI). Cached after the first call.
+    Requires a live ``QApplication`` — returns ``False`` if none exists yet.
+    """
+    global _GPU_CACHE
+    if _GPU_CACHE is not None:
+        return _GPU_CACHE
+    _GPU_CACHE = False
+    try:
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtGui import QOffscreenSurface, QOpenGLContext
+        if QApplication.instance() is None:
+            return False
+        fmt = request_gl_format()
+        surf = QOffscreenSurface()
+        surf.setFormat(fmt)
+        surf.create()
+        if not surf.isValid():
+            return False
+        ctx = QOpenGLContext()
+        ctx.setFormat(fmt)
+        if ctx.create() and ctx.makeCurrent(surf):
+            f = ctx.format()
+            from OpenGL import GL
+            renderer = (GL.glGetString(GL.GL_RENDERER) or b"").decode(errors="ignore")
+            ok = (f.majorVersion(), f.minorVersion()) >= (3, 3)
+            soft = any(s in renderer.lower()
+                       for s in ("llvmpipe", "softpipe", "software", "gdi generic"))
+            ctx.doneCurrent()
+            _GPU_CACHE = bool(ok and not soft)
+        surf.destroy()
+    except Exception as exc:  # noqa: BLE001
+        log.info("GPU probe failed (%s); hiding 3-D options.", exc)
+        _GPU_CACHE = False
+    return _GPU_CACHE
+
+
 # Effects (index == uEffect in the shader).
-EFFECTS = ["Surface", "MIP", "Glass", "X-ray", "Edges"]
+EFFECTS = ["Default", "Matte", "Glass", "X-ray", "MIP", "Edges",
+           "Opacity peeling", "Opacity peeling 2", "Shell", "Topography"]
+
+# Which control keys each effect uses (others are greyed out in the panel).
+# "overlay"/"overlaydepth" (the cut-face intensity slice) only appear for the
+# opaque surface effects where a cross-section reads sensibly.
+_COMMON = {"lo", "hi", "quality"}
+_OVERLAY = {"overlay", "overlaydepth"}
+EFFECT_PARAMS: dict[str, set] = {
+    "Default":           _COMMON | _OVERLAY | {"density", "light", "brighten",
+                                               "surface", "lightaz", "lightel"},
+    "Matte":             _COMMON | _OVERLAY | {"density", "ambient", "diffuse",
+                                               "specular", "shininess",
+                                               "lightaz", "lightel"},
+    "Glass":             _COMMON | {"specular", "shininess", "edgethresh",
+                                    "boundthresh", "edgemix", "colortemp",
+                                    "lightaz", "lightel"},
+    "X-ray":             _COMMON | {"density"},
+    "MIP":               _COMMON,
+    "Edges":             _COMMON | {"density", "light", "brighten", "surface",
+                                    "boundthresh", "edgethresh", "edgemix",
+                                    "lightaz", "lightel"},
+    "Opacity peeling":   _COMMON | {"density", "ambient", "diffuse", "specular",
+                                    "shininess", "peel", "tlow", "thigh",
+                                    "lightaz", "lightel"},
+    "Opacity peeling 2": _COMMON | {"density", "ambient", "diffuse", "specular",
+                                    "shininess", "peel", "tlow", "thigh",
+                                    "lightaz", "lightel"},
+    "Shell":             _COMMON | {"boundthresh", "edgethresh", "edgemix",
+                                    "colortemp", "specular", "lightaz", "lightel"},
+    "Topography":        _COMMON | _OVERLAY | {"density", "light", "brighten",
+                                               "surface", "gradientmix",
+                                               "intensitymix", "hardness",
+                                               "lightaz", "lightel"},
+}
+# Effects whose cut-face intensity slice is ON by default.
+SLICE_DEFAULT_ON = {"Default", "Matte", "Topography"}
 
 # Matcap "lighting" materials: (ambient, key, fill, spec_power, spec_int, tint).
 _LIGHTINGS: dict[str, tuple] = {
-    "Shiny White": (0.34, 0.78, 0.26, 90.0, 1.05, (1.00, 0.99, 0.97)),
+    "Shiny White": (0.32, 0.90, 0.24, 55.0, 1.55, (1.00, 0.98, 0.95)),
     "Clay":        (0.38, 0.64, 0.28, 12.0, 0.16, (0.86, 0.78, 0.70)),
-    "Matte":       (0.48, 0.54, 0.32,  4.0, 0.00, (0.82, 0.82, 0.84)),
+    "Bone":        (0.40, 0.66, 0.26, 28.0, 0.35, (0.94, 0.91, 0.84)),
     "Titanium":    (0.24, 0.82, 0.22, 96.0, 0.95, (0.72, 0.75, 0.80)),
     "Gold":        (0.30, 0.74, 0.22, 44.0, 0.85, (0.96, 0.80, 0.36)),
     "Blue":        (0.30, 0.68, 0.28, 34.0, 0.60, (0.56, 0.69, 0.96)),
 }
 LIGHTINGS = list(_LIGHTINGS)
 
-# Default control values (used by "Reset parameters").
+# Default control values ("Reset parameters"). Quality defaults to the max.
 DEFAULTS = dict(
-    effect=0, light=0, lo=120, hi=420, den=100, bright=140, surf=65, q=512,
-    clip=False, az=0, el=0, depth=500, thick=1000,
+    effect=0, light=0, lo=100, hi=420, density=100, brighten=150, surface=70,
+    ambient=60, diffuse=55, specular=30, shininess=40,
+    boundthresh=30, edgethresh=12, edgemix=65, colortemp=50,
+    gradientmix=60, intensitymix=35, hardness=50,
+    peel=1, tlow=25, thigh=85, lightaz=210, lightel=40, overlay=True, overlaydepth=40,
+    quality=1024, clip=False, clipaz=0, clipel=0, depth=500, thick=1000, cube=True,
 )
 
 
 # --------------------------------------------------------------------------
-# Volume normalisation + matrix helpers
+# Volume normalisation + geometry helpers
 # --------------------------------------------------------------------------
 
 def normalize_to_u8(vol: np.ndarray) -> np.ndarray:
@@ -115,9 +192,16 @@ def clip_normal_from(az_deg: float, el_deg: float) -> tuple[float, float, float]
     """Unit clip-plane normal from azimuth/elevation (RAS texcoord space)."""
     az, el = np.radians(az_deg), np.radians(el_deg)
     ce = np.cos(el)
-    n = np.array([ce * np.sin(az), ce * np.cos(az), np.sin(el)], np.float32)
-    n = _normalize(n)
+    n = _normalize(np.array([ce * np.sin(az), ce * np.cos(az), np.sin(el)], np.float32))
     return float(n[0]), float(n[1]), float(n[2])
+
+
+def light_dir_view(az_deg: float, el_deg: float) -> tuple[float, float, float]:
+    """Light direction in view space (x right, y up, z toward camera)."""
+    az, el = np.radians(az_deg), np.radians(el_deg)
+    ce = np.cos(el)
+    d = _normalize(np.array([ce * np.sin(az), np.sin(el), ce * np.cos(az)], np.float32))
+    return float(d[0]), float(d[1]), float(d[2])
 
 
 def _perspective(fovy_deg: float, aspect: float, near: float, far: float) -> np.ndarray:
@@ -128,6 +212,15 @@ def _perspective(fovy_deg: float, aspect: float, near: float, far: float) -> np.
     m[2, 2] = (far + near) / (near - far)
     m[2, 3] = (2.0 * far * near) / (near - far)
     m[3, 2] = -1.0
+    return m
+
+
+def _ortho(r: float, t: float, n: float, f: float) -> np.ndarray:
+    m = np.eye(4, dtype=np.float32)
+    m[0, 0] = 1.0 / r
+    m[1, 1] = 1.0 / t
+    m[2, 2] = -2.0 / (f - n)
+    m[2, 3] = -(f + n) / (f - n)
     return m
 
 
@@ -146,15 +239,7 @@ def _look_at(eye: np.ndarray, center: np.ndarray, up: np.ndarray) -> np.ndarray:
 
 
 def _make_matcap(name: str, size: int = 256) -> np.ndarray:
-    """Procedural studio-lit sphere → an RGB matcap (``size×size×3`` uint8).
-
-    A matcap encodes the shaded appearance of a unit sphere: for a screen-
-    space normal ``(nx, ny)`` the lit colour is read straight out of this
-    image. Two directional lights + ambient + a Blinn-Phong highlight give
-    MRIcroGL's soft "clay / shiny / metal" looks — parameterised per material
-    in :data:`_LIGHTINGS`. A broad soft key plus a tight bright hotspot give
-    "Shiny White" the glossy sheen MRIcroGL's default has.
-    """
+    """Procedural studio-lit sphere → an RGB matcap (``size×size×3`` uint8)."""
     amb, key_i, fill_i, spow, spec_i, tint = _LIGHTINGS[name]
     ax = np.linspace(-1.0, 1.0, size, dtype=np.float32)
     u, v = np.meshgrid(ax, ax)
@@ -162,18 +247,14 @@ def _make_matcap(name: str, size: int = 256) -> np.ndarray:
     inside = r2 <= 1.0
     z = np.sqrt(np.clip(1.0 - r2, 0.0, 1.0))
     n = np.stack([u, v, z], axis=-1)
-
     key = _normalize(np.array([0.35, 0.55, 0.75], np.float32))
     fill = _normalize(np.array([-0.6, 0.10, 0.55], np.float32))
     view = np.array([0.0, 0.0, 1.0], np.float32)
     half = _normalize(key + view)
-
     ndl_key = np.clip((n * key).sum(-1), 0.0, 1.0)
     ndl_fill = np.clip((n * fill).sum(-1), 0.0, 1.0)
     nh = np.clip((n * half).sum(-1), 0.0, 1.0)
-    spec = nh ** spow + 0.25 * (nh ** (spow * 0.25))   # tight hotspot + soft sheen
-
-    # Wrap-diffuse (soft terminator) reads more like MRIcroGL than hard N·L.
+    spec = nh ** spow + 0.25 * (nh ** (spow * 0.25))
     wrap = np.clip((ndl_key + 0.35) / 1.35, 0.0, 1.0)
     lum = amb + key_i * wrap + fill_i * ndl_fill
     col = lum[..., None] * np.array(tint, np.float32)
@@ -181,6 +262,66 @@ def _make_matcap(name: str, size: int = 256) -> np.ndarray:
     col = np.clip(col, 0.0, 1.0)
     col[~inside] = 0.0
     return (col * 255.0).astype(np.uint8)
+
+
+def _make_cube_atlas(size: int = 96) -> np.ndarray:
+    """Render the 6 orientation letters into a 3×2 RGBA atlas (numpy)."""
+    letters = [["R", "A", "S"], ["L", "P", "I"]]
+    img = QImage(size * 3, size * 2, QImage.Format.Format_RGBA8888)
+    img.fill(QColor(38, 44, 54))
+    p = QPainter(img)
+    f = QFont()
+    f.setPixelSize(int(size * 0.6))
+    f.setBold(True)
+    p.setFont(f)
+    p.setPen(QColor(235, 240, 248))
+    for row in range(2):
+        for col in range(3):
+            rect = img.rect().adjusted(col * size, row * size, 0, 0)
+            rect.setWidth(size)
+            rect.setHeight(size)
+            p.drawText(rect, Qt.AlignmentFlag.AlignCenter, letters[row][col])
+    p.end()
+    img = img.mirrored(False, True)  # flip for GL bottom-up texture coords
+    ptr = img.constBits()
+    ptr.setsize(img.sizeInBytes())
+    arr = np.frombuffer(ptr, np.uint8).reshape(img.height(), img.width(), 4).copy()
+    return arr
+
+
+def _cube_geometry() -> np.ndarray:
+    """Interleaved [pos3, normal3, uv2] for a labelled orientation cube.
+
+    Atlas cells (3×2): R A S / L P I. Each face's in-plane "up" axis is chosen
+    so the letter reads upright when that face points at the viewer — S
+    (superior, +Z) for the four side faces, A (anterior, +Y) for top/bottom.
+    Depth testing (not culling) resolves visibility, so winding is free.
+    """
+    cells = {"R": (0, 0), "A": (1, 0), "S": (2, 0), "L": (0, 1), "P": (1, 1), "I": (2, 1)}
+    faces = [
+        ("R", (1, 0, 0), (0, 0, 1)),
+        ("L", (-1, 0, 0), (0, 0, 1)),
+        ("A", (0, 1, 0), (0, 0, 1)),
+        ("P", (0, -1, 0), (0, 0, 1)),
+        ("S", (0, 0, 1), (0, 1, 0)),
+        ("I", (0, 0, -1), (0, 1, 0)),
+    ]
+    verts = []
+    for letter, nrm, up in faces:
+        n = np.array(nrm, np.float32)
+        upv = np.array(up, np.float32)
+        right = np.cross(upv, n)
+        col, vrow = cells[letter]
+        u0, v0 = col / 3.0, (1 - vrow) * 0.5   # atlas flipped: row 0 -> high v
+
+        def corner(iu, iv):
+            pos = n + (2 * iu - 1) * right + (2 * iv - 1) * upv
+            return [*pos, *nrm, u0 + iu / 3.0, v0 + iv * 0.5]
+
+        c = [corner(0, 0), corner(1, 0), corner(1, 1), corner(0, 1)]
+        for a, b, d in ((0, 1, 2), (0, 2, 3)):
+            verts += [c[a], c[b], c[d]]
+    return np.array(verts, np.float32)
 
 
 # --------------------------------------------------------------------------
@@ -208,47 +349,48 @@ uniform mat4  uInvViewProj;
 uniform mat3  uNormalMatrix;
 uniform vec3  uBoxHalf;
 uniform vec3  uTexSize;
-uniform int   uEffect;         // 0 Surface, 1 MIP, 2 Glass, 3 X-ray, 4 Edges
-uniform float uThreshLo;
-uniform float uThreshHi;
-uniform float uDensity;
-uniform float uBrighten;
-uniform float uSurface;
+uniform int   uEffect;
+uniform float uThreshLo, uThreshHi, uDensity;
+uniform float uBrighten, uSurface;
+uniform float uAmbient, uDiffuse, uSpecular, uShininess;
+uniform float uBoundThresh, uEdgeThresh, uEdgeMix, uColorTemp;
+uniform float uGradientMix, uIntensityMix, uHardness;
+uniform int   uPeel; uniform float uTlow, uThigh;
+uniform vec3  uLightDir;
 uniform int   uSteps;
 uniform vec3  uBg;
 uniform int   uClipActive;
 uniform vec3  uClipNormal;
-uniform float uClipDepth;      // signed distance of the near cut plane
-uniform float uClipThick;      // slab thickness removed
+uniform float uClipDepth, uClipThick;
+uniform int   uSliceOverlay;   // draw the cut face as an intensity slice
+uniform float uSliceDepth;     // 0..1 -> how deep the slice integrates
 
-bool intersectBox(vec3 ro, vec3 rd, out float tNear, out float tFar) {
+bool intersectBox(vec3 ro, vec3 rd, out float tN, out float tF) {
     vec3 inv = 1.0 / rd;
-    vec3 t0 = (-uBoxHalf - ro) * inv;
-    vec3 t1 = ( uBoxHalf - ro) * inv;
-    vec3 tsm = min(t0, t1), tbg = max(t0, t1);
-    tNear = max(max(tsm.x, tsm.y), tsm.z);
-    tFar  = min(min(tbg.x, tbg.y), tbg.z);
-    return tFar >= max(tNear, 0.0);
+    vec3 t0 = (-uBoxHalf - ro) * inv, t1 = (uBoxHalf - ro) * inv;
+    vec3 a = min(t0, t1), b = max(t0, t1);
+    tN = max(max(a.x, a.y), a.z);
+    tF = min(min(b.x, b.y), b.z);
+    return tF >= max(tN, 0.0);
 }
-
-float samp(vec3 uvw) { return texture(uVol, uvw).r; }
-
-bool clipped(vec3 uvw) {
+float samp(vec3 p) { return texture(uVol, p).r; }
+bool clipped(vec3 p) {
     if (uClipActive == 0) return false;
-    float sd = dot(uClipNormal, uvw - vec3(0.5));
+    float sd = dot(uClipNormal, p - vec3(0.5));
     return sd > uClipDepth && sd < uClipDepth + uClipThick;
 }
-
-vec3 gradient(vec3 uvw) {
+vec3 grad(vec3 p) {
     vec3 e = 1.0 / uTexSize;
-    return vec3(
-        samp(uvw + vec3(e.x, 0, 0)) - samp(uvw - vec3(e.x, 0, 0)),
-        samp(uvw + vec3(0, e.y, 0)) - samp(uvw - vec3(0, e.y, 0)),
-        samp(uvw + vec3(0, 0, e.z)) - samp(uvw - vec3(0, 0, e.z)));
+    return vec3(samp(p+vec3(e.x,0,0))-samp(p-vec3(e.x,0,0)),
+                samp(p+vec3(0,e.y,0))-samp(p-vec3(0,e.y,0)),
+                samp(p+vec3(0,0,e.z))-samp(p-vec3(0,0,e.z)));
 }
-
-float hash(vec2 p) {
-    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+float hash(vec2 p){ return fract(sin(dot(p, vec2(12.9898,78.233)))*43758.5453); }
+vec3 tempTint(float t){
+    vec3 c = vec3(1.0);
+    if (t < 0.5) { c.b = 1.0+(0.5-t); c.r = 1.0-(0.5-t)*0.6; }
+    else         { c.r = 1.0+(t-0.5); c.b = 1.0-(t-0.5)*0.6; }
+    return clamp(c, 0.0, 1.4);
 }
 
 void main() {
@@ -256,101 +398,192 @@ void main() {
     vec4 pf = uInvViewProj * vec4(vNdc,  1.0, 1.0);
     vec3 ro = pn.xyz / pn.w;
     vec3 rd = normalize(pf.xyz / pf.w - ro);
-
-    float tNear, tFar;
-    if (!intersectBox(ro, rd, tNear, tFar)) { FragColor = vec4(uBg, 1.0); return; }
-    tNear = max(tNear, 0.0);
-
-    vec3  boxSize = 2.0 * uBoxHalf;
-    float dt      = length(boxSize) / float(uSteps);
+    float tN, tF;
+    if (!intersectBox(ro, rd, tN, tF)) { FragColor = vec4(uBg,1.0); return; }
+    tN = max(tN, 0.0);
+    vec3 boxSize = 2.0 * uBoxHalf;
+    float dt = length(boxSize) / float(uSteps);
     float refStep = length(boxSize) / 512.0;
-    float t0      = tNear + hash(gl_FragCoord.xy) * dt;
+    float t0 = tN + hash(gl_FragCoord.xy) * dt;
+    vec3 duvw = rd * dt / boxSize;
 
-    // Guard the transfer-function window so a lo>=hi drag can't invert the
-    // smoothstep and paint the whole box (the "black square" bug).
     float e0 = min(uThreshLo, uThreshHi);
     float e1 = max(uThreshLo, uThreshHi);
     if (e1 <= e0) e1 = e0 + 1e-3;
 
     // ---- MIP ----
-    if (uEffect == 1) {
+    if (uEffect == 4) {
         float mx = 0.0, t = t0;
-        for (int i = 0; i < 4096; ++i) {
-            if (t > tFar) break;
-            vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
-            if (!clipped(uvw)) mx = max(mx, samp(uvw));
-            t += dt;
-        }
-        float w = clamp((mx - e0) / (e1 - e0), 0.0, 1.0);
-        FragColor = vec4(mix(uBg, vec3(1.0), w), 1.0);
-        return;
+        for (int i=0;i<4096;++i){ if(t>tF)break; vec3 p=(ro+rd*t+uBoxHalf)/boxSize;
+            if(!clipped(p)) mx=max(mx,samp(p)); t+=dt; }
+        float w = clamp((mx-e0)/(e1-e0),0.0,1.0);
+        FragColor = vec4(mix(uBg, vec3(1.0), w), 1.0); return;
     }
-
     // ---- X-ray ----
     if (uEffect == 3) {
-        float sum = 0.0, t = t0;
-        for (int i = 0; i < 4096; ++i) {
-            if (t > tFar) break;
-            vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
-            if (!clipped(uvw)) { float d = samp(uvw); if (d > e0) sum += (d - e0) * uDensity; }
-            t += dt;
-        }
-        float a = 1.0 - exp(-sum * dt * 6.0);
-        FragColor = vec4(mix(uBg, vec3(1.0), clamp(a, 0.0, 1.0)), 1.0);
-        return;
+        float sum=0.0, t=t0;
+        for (int i=0;i<4096;++i){ if(t>tF)break; vec3 p=(ro+rd*t+uBoxHalf)/boxSize;
+            if(!clipped(p)){ float d=samp(p); if(d>e0) sum+=(d-e0)*uDensity; } t+=dt; }
+        float a = 1.0 - exp(-sum*dt*6.0);
+        FragColor = vec4(mix(uBg, vec3(1.0), clamp(a,0.0,1.0)), 1.0); return;
     }
 
-    // ---- Surface (0) / Glass (2) / Edges (4): compositing ----
-    bool glass = (uEffect == 2);
-    bool edges = (uEffect == 4);
-    float aScale = glass ? 0.4 : 1.0;
+    vec3 viewDir = vec3(0.0, 0.0, 1.0);
+
+    // ---- Opacity peeling (Rezk-Salama & Kolb): render the (peel+1)-th layer.
+    //      Peeling (6) resets the accumulator on each layer; Peeling 2 (7)
+    //      keeps prior layers faintly (translucent nested peel).
+    if (uEffect==6 || uEffect==7) {
+        vec4 acc = vec4(0.0); float pNum = 0.0; float t = t0;
+        for (int i=0;i<4096;++i){
+            if (t>tF) break;
+            vec3 p = (ro+rd*t+uBoxHalf)/boxSize;
+            if (clipped(p)) { t+=dt; continue; }
+            float d = samp(p);
+            float a = smoothstep(e0,e1,d) * uDensity;
+            a = 1.0 - pow(1.0-clamp(a,0.0,1.0), dt/refStep);
+            if (a > 0.01) {
+                vec3 nv = normalize(uNormalMatrix * normalize(-grad(p)+1e-6));
+                float ndl = max(dot(nv, uLightDir), 0.0);
+                float sp = pow(max(dot(reflect(-uLightDir,nv),viewDir),0.0), max(uShininess,1.0))*uSpecular;
+                vec3 base = vec3(pow(d,0.8));
+                vec3 lit = base*(uAmbient + uDiffuse*ndl) + vec3(sp);
+                acc.rgb += (1.0-acc.a)*lit*a; acc.a += (1.0-acc.a)*a;
+            }
+            if (acc.a > uThigh && a < uTlow) {            // filled a layer, then exited it
+                pNum += 1.0;
+                if (pNum > float(uPeel)) break;
+                if (uEffect==6) acc = vec4(0.0);          // hard peel
+                else { acc.rgb *= 0.30; acc.a *= 0.30; }  // soft (translucent) peel
+            }
+            t += dt;
+        }
+        FragColor = vec4(acc.rgb + (1.0-acc.a)*uBg, 1.0); return;
+    }
+
+    bool translucent = (uEffect==2 || uEffect==5 || uEffect==8);   // Glass/Edges/Shell
+    vec3 edgeCol = tempTint(uColorTemp);
+
     vec4 acc = vec4(0.0);
     float t = t0;
     bool prevClip = false;
-    for (int i = 0; i < 4096; ++i) {
-        if (t > tFar || (acc.a > 0.985 && !glass)) break;
-        vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
-        if (clipped(uvw)) { prevClip = true; t += dt; continue; }
-        float d = samp(uvw);
+    for (int i=0;i<4096;++i){
+        if (t>tF || (acc.a>0.985 && !translucent)) break;
+        vec3 p = (ro+rd*t+uBoxHalf)/boxSize;
+        if (clipped(p)) { prevClip = true; t += dt; continue; }
+        float d = samp(p);
 
-        // Cut face: first kept sample right after crossing the clip plane.
-        // Show a smooth intensity cross-section (MRIcroGL slice look) where
-        // tissue is present; fall through to the 3-D surface where it's air.
-        if (uClipActive == 1 && prevClip && !edges) {
+        // Cut face -> intensity slice WITH depth. Bright tissue saturates fast
+        // (reads as a crisp slice); dark CSF/ventricles have low per-step
+        // opacity so the ray penetrates and reveals interior structure. The
+        // integration depth is user-controlled (uSliceDepth).
+        if (uSliceOverlay==1 && uClipActive==1 && prevClip) {
             prevClip = false;
-            if (d > 0.05) {
-                float sv = pow(clamp(d, 0.0, 1.0), 0.8);
-                acc.rgb += (1.0 - acc.a) * vec3(sv);
-                acc.a = 1.0;
-                break;
+            if (d > 0.04) {
+                vec4 s = vec4(0.0);
+                vec3 q = p;
+                int ns = int(mix(18.0, 180.0, uSliceDepth));
+                for (int k=0;k<220;++k){
+                    if (k >= ns) break;
+                    float sd = samp(q);
+                    float sv = pow(clamp(sd,0.0,1.0), 0.72);        // contrasty tone
+                    float sa = smoothstep(0.03, 0.14, sd) * 0.11;   // deep penetration
+                    s.rgb += (1.0-s.a) * vec3(sv) * sa;
+                    s.a   += (1.0-s.a) * sa;
+                    if (s.a > 0.985) break;
+                    q += duvw;
+                    if (any(lessThan(q, vec3(0.0))) || any(greaterThan(q, vec3(1.0)))) break;
+                }
+                acc.rgb += (1.0-acc.a) * s.rgb;
+                acc.a = 1.0; break;
             }
         }
         prevClip = false;
 
-        float a = smoothstep(e0, e1, d) * uDensity * aScale;
-        if (a > 0.001) {
-            a = 1.0 - pow(1.0 - a, dt / refStep);
-            vec3 nw = normalize(-gradient(uvw) + 1e-6);
-            vec3 nv = normalize(uNormalMatrix * nw);
-            float fres = pow(1.0 - abs(nv.z), 2.5);
-            vec3 lit;
-            if (edges) {
-                lit = vec3(fres) * uBrighten;
-            } else {
-                vec3 mc = texture(uMatcap, nv.xy * 0.5 + 0.5).rgb;
-                vec3 surf = mix(vec3(0.5), vec3(pow(d, 0.8)), uSurface);
-                lit = mc * surf * uBrighten;
-                if (glass) lit += vec3(0.5) * fres;
-                // Depth cue: dim samples deeper into the volume for shape.
-                float depth01 = clamp((t - tNear) / max(tFar - tNear, 1e-3), 0.0, 1.0);
-                lit *= 1.0 - 0.3 * depth01;
-            }
-            acc.rgb += (1.0 - acc.a) * lit * a;
-            acc.a   += (1.0 - acc.a) * a;
+        vec3 g = grad(p);
+        float gm = length(g);
+        vec3 nv = normalize(uNormalMatrix * normalize(-g + 1e-6));
+        float op = smoothstep(e0, e1, d) * uDensity;
+        float depth01 = clamp((t-tN)/max(tF-tN,1e-3), 0.0, 1.0);
+        float ndl = max(dot(nv, uLightDir), 0.0);
+        float sp = pow(max(dot(reflect(-uLightDir, nv), viewDir), 0.0), max(uShininess,1.0));
+
+        vec3 lit; float a = op;
+        if (uEffect==0) {                                  // Default: waxy matcap
+            vec3 mc = texture(uMatcap, nv.xy*0.5+0.5).rgb;
+            vec3 surf = mix(vec3(0.74), vec3(pow(d,0.72)), uSurface);
+            lit = mc * surf * uBrighten;
+            lit += vec3(1.0, 0.98, 0.94) * sp * 0.6;       // controllable glossy highlight
+            lit *= 1.0 - 0.18 * depth01;
+            a = op * 0.92;
+        } else if (uEffect==9) {                           // Topography
+            vec3 mc = texture(uMatcap, nv.xy*0.5+0.5).rgb;
+            vec3 surf = mix(vec3(0.74), vec3(pow(d,0.72)), uSurface);
+            lit = mc * surf * uBrighten;
+            vec3 iShade = vec3(pow(d, mix(1.6, 0.5, uHardness))) * uBrighten;
+            lit = mix(lit, iShade, uIntensityMix);
+            lit += vec3(1.0) * sp * 0.4;
+            op *= mix(1.0, clamp(gm*4.0, 0.0, 1.0), uGradientMix);
+            a = op;
+            lit *= 1.0 - 0.18 * depth01;
+        } else if (uEffect==5) {                           // Edges: translucent + contours
+            vec3 mc = texture(uMatcap, nv.xy*0.5+0.5).rgb;
+            float edge = smoothstep(uEdgeThresh, 1.0, gm);
+            float bound = smoothstep(uBoundThresh, 1.0, gm);
+            vec3 surf = mix(vec3(0.6), vec3(pow(d,0.8)), uSurface);
+            lit = mc * surf * uBrighten * (0.35 + 0.9*edge);
+            a = op * mix(0.02, 0.9, mix(bound, edge, uEdgeMix));
+        } else if (uEffect==2 || uEffect==8) {             // Glass / Shell
+            float edge = smoothstep(uEdgeThresh, 1.0, gm);
+            float bnd = (uEffect==2) ? ((gm>uBoundThresh)?pow(1.0-abs(nv.z),4.0):0.0)
+                                     : smoothstep(uBoundThresh, 1.0, gm);
+            float e = mix(bnd, edge, uEdgeMix);
+            lit = edgeCol * (e * uBrighten + sp * uSpecular);
+            a = e * (uEffect==2 ? 0.35 : 0.7);
+        } else {                                           // Matte: Phong + depth cue
+            vec3 base = vec3(mix(0.5, pow(d,0.8), 0.7));
+            lit = base * (uAmbient + uDiffuse*ndl) + vec3(sp*uSpecular);
+            lit *= 1.0 - 0.30 * depth01;
+            a = op;
+        }
+        if (a > 0.0008) {
+            a = 1.0 - pow(1.0 - clamp(a,0.0,1.0), dt/refStep);
+            acc.rgb += (1.0-acc.a) * lit * a;
+            acc.a   += (1.0-acc.a) * a;
         }
         t += dt;
     }
-    FragColor = vec4(acc.rgb + (1.0 - acc.a) * uBg, 1.0);
+    FragColor = vec4(acc.rgb + (1.0-acc.a)*uBg, 1.0);
+}
+"""
+
+_CUBE_VERT = """
+#version 330 core
+layout(location=0) in vec3 aPos;
+layout(location=1) in vec3 aNormal;
+layout(location=2) in vec2 aUV;
+uniform mat4 uProj;
+uniform mat3 uRot;
+out vec3 vN; out vec2 vUV;
+void main(){
+    vec3 p = uRot * aPos;
+    vN = uRot * aNormal;
+    vUV = aUV;
+    gl_Position = uProj * vec4(p * 0.62, 1.0);
+}
+"""
+
+_CUBE_FRAG = """
+#version 330 core
+in vec3 vN; in vec2 vUV;
+uniform sampler2D uAtlas;
+out vec4 FragColor;
+void main(){
+    float sh = 0.55 + 0.45 * clamp(vN.z, 0.0, 1.0);
+    vec4 tx = texture(uAtlas, vUV);
+    vec3 face = vec3(0.15, 0.18, 0.24) * sh;
+    vec3 col = mix(face, vec3(0.96), tx.r);   // white letters over shaded face
+    FragColor = vec4(col, 1.0);
 }
 """
 
@@ -365,44 +598,59 @@ class RaycastGLWidget(QOpenGLWidget):
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setFormat(request_gl_format())
-
         self._prog = 0
         self._vao = 0
         self._tex = 0
         self._matcap_tex = 0
+        self._cube_prog = 0
+        self._cube_vao = 0
+        self._cube_vbo = 0
+        self._cube_tex = 0
+        self._cube_nverts = 0
         self._tex_dims = (1, 1, 1)
         self._box_half = np.array([0.5, 0.5, 0.5], dtype=np.float32)
         self._gl_ok = False
         self._gl_error = ""
-        # Retained so the render survives context loss (detach / re-attach):
-        # ``initializeGL`` re-runs on the new context and re-uploads this.
         self._volume: Optional[tuple[np.ndarray, tuple[float, float, float]]] = None
         self._matcaps: dict[str, np.ndarray] = {}
         self._matcap_dirty = True
+        self._show_cube = True
 
-        # Camera: orbit (azimuth/elevation/distance) about a pannable target.
-        self._az = 0.6
-        self._el = 0.3
-        self._dist = 2.6
+        self._az, self._el, self._dist = 0.6, 0.3, 2.6
         self._target = np.zeros(3, np.float32)
         self._last: Optional[QPoint] = None
         self._drag = "rotate"
 
-        # Shader-driven display state (mutated by Nifti3DControls).
         self.effect = DEFAULTS["effect"]
         self.thresh_lo = DEFAULTS["lo"] / 1000.0
         self.thresh_hi = DEFAULTS["hi"] / 1000.0
-        self.density = DEFAULTS["den"] / 100.0
-        self.brighten = DEFAULTS["bright"] / 100.0
-        self.surface = DEFAULTS["surf"] / 100.0
-        self.steps = DEFAULTS["q"]
+        self.density = DEFAULTS["density"] / 100.0
+        self.brighten = DEFAULTS["brighten"] / 100.0
+        self.surface = DEFAULTS["surface"] / 100.0
+        self.ambient = DEFAULTS["ambient"] / 100.0
+        self.diffuse = DEFAULTS["diffuse"] / 100.0
+        self.specular = DEFAULTS["specular"] / 100.0
+        self.shininess = float(DEFAULTS["shininess"])
+        self.bound_thresh = DEFAULTS["boundthresh"] / 100.0
+        self.edge_thresh = DEFAULTS["edgethresh"] / 100.0
+        self.edge_mix = DEFAULTS["edgemix"] / 100.0
+        self.color_temp = DEFAULTS["colortemp"] / 100.0
+        self.gradient_mix = DEFAULTS["gradientmix"] / 100.0
+        self.intensity_mix = DEFAULTS["intensitymix"] / 100.0
+        self.hardness = DEFAULTS["hardness"] / 100.0
+        self.peel = DEFAULTS["peel"]
+        self.tlow = DEFAULTS["tlow"] / 100.0
+        self.thigh = DEFAULTS["thigh"] / 100.0
+        self.light_dir = light_dir_view(DEFAULTS["lightaz"], DEFAULTS["lightel"])
+        self.steps = DEFAULTS["quality"]
         self.matcap_name = LIGHTINGS[0]
         self.clip_active = 0
         self.clip_normal = (0.0, 1.0, 0.0)
         self.clip_depth = 0.0
         self.clip_thick = 3.0
+        self.slice_overlay = 1
+        self.slice_depth = DEFAULTS["overlaydepth"] / 100.0
         self._bg = (0.05, 0.06, 0.08)
-
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
     # -- public API --------------------------------------------------------
@@ -414,7 +662,6 @@ class RaycastGLWidget(QOpenGLWidget):
         return self._volume is not None
 
     def set_volume(self, u8: np.ndarray, spacing: tuple[float, float, float]) -> None:
-        """Bind a uint8 volume; retained + uploaded when GL is ready."""
         self._volume = (np.ascontiguousarray(u8, dtype=np.uint8), spacing)
         if self._prog and self._gl_ok and self._make_current():
             try:
@@ -423,8 +670,7 @@ class RaycastGLWidget(QOpenGLWidget):
                 self.doneCurrent()
             self.update()
 
-    def set_volume_float(self, vol: np.ndarray,
-                         spacing: tuple[float, float, float]) -> None:
+    def set_volume_float(self, vol, spacing) -> None:
         self.set_volume(normalize_to_u8(vol), spacing)
 
     def set_matcap(self, name: str) -> None:
@@ -439,8 +685,11 @@ class RaycastGLWidget(QOpenGLWidget):
                 self.doneCurrent()
             self.update()
 
+    def set_show_cube(self, on: bool) -> None:
+        self._show_cube = bool(on)
+        self.update()
+
     def refresh(self) -> None:
-        """Re-upload the matcap + volume and repaint (manual recovery)."""
         self._matcap_dirty = True
         if self._prog and self._gl_ok and self._make_current():
             try:
@@ -469,8 +718,6 @@ class RaycastGLWidget(QOpenGLWidget):
     # -- GL lifecycle ------------------------------------------------------
 
     def initializeGL(self) -> None:
-        # A fresh context (first show, or after a detach/re-attach) invalidates
-        # every prior GL object — rebuild them all and re-upload the volume.
         self._gl_ok = False
         self._tex = 0
         try:
@@ -480,12 +727,13 @@ class RaycastGLWidget(QOpenGLWidget):
             self._matcap_tex = GL.glGenTextures(1)
             self._matcap_dirty = True
             self._refresh_matcap()
+            self._init_cube()
             GL.glDisable(GL.GL_DEPTH_TEST)
             GL.glClearColor(*self._bg, 1.0)
             self._gl_ok = True
             if self._volume is not None:
                 self._upload_volume()
-        except Exception as exc:  # noqa: BLE001 - degrade, never crash the app
+        except Exception as exc:  # noqa: BLE001
             self._gl_ok = False
             self._gl_error = str(exc)
             log.warning("3-D GL initialisation failed: %s", exc)
@@ -497,47 +745,87 @@ class RaycastGLWidget(QOpenGLWidget):
     def paintGL(self) -> None:
         if not self._gl_ok:
             return
+        w = max(self.width(), 1)
+        h = max(self.height(), 1)
+        dpr = self.devicePixelRatioF()
+        GL.glViewport(0, 0, int(w * dpr), int(h * dpr))
+        GL.glDisable(GL.GL_DEPTH_TEST)
+        GL.glDisable(GL.GL_CULL_FACE)
         GL.glClearColor(*self._bg, 1.0)
-        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT)
         if not self._tex:
             return
 
-        w = max(self.width(), 1)
-        h = max(self.height(), 1)
         eye = self._eye()
         view = _look_at(eye, self._target, np.array([0, 0, 1], np.float32))
         proj = _perspective(45.0, w / h, 0.01, 20.0)
         inv_vp = np.linalg.inv(proj @ view).astype(np.float32)
-        normal_mat = np.ascontiguousarray(view[:3, :3], np.float32)
+        rot = np.ascontiguousarray(view[:3, :3], np.float32)
 
         GL.glUseProgram(self._prog)
-        self._set_mat4("uInvViewProj", inv_vp)
-        self._set_mat3("uNormalMatrix", normal_mat)
-        self._set_vec3("uBoxHalf", self._box_half)
-        self._set_vec3("uTexSize", np.array(self._tex_dims, np.float32))
-        self._set_vec3("uBg", np.array(self._bg, np.float32))
-        GL.glUniform1i(self._loc("uEffect"), int(self.effect))
-        GL.glUniform1f(self._loc("uThreshLo"), float(self.thresh_lo))
-        GL.glUniform1f(self._loc("uThreshHi"), float(self.thresh_hi))
-        GL.glUniform1f(self._loc("uDensity"), float(self.density))
-        GL.glUniform1f(self._loc("uBrighten"), float(self.brighten))
-        GL.glUniform1f(self._loc("uSurface"), float(self.surface))
-        GL.glUniform1i(self._loc("uSteps"), int(self.steps))
-        GL.glUniform1i(self._loc("uClipActive"), int(self.clip_active))
-        self._set_vec3("uClipNormal", np.array(self.clip_normal, np.float32))
-        GL.glUniform1f(self._loc("uClipDepth"), float(self.clip_depth))
-        GL.glUniform1f(self._loc("uClipThick"), float(self.clip_thick))
-
+        self._set_mat4(self._prog, "uInvViewProj", inv_vp)
+        self._set_mat3(self._prog, "uNormalMatrix", rot)
+        self._set_vec3(self._prog, "uBoxHalf", self._box_half)
+        self._set_vec3(self._prog, "uTexSize", np.array(self._tex_dims, np.float32))
+        self._set_vec3(self._prog, "uBg", np.array(self._bg, np.float32))
+        self._set_vec3(self._prog, "uLightDir", np.array(self.light_dir, np.float32))
+        u = lambda n: GL.glGetUniformLocation(self._prog, n)
+        GL.glUniform1i(u("uEffect"), int(self.effect))
+        GL.glUniform1f(u("uThreshLo"), float(self.thresh_lo))
+        GL.glUniform1f(u("uThreshHi"), float(self.thresh_hi))
+        GL.glUniform1f(u("uDensity"), float(self.density))
+        GL.glUniform1f(u("uBrighten"), float(self.brighten))
+        GL.glUniform1f(u("uSurface"), float(self.surface))
+        GL.glUniform1f(u("uAmbient"), float(self.ambient))
+        GL.glUniform1f(u("uDiffuse"), float(self.diffuse))
+        GL.glUniform1f(u("uSpecular"), float(self.specular))
+        GL.glUniform1f(u("uShininess"), float(self.shininess))
+        GL.glUniform1f(u("uBoundThresh"), float(self.bound_thresh))
+        GL.glUniform1f(u("uEdgeThresh"), float(self.edge_thresh))
+        GL.glUniform1f(u("uEdgeMix"), float(self.edge_mix))
+        GL.glUniform1f(u("uColorTemp"), float(self.color_temp))
+        GL.glUniform1f(u("uGradientMix"), float(self.gradient_mix))
+        GL.glUniform1f(u("uIntensityMix"), float(self.intensity_mix))
+        GL.glUniform1f(u("uHardness"), float(self.hardness))
+        GL.glUniform1i(u("uPeel"), int(self.peel))
+        GL.glUniform1f(u("uTlow"), float(self.tlow))
+        GL.glUniform1f(u("uThigh"), float(self.thigh))
+        GL.glUniform1i(u("uSteps"), int(self.steps))
+        GL.glUniform1i(u("uClipActive"), int(self.clip_active))
+        self._set_vec3(self._prog, "uClipNormal", np.array(self.clip_normal, np.float32))
+        GL.glUniform1f(u("uClipDepth"), float(self.clip_depth))
+        GL.glUniform1f(u("uClipThick"), float(self.clip_thick))
+        GL.glUniform1i(u("uSliceOverlay"), int(self.slice_overlay))
+        GL.glUniform1f(u("uSliceDepth"), float(self.slice_depth))
         GL.glActiveTexture(GL.GL_TEXTURE0)
         GL.glBindTexture(GL.GL_TEXTURE_3D, self._tex)
-        GL.glUniform1i(self._loc("uVol"), 0)
+        GL.glUniform1i(u("uVol"), 0)
         GL.glActiveTexture(GL.GL_TEXTURE1)
         GL.glBindTexture(GL.GL_TEXTURE_2D, self._matcap_tex)
-        GL.glUniform1i(self._loc("uMatcap"), 1)
-
+        GL.glUniform1i(u("uMatcap"), 1)
         GL.glBindVertexArray(self._vao)
         GL.glDrawArrays(GL.GL_TRIANGLES, 0, 3)
         GL.glBindVertexArray(0)
+
+        if self._show_cube and self._cube_prog:
+            self._draw_cube(rot, dpr)
+
+    def _draw_cube(self, rot: np.ndarray, dpr: float) -> None:
+        s = int(96 * dpr)
+        GL.glViewport(int(8 * dpr), int(8 * dpr), s, s)
+        GL.glEnable(GL.GL_DEPTH_TEST)
+        GL.glClear(GL.GL_DEPTH_BUFFER_BIT)
+        GL.glUseProgram(self._cube_prog)
+        proj = _ortho(1.0, 1.0, -4.0, 4.0)
+        self._set_mat4(self._cube_prog, "uProj", proj)
+        self._set_mat3(self._cube_prog, "uRot", rot)
+        GL.glActiveTexture(GL.GL_TEXTURE0)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._cube_tex)
+        GL.glUniform1i(GL.glGetUniformLocation(self._cube_prog, "uAtlas"), 0)
+        GL.glBindVertexArray(self._cube_vao)
+        GL.glDrawArrays(GL.GL_TRIANGLES, 0, self._cube_nverts)
+        GL.glBindVertexArray(0)
+        GL.glDisable(GL.GL_DEPTH_TEST)
 
     # -- helpers -----------------------------------------------------------
 
@@ -563,16 +851,45 @@ class RaycastGLWidget(QOpenGLWidget):
 
     def _eye(self) -> np.ndarray:
         ce = np.cos(self._el)
-        d = np.array([ce * np.sin(self._az), ce * np.cos(self._az), np.sin(self._el)])
+        d = np.array([ce*np.sin(self._az), ce*np.cos(self._az), np.sin(self._el)])
         return (self._target + self._dist * d).astype(np.float32)
 
-    def _camera_basis(self) -> tuple[np.ndarray, np.ndarray]:
+    def _camera_basis(self):
         eye = self._eye()
         up = np.array([0, 0, 1], np.float32)
         f = _normalize(self._target - eye)
         r = _normalize(np.cross(f, up))
-        u = np.cross(r, f)
-        return r, u
+        return r, np.cross(r, f)
+
+    def _init_cube(self) -> None:
+        self._cube_prog = self._build_program(_CUBE_VERT, _CUBE_FRAG)
+        geo = _cube_geometry()
+        self._cube_nverts = geo.shape[0]
+        self._cube_vao = GL.glGenVertexArrays(1)
+        self._cube_vbo = GL.glGenBuffers(1)
+        GL.glBindVertexArray(self._cube_vao)
+        GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self._cube_vbo)
+        GL.glBufferData(GL.GL_ARRAY_BUFFER, geo.nbytes, geo, GL.GL_STATIC_DRAW)
+        stride = 8 * 4
+        GL.glEnableVertexAttribArray(0)
+        GL.glVertexAttribPointer(0, 3, GL.GL_FLOAT, GL.GL_FALSE, stride, None)
+        GL.glEnableVertexAttribArray(1)
+        GL.glVertexAttribPointer(1, 3, GL.GL_FLOAT, GL.GL_FALSE, stride,
+                                 ctypes.c_void_p(12))
+        GL.glEnableVertexAttribArray(2)
+        GL.glVertexAttribPointer(2, 2, GL.GL_FLOAT, GL.GL_FALSE, stride,
+                                 ctypes.c_void_p(24))
+        GL.glBindVertexArray(0)
+        atlas = _make_cube_atlas(96)
+        self._cube_tex = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._cube_tex)
+        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA8, atlas.shape[1], atlas.shape[0],
+                        0, GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, np.ascontiguousarray(atlas))
 
     def _refresh_matcap(self) -> None:
         if not self._matcap_dirty or not self._matcap_tex:
@@ -598,30 +915,29 @@ class RaycastGLWidget(QOpenGLWidget):
         u8, spacing = self._volume
         x, y, z = u8.shape
         self._tex_dims = (x, y, z)
-        extent = np.array([x * spacing[0], y * spacing[1], z * spacing[2]], np.float32)
+        extent = np.array([x*spacing[0], y*spacing[1], z*spacing[2]], np.float32)
         self._box_half = (0.5 * extent / float(extent.max())).astype(np.float32)
-        data = np.ascontiguousarray(u8.transpose(2, 1, 0))  # x fastest for GL
+        data = np.ascontiguousarray(u8.transpose(2, 1, 0))
         if self._tex:
             GL.glDeleteTextures([self._tex])
         self._tex = GL.glGenTextures(1)
         GL.glBindTexture(GL.GL_TEXTURE_3D, self._tex)
         GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
-        for pname in (GL.GL_TEXTURE_WRAP_S, GL.GL_TEXTURE_WRAP_T, GL.GL_TEXTURE_WRAP_R):
-            GL.glTexParameteri(GL.GL_TEXTURE_3D, pname, GL.GL_CLAMP_TO_EDGE)
+        for pn in (GL.GL_TEXTURE_WRAP_S, GL.GL_TEXTURE_WRAP_T, GL.GL_TEXTURE_WRAP_R):
+            GL.glTexParameteri(GL.GL_TEXTURE_3D, pn, GL.GL_CLAMP_TO_EDGE)
         GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
         GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
         GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_R8, x, y, z, 0,
                         GL.GL_RED, GL.GL_UNSIGNED_BYTE, data)
 
     def _build_program(self, vsrc: str, fsrc: str) -> int:
-        def compile_stage(src: str, stage: int) -> int:
+        def compile_stage(src, stage):
             sh = GL.glCreateShader(stage)
             GL.glShaderSource(sh, src)
             GL.glCompileShader(sh)
             if not GL.glGetShaderiv(sh, GL.GL_COMPILE_STATUS):
                 raise RuntimeError(GL.glGetShaderInfoLog(sh).decode())
             return sh
-
         vs = compile_stage(vsrc, GL.GL_VERTEX_SHADER)
         fs = compile_stage(fsrc, GL.GL_FRAGMENT_SHADER)
         prog = GL.glCreateProgram()
@@ -634,28 +950,25 @@ class RaycastGLWidget(QOpenGLWidget):
         GL.glDeleteShader(fs)
         return prog
 
-    def _loc(self, name: str) -> int:
-        return GL.glGetUniformLocation(self._prog, name)
-
-    def _set_mat4(self, name: str, m: np.ndarray) -> None:
-        GL.glUniformMatrix4fv(self._loc(name), 1, GL.GL_TRUE,
+    def _set_mat4(self, prog, name, m):
+        GL.glUniformMatrix4fv(GL.glGetUniformLocation(prog, name), 1, GL.GL_TRUE,
                               np.ascontiguousarray(m, np.float32))
 
-    def _set_mat3(self, name: str, m: np.ndarray) -> None:
-        GL.glUniformMatrix3fv(self._loc(name), 1, GL.GL_TRUE,
+    def _set_mat3(self, prog, name, m):
+        GL.glUniformMatrix3fv(GL.glGetUniformLocation(prog, name), 1, GL.GL_TRUE,
                               np.ascontiguousarray(m, np.float32))
 
-    def _set_vec3(self, name: str, v: np.ndarray) -> None:
-        GL.glUniform3f(self._loc(name), float(v[0]), float(v[1]), float(v[2]))
+    def _set_vec3(self, prog, name, v):
+        GL.glUniform3f(GL.glGetUniformLocation(prog, name),
+                       float(v[0]), float(v[1]), float(v[2]))
 
     # -- interaction -------------------------------------------------------
 
     def mousePressEvent(self, ev) -> None:
         self.setFocus(Qt.FocusReason.MouseFocusReason)
         self._last = ev.position().toPoint()
-        btn = ev.button()
-        pan = (btn in (Qt.MouseButton.RightButton, Qt.MouseButton.MiddleButton)
-               or ev.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        pan = (ev.button() in (Qt.MouseButton.RightButton, Qt.MouseButton.MiddleButton)
+               or bool(ev.modifiers() & Qt.KeyboardModifier.ShiftModifier))
         self._drag = "pan" if pan else "rotate"
 
     def mouseMoveEvent(self, ev) -> None:
@@ -670,7 +983,6 @@ class RaycastGLWidget(QOpenGLWidget):
             scale = 0.0022 * self._dist
             self._target += (-dx * r + dy * u) * scale
         else:
-            # Drag right -> volume turns right (camera orbits the other way).
             self._az += dx * 0.01
             self._el = float(np.clip(self._el + dy * 0.01, -1.55, 1.55))
         self.update()
@@ -685,254 +997,284 @@ class RaycastGLWidget(QOpenGLWidget):
 
 
 # --------------------------------------------------------------------------
-# Controls (bound to a RaycastGLWidget; laid out as a vertical column)
+# Controls
 # --------------------------------------------------------------------------
 
-_THRESH_GAP = 20  # min separation (slider units) between lo and hi
+_THRESH_GAP = 20
 
 
 class Nifti3DControls(QWidget):
-    """Effect / lighting / transfer-function / clip controls for a render.
+    """Effect / lighting / transfer-function / clip controls, one per render.
 
-    Bound to a :class:`RaycastGLWidget` and stacked vertically so the growing
-    control set (now including the MRIcroGL-style clip Azimuth / Elevation /
-    Depth / Thickness) stays legible; used inside a scroll area by the pane.
-    ``vertical`` is retained for API symmetry (layout is always a column).
+    Vertical column (used in a scroll area). Per-effect the irrelevant
+    parameters grey out (:data:`EFFECT_PARAMS`), mirroring MRIcroGL.
     """
 
-    def __init__(self, gl: RaycastGLWidget, *, vertical: bool = True,
-                 parent=None) -> None:
+    def __init__(self, gl: RaycastGLWidget, *, vertical: bool = True, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("sidecar-toolbar")
         self.gl = gl
         self._vertical = vertical
+        self._rows: dict[str, QWidget] = {}     # key -> label+widget container
         self._build_widgets()
         self._layout()
         self._apply_clip()
-
-    # -- widget construction ----------------------------------------------
+        self._sync_effect_params()
 
     def _build_widgets(self) -> None:
-        self._effect = QComboBox()
-        self._effect.addItems(EFFECTS)
-        self._effect.setToolTip("Rendering effect (Surface, MIP, Glass, X-ray, Edges).")
+        self._effect = QComboBox(); self._effect.addItems(EFFECTS)
         self._effect.currentIndexChanged.connect(self._on_effect)
-
-        self._light = QComboBox()
-        self._light.addItems(LIGHTINGS)
-        self._light.setToolTip("Lighting material (matcap).")
+        self._light = QComboBox(); self._light.addItems(LIGHTINGS)
         self._light.currentIndexChanged.connect(self._on_light)
 
-        self._lo = self._slider(0, 1000, DEFAULTS["lo"], self._on_lo)
-        self._hi = self._slider(0, 1000, DEFAULTS["hi"], self._on_hi)
-        self._den = self._slider(0, 300, DEFAULTS["den"], self._on_den)
-        self._bright = self._slider(50, 300, DEFAULTS["bright"], self._on_bright)
-        self._surf = self._slider(0, 100, DEFAULTS["surf"], self._on_surf)
-        self._q = self._slider(64, 1024, DEFAULTS["q"], self._on_q)
+        self._lo = self._sl(0, 1000, DEFAULTS["lo"], self._on_lo)
+        self._hi = self._sl(0, 1000, DEFAULTS["hi"], self._on_hi)
+        self._den = self._sl(0, 300, DEFAULTS["density"], self._on_den)
+        self._bright = self._sl(50, 300, DEFAULTS["brighten"], self._on_bright)
+        self._surf = self._sl(0, 100, DEFAULTS["surface"], self._on_surf)
+        self._amb = self._sl(0, 150, DEFAULTS["ambient"], self._on_amb)
+        self._dif = self._sl(0, 150, DEFAULTS["diffuse"], self._on_dif)
+        self._spec = self._sl(0, 100, DEFAULTS["specular"], self._on_spec)
+        self._shin = self._sl(1, 100, DEFAULTS["shininess"], self._on_shin)
+        self._bound = self._sl(0, 100, DEFAULTS["boundthresh"], self._on_bound)
+        self._edge = self._sl(0, 100, DEFAULTS["edgethresh"], self._on_edge)
+        self._emix = self._sl(0, 100, DEFAULTS["edgemix"], self._on_emix)
+        self._ctemp = self._sl(0, 100, DEFAULTS["colortemp"], self._on_ctemp)
+        self._gmix = self._sl(0, 100, DEFAULTS["gradientmix"], self._on_gmix)
+        self._imix = self._sl(0, 100, DEFAULTS["intensitymix"], self._on_imix)
+        self._hard = self._sl(0, 100, DEFAULTS["hardness"], self._on_hard)
+        self._peel = self._sl(0, 6, DEFAULTS["peel"], self._on_peel)
+        self._tlow = self._sl(0, 100, DEFAULTS["tlow"], self._on_tlow)
+        self._thigh = self._sl(0, 100, DEFAULTS["thigh"], self._on_thigh)
+        self._q = self._sl(64, 1024, DEFAULTS["quality"], self._on_q)
+        self._laz = self._sl(0, 360, DEFAULTS["lightaz"], self._on_light_dir)
+        self._lel = self._sl(-90, 90, DEFAULTS["lightel"], self._on_light_dir)
+        self._overlay_en = QCheckBox("Slice overlay")
+        self._overlay_en.setChecked(bool(DEFAULTS["overlay"]))
+        self._overlay_en.stateChanged.connect(self._on_overlay)
+        self._odepth = self._sl(0, 100, DEFAULTS["overlaydepth"], self._on_odepth)
 
-        # Clip: MRIcroGL-style oblique plane (enable + az / el / depth / thick).
-        self._clip_enable = QCheckBox("Enable clip plane")
-        self._clip_enable.setToolTip("Slice into the volume to reveal interior.")
-        self._clip_enable.stateChanged.connect(self._on_clip_change)
-        self._az = self._slider(0, 360, DEFAULTS["az"], self._on_clip_change)
-        self._el = self._slider(-90, 90, DEFAULTS["el"], self._on_clip_change)
-        self._depth = self._slider(0, 1000, DEFAULTS["depth"], self._on_clip_change)
-        self._thick = self._slider(0, 1000, DEFAULTS["thick"], self._on_clip_change)
+        self._clip_en = QCheckBox("Enable clip plane")
+        self._clip_en.stateChanged.connect(self._on_clip)
+        self._caz = self._sl(0, 360, DEFAULTS["clipaz"], self._on_clip)
+        self._cel = self._sl(-90, 90, DEFAULTS["clipel"], self._on_clip)
+        self._cdepth = self._sl(0, 1000, DEFAULTS["depth"], self._on_clip)
+        self._cthick = self._sl(0, 1000, DEFAULTS["thick"], self._on_clip)
 
-        self._refresh_btn = QPushButton("Refresh image")
-        self._refresh_btn.setObjectName("tb-btn-toggle")
-        self._refresh_btn.setToolTip("Re-upload + repaint the render.")
-        self._refresh_btn.clicked.connect(lambda: self.gl.refresh())
-
-        self._reset_params_btn = QPushButton("Reset parameters")
-        self._reset_params_btn.setObjectName("tb-btn-toggle")
-        self._reset_params_btn.setToolTip("Restore all render settings to defaults.")
-        self._reset_params_btn.clicked.connect(self.reset_params)
-
-        self._reset_view_btn = QPushButton("Reset view")
-        self._reset_view_btn.setObjectName("tb-btn-toggle")
-        self._reset_view_btn.setToolTip("Recentre the camera.")
-        self._reset_view_btn.clicked.connect(self.gl.reset_view)
+        self._refresh_btn = self._btn("Refresh image", lambda: self.gl.refresh())
+        self._reset_params_btn = self._btn("Reset parameters", self.reset_params)
+        self._reset_view_btn = self._btn("Reset view", self.gl.reset_view)
 
     def _layout(self) -> None:
         outer = QVBoxLayout(self)
         outer.setContentsMargins(12, 10, 12, 10)
-        outer.setSpacing(9)
-        for lbl, wdg in (
-            ("Effect", self._effect), ("Lighting", self._light),
-            ("Threshold low", self._lo), ("Threshold high", self._hi),
-            ("Density", self._den), ("Brightness", self._bright),
-            ("Surface colour", self._surf), ("Quality", self._q),
-        ):
-            outer.addLayout(self._stacked(lbl, wdg))
+        outer.setSpacing(8)
+        specs = [
+            ("effect", "Effect", self._effect), ("light", "Lighting", self._light),
+            ("lo", "Threshold low", self._lo), ("hi", "Threshold high", self._hi),
+            ("density", "Density", self._den),
+            ("brighten", "Brightness", self._bright), ("surface", "Surface colour", self._surf),
+            ("ambient", "Ambient", self._amb), ("diffuse", "Diffuse", self._dif),
+            ("specular", "Specular", self._spec), ("shininess", "Shininess", self._shin),
+            ("boundthresh", "Boundary thresh", self._bound),
+            ("edgethresh", "Edge thresh", self._edge), ("edgemix", "Edge/bound mix", self._emix),
+            ("colortemp", "Colour temp", self._ctemp),
+            ("gradientmix", "Gradient mix", self._gmix),
+            ("intensitymix", "Intensity mix", self._imix), ("hardness", "Surface hardness", self._hard),
+            ("peel", "Peel layers", self._peel), ("tlow", "T low", self._tlow),
+            ("thigh", "T high", self._thigh),
+            ("lightaz", "Light azimuth", self._laz), ("lightel", "Light elevation", self._lel),
+            ("overlay", None, self._overlay_en), ("overlaydepth", "Overlay depth", self._odepth),
+            ("quality", "Quality", self._q),
+        ]
+        for key, lbl, wdg in specs:
+            row = self._stacked(lbl, wdg) if lbl is not None else self._wrap(wdg)
+            self._rows[key] = row
+            outer.addWidget(row)
 
         outer.addSpacing(4)
-        outer.addWidget(self._clip_enable)
-        for lbl, wdg in (
-            ("Clip azimuth", self._az), ("Clip elevation", self._el),
-            ("Clip depth", self._depth), ("Clip thickness", self._thick),
-        ):
-            outer.addLayout(self._stacked(lbl, wdg))
-
+        outer.addWidget(self._clip_en)
+        for lbl, wdg in (("Clip azimuth", self._caz), ("Clip elevation", self._cel),
+                         ("Clip depth", self._cdepth), ("Clip thickness", self._cthick)):
+            outer.addWidget(self._stacked(lbl, wdg))
         outer.addSpacing(6)
-        outer.addWidget(self._refresh_btn)
-        outer.addWidget(self._reset_params_btn)
-        outer.addWidget(self._reset_view_btn)
+        for b in (self._refresh_btn, self._reset_params_btn, self._reset_view_btn):
+            outer.addWidget(b)
         outer.addStretch(1)
-        hint = self._chip("Left-drag rotate · right-drag pan · scroll zoom")
+        hint = self._chip("Left-drag rotate · right-drag pan · scroll zoom · O = cube")
         hint.setWordWrap(True)
         outer.addWidget(hint)
 
-    # -- helpers -----------------------------------------------------------
+    # -- construction helpers ---------------------------------------------
 
     @staticmethod
-    def _chip(text: str) -> QLabel:
-        lbl = QLabel(text)
-        lbl.setObjectName("sidecar-footer-summary")
-        return lbl
+    def _chip(text):
+        lbl = QLabel(text); lbl.setObjectName("sidecar-footer-summary"); return lbl
 
-    def _stacked(self, text: str, wdg: QWidget) -> QVBoxLayout:
-        box = QVBoxLayout()
+    def _stacked(self, text, wdg):
+        w = QWidget()
+        box = QVBoxLayout(w)
         box.setContentsMargins(0, 0, 0, 0)
         box.setSpacing(2)
         box.addWidget(self._chip(text))
         box.addWidget(wdg)
-        return box
+        return w
 
     @staticmethod
-    def _slider(lo: int, hi: int, val: int, cb) -> QSlider:
+    def _wrap(wdg):
+        w = QWidget()
+        box = QVBoxLayout(w)
+        box.setContentsMargins(0, 0, 0, 0)
+        box.setSpacing(2)
+        box.addWidget(wdg)
+        return w
+
+    @staticmethod
+    def _sl(lo, hi, val, cb):
         s = QSlider(Qt.Orientation.Horizontal)
-        s.setRange(lo, hi)
-        s.setValue(val)
-        s.setFixedWidth(180)
+        s.setRange(lo, hi); s.setValue(val); s.setFixedWidth(180)
         s.valueChanged.connect(cb)
         return s
 
+    @staticmethod
+    def _btn(text, cb):
+        b = QPushButton(text); b.setObjectName("tb-btn-toggle"); b.clicked.connect(cb)
+        return b
+
     # -- slots -------------------------------------------------------------
 
-    def _on_effect(self, i: int) -> None:
-        self.gl.effect = int(i)
-        self.gl.update()
+    def _on_effect(self, i):
+        self.gl.effect = int(i); self._sync_effect_params(); self.gl.update()
 
-    def _on_light(self, i: int) -> None:
-        self.gl.set_matcap(LIGHTINGS[int(i)])
+    def _sync_effect_params(self) -> None:
+        name = EFFECTS[self._effect.currentIndex()]
+        keys = EFFECT_PARAMS[name]
+        for key, row in self._rows.items():
+            if key == "effect":
+                continue
+            row.setVisible(key in keys)
+        # Per-effect default for the cut-face slice overlay (MRIcroGL-style):
+        # on for the opaque surface effects, off elsewhere.
+        want = name in SLICE_DEFAULT_ON
+        if self._overlay_en.isChecked() != want:
+            self._overlay_en.setChecked(want)     # slot pushes to gl
+        else:
+            self.gl.slice_overlay = 1 if want else 0
 
-    def _on_lo(self, v: int) -> None:
+    def _on_light(self, i): self.gl.set_matcap(LIGHTINGS[int(i)])
+
+    def _on_lo(self, v):
         if v > self._hi.value() - _THRESH_GAP:
-            self._hi.blockSignals(True)
-            self._hi.setValue(min(1000, v + _THRESH_GAP))
-            self._hi.blockSignals(False)
+            self._hi.blockSignals(True); self._hi.setValue(min(1000, v + _THRESH_GAP)); self._hi.blockSignals(False)
             self.gl.thresh_hi = self._hi.value() / 1000.0
-        self.gl.thresh_lo = v / 1000.0
-        self.gl.update()
+        self.gl.thresh_lo = v / 1000.0; self.gl.update()
 
-    def _on_hi(self, v: int) -> None:
+    def _on_hi(self, v):
         if v < self._lo.value() + _THRESH_GAP:
-            self._lo.blockSignals(True)
-            self._lo.setValue(max(0, v - _THRESH_GAP))
-            self._lo.blockSignals(False)
+            self._lo.blockSignals(True); self._lo.setValue(max(0, v - _THRESH_GAP)); self._lo.blockSignals(False)
             self.gl.thresh_lo = self._lo.value() / 1000.0
-        self.gl.thresh_hi = v / 1000.0
+        self.gl.thresh_hi = v / 1000.0; self.gl.update()
+
+    def _on_den(self, v): self.gl.density = v / 100.0; self.gl.update()
+    def _on_bright(self, v): self.gl.brighten = v / 100.0; self.gl.update()
+    def _on_surf(self, v): self.gl.surface = v / 100.0; self.gl.update()
+    def _on_amb(self, v): self.gl.ambient = v / 100.0; self.gl.update()
+    def _on_dif(self, v): self.gl.diffuse = v / 100.0; self.gl.update()
+    def _on_spec(self, v): self.gl.specular = v / 100.0; self.gl.update()
+    def _on_shin(self, v): self.gl.shininess = float(v); self.gl.update()
+    def _on_bound(self, v): self.gl.bound_thresh = v / 100.0; self.gl.update()
+    def _on_edge(self, v): self.gl.edge_thresh = v / 100.0; self.gl.update()
+    def _on_emix(self, v): self.gl.edge_mix = v / 100.0; self.gl.update()
+    def _on_ctemp(self, v): self.gl.color_temp = v / 100.0; self.gl.update()
+    def _on_gmix(self, v): self.gl.gradient_mix = v / 100.0; self.gl.update()
+    def _on_imix(self, v): self.gl.intensity_mix = v / 100.0; self.gl.update()
+    def _on_hard(self, v): self.gl.hardness = v / 100.0; self.gl.update()
+    def _on_peel(self, v): self.gl.peel = int(v); self.gl.update()
+    def _on_tlow(self, v): self.gl.tlow = v / 100.0; self.gl.update()
+    def _on_thigh(self, v): self.gl.thigh = v / 100.0; self.gl.update()
+    def _on_q(self, v): self.gl.steps = int(v); self.gl.update()
+    def _on_overlay(self, *_a): self.gl.slice_overlay = 1 if self._overlay_en.isChecked() else 0; self.gl.update()
+    def _on_odepth(self, v): self.gl.slice_depth = v / 100.0; self.gl.update()
+
+    def _on_light_dir(self, *_a):
+        self.gl.light_dir = light_dir_view(self._laz.value(), self._lel.value())
         self.gl.update()
 
-    def _on_den(self, v: int) -> None:
-        self.gl.density = v / 100.0
-        self.gl.update()
-
-    def _on_bright(self, v: int) -> None:
-        self.gl.brighten = v / 100.0
-        self.gl.update()
-
-    def _on_surf(self, v: int) -> None:
-        self.gl.surface = v / 100.0
-        self.gl.update()
-
-    def _on_q(self, v: int) -> None:
-        self.gl.steps = int(v)
-        self.gl.update()
-
-    def _on_clip_change(self, *_args) -> None:
-        self._apply_clip()
+    def _on_clip(self, *_a): self._apply_clip()
 
     def _apply_clip(self) -> None:
-        on = self._clip_enable.isChecked()
-        for w in (self._az, self._el, self._depth, self._thick):
+        on = self._clip_en.isChecked()
+        for w in (self._caz, self._cel, self._cdepth, self._cthick):
             w.setEnabled(on)
         if not on:
             self.gl.clip_active = 0
         else:
             self.gl.clip_active = 1
-            self.gl.clip_normal = clip_normal_from(self._az.value(), self._el.value())
-            self.gl.clip_depth = (self._depth.value() / 1000.0 - 0.5) * 1.8
-            self.gl.clip_thick = 0.02 + (self._thick.value() / 1000.0) * 2.98
+            self.gl.clip_normal = clip_normal_from(self._caz.value(), self._cel.value())
+            self.gl.clip_depth = (self._cdepth.value() / 1000.0 - 0.5) * 1.8
+            self.gl.clip_thick = 0.02 + (self._cthick.value() / 1000.0) * 2.98
         self.gl.update()
 
     def reset_params(self) -> None:
-        """Restore every control (and the GL state it drives) to defaults."""
-        specs = (
+        pairs = (
             (self._effect.setCurrentIndex, DEFAULTS["effect"]),
             (self._light.setCurrentIndex, DEFAULTS["light"]),
-            (self._lo.setValue, DEFAULTS["lo"]),
-            (self._hi.setValue, DEFAULTS["hi"]),
-            (self._den.setValue, DEFAULTS["den"]),
-            (self._bright.setValue, DEFAULTS["bright"]),
-            (self._surf.setValue, DEFAULTS["surf"]),
-            (self._q.setValue, DEFAULTS["q"]),
-            (self._az.setValue, DEFAULTS["az"]),
-            (self._el.setValue, DEFAULTS["el"]),
-            (self._depth.setValue, DEFAULTS["depth"]),
-            (self._thick.setValue, DEFAULTS["thick"]),
-            (self._clip_enable.setChecked, DEFAULTS["clip"]),
+            (self._lo.setValue, DEFAULTS["lo"]), (self._hi.setValue, DEFAULTS["hi"]),
+            (self._den.setValue, DEFAULTS["density"]),
+            (self._bright.setValue, DEFAULTS["brighten"]), (self._surf.setValue, DEFAULTS["surface"]),
+            (self._amb.setValue, DEFAULTS["ambient"]), (self._dif.setValue, DEFAULTS["diffuse"]),
+            (self._spec.setValue, DEFAULTS["specular"]), (self._shin.setValue, DEFAULTS["shininess"]),
+            (self._bound.setValue, DEFAULTS["boundthresh"]), (self._edge.setValue, DEFAULTS["edgethresh"]),
+            (self._emix.setValue, DEFAULTS["edgemix"]), (self._ctemp.setValue, DEFAULTS["colortemp"]),
+            (self._gmix.setValue, DEFAULTS["gradientmix"]), (self._imix.setValue, DEFAULTS["intensitymix"]),
+            (self._hard.setValue, DEFAULTS["hardness"]),
+            (self._peel.setValue, DEFAULTS["peel"]), (self._tlow.setValue, DEFAULTS["tlow"]),
+            (self._thigh.setValue, DEFAULTS["thigh"]),
+            (self._laz.setValue, DEFAULTS["lightaz"]), (self._lel.setValue, DEFAULTS["lightel"]),
+            (self._odepth.setValue, DEFAULTS["overlaydepth"]),
+            (self._q.setValue, DEFAULTS["quality"]),
+            (self._caz.setValue, DEFAULTS["clipaz"]), (self._cel.setValue, DEFAULTS["clipel"]),
+            (self._cdepth.setValue, DEFAULTS["depth"]), (self._cthick.setValue, DEFAULTS["thick"]),
+            (self._clip_en.setChecked, DEFAULTS["clip"]),
         )
-        for setter, val in specs:
+        for setter, val in pairs:
             setter(val)
         self._apply_clip()
+        self._sync_effect_params()
         self.gl.reset_view()
 
 
 # --------------------------------------------------------------------------
-# Composite view: canvas + vertical controls (pure-3-D mode)
+# Composite view (pure-3-D mode)
 # --------------------------------------------------------------------------
 
 class Nifti3DView(QWidget):
-    """GL canvas + a vertical controls panel (scrollable), the pane's "3D" mode."""
+    """GL canvas + a scrollable vertical controls panel (the pane's "3D" mode)."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("pane-dark")
         self.gl = RaycastGLWidget()
         self.controls = Nifti3DControls(self.gl, vertical=True)
-
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         scroll.setWidget(self.controls)
         scroll.setFixedWidth(224)
-
         root = QHBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(2)
         root.addWidget(self.gl, 1)
         root.addWidget(scroll)
 
-    def set_volume(self, vol: np.ndarray, spacing: tuple[float, float, float]) -> None:
-        self.gl.set_volume_float(vol, spacing)
-
-    def clear(self) -> None:
-        self.gl.clear()
-
-    def reset_view(self) -> None:
-        self.gl.reset_view()
+    def set_volume(self, vol, spacing): self.gl.set_volume_float(vol, spacing)
+    def clear(self): self.gl.clear()
+    def reset_view(self): self.gl.reset_view()
+    def set_show_cube(self, on): self.gl.set_show_cube(on)
 
 
 __all__ = [
-    "Nifti3DControls",
-    "Nifti3DView",
-    "RaycastGLWidget",
-    "request_gl_format",
-    "normalize_to_u8",
-    "clip_normal_from",
-    "EFFECTS",
-    "LIGHTINGS",
-    "DEFAULTS",
+    "Nifti3DControls", "Nifti3DView", "RaycastGLWidget", "request_gl_format",
+    "gpu_available", "normalize_to_u8", "clip_normal_from", "light_dir_view",
+    "EFFECTS", "LIGHTINGS", "EFFECT_PARAMS", "DEFAULTS",
 ]

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -122,8 +122,8 @@ def gpu_available() -> bool:
 # parameter presets of Opacity peeling). The display label is decoupled from
 # the shader ``uEffect`` index via :data:`EFFECT_FX`, so labels/order can change
 # without touching the shader.
-EFFECTS = ["Standard", "Matte", "Juicy shiny", "Juicy shiny 2", "Glass",
-           "X-ray", "Jelly", "Skull", "MIP", "Edges",
+EFFECTS = ["Standard", "Matte", "Juicy shiny", "Juicy shiny 2", "Realistic",
+           "Glass", "X-ray", "Jelly", "Skull", "MIP", "Edges",
            "Opacity peeling", "Opacity peeling 2", "Shell", "Topography"]
 
 # Label -> shader effect index (uEffect). "Standard" = flat Phong (shader fx 1),
@@ -131,6 +131,7 @@ EFFECTS = ["Standard", "Matte", "Juicy shiny", "Juicy shiny 2", "Glass",
 # Jelly/Skull reuse Opacity peeling (fx 6).
 EFFECT_FX: dict[str, int] = {
     "Standard": 1, "Matte": 0, "Juicy shiny": 1, "Juicy shiny 2": 1,
+    "Realistic": 10,
     "Glass": 2, "X-ray": 3, "MIP": 4, "Edges": 5,
     "Opacity peeling": 6, "Opacity peeling 2": 7, "Shell": 8, "Topography": 9,
     "Jelly": 6, "Skull": 6,
@@ -153,6 +154,7 @@ EFFECT_PARAMS: dict[str, set] = {
     "Matte":             _MATCAP_PARAMS,    # waxy matcap (was "Default")
     "Juicy shiny":       _PHONG_PARAMS,     # Standard preset (wet, glossy tissue)
     "Juicy shiny 2":     _PHONG_PARAMS,     # sharper, harder highlight
+    "Realistic":         _PHONG_PARAMS,     # living-tissue colour ramp
     "Glass":             _COMMON | {"specular", "shininess", "edgethresh",
                                     "boundthresh", "edgemix", "colortemp",
                                     "lightaz", "lightel"},
@@ -174,7 +176,7 @@ EFFECT_PARAMS: dict[str, set] = {
 }
 # Effects whose cut-face intensity slice is ON by default.
 SLICE_DEFAULT_ON = {"Standard", "Matte", "Juicy shiny", "Juicy shiny 2",
-                    "Topography"}
+                    "Realistic", "Topography"}
 
 # Named parameter presets (control key -> value) applied when a preset effect
 # is selected. Derived from the reference MRIcroGL-style looks.
@@ -194,6 +196,13 @@ EFFECT_PRESET: dict[str, dict] = {
     "Juicy shiny 2": dict(lo=36, hi=303, density=150, ambient=94, diffuse=23,
                           specular=96, shininess=100, lightaz=0, lightel=30,
                           overlay=True, overlaydepth=68),
+    # "Juicy shiny 2" lighting on the living-tissue shader. Ambient is pulled
+    # down and diffuse up versus its parent: the flat, heavily-ambient look
+    # that reads fine in grey turns a coloured surface into a flat pink card,
+    # so the form has to come from directional light instead.
+    "Realistic": dict(lo=36, hi=303, density=150, ambient=52, diffuse=78,
+                      specular=62, shininess=80, lightaz=0, lightel=30,
+                      overlay=True, overlaydepth=68),
     # Translucent, glassy tissue — the brain shows through the skin.
     "Jelly": dict(lo=110, hi=400, density=7, ambient=115, diffuse=65,
                   specular=35, shininess=45, peel=1, tlow=13, thigh=82,
@@ -476,6 +485,33 @@ vec3 grad(vec3 p) {
                 samp(p+vec3(0,0,e.z))-samp(p-vec3(0,0,e.z)));
 }
 float hash(vec2 p){ return fract(sin(dot(p, vec2(12.9898,78.233)))*43758.5453); }
+// Living-brain tissue colour by intensity. A fresh brain is not grey: pia and
+// the vessels over it are dark red, cortical grey matter is a dull pinkish
+// mauve, and white matter / fatty tissue is a pale warm cream. Ramping T1
+// intensity through those three anchors reads as real tissue instead of
+// tinted stone. Deliberately desaturated at the top end — pushing white
+// matter toward saturated pink is what makes fake-looking "meat" renders.
+vec3 brainTissue(float d) {
+    // Sampled from a fixed coronal specimen. Real brain is far LIGHTER and
+    // far LESS saturated than intuition suggests: white matter is close to
+    // ivory, cortex only a muted tan-grey, and only the vessels are properly
+    // red. Saturated pink everywhere is the classic "raw meat" failure.
+    //
+    // The floor is deliberately a dusky rose rather than anything near black:
+    // a cut brain has no black regions (sulci read as thin red lines, CSF as
+    // gaps), so letting the ramp fall to black paints holes in the tissue.
+    const vec3 DEEP   = vec3(0.55, 0.33, 0.30);   // sulcal shadow / vessel bed
+    const vec3 CORTEX = vec3(0.82, 0.69, 0.63);   // grey matter, muted tan
+    const vec3 WHITE  = vec3(0.97, 0.94, 0.89);   // white matter, ivory
+    // The white transition is centred on the measured grey/white boundary of
+    // a percentile-normalised T1 (grey matter lands near 0.40, white matter
+    // near 0.58 here). Starting it higher, as a first pass did, left white
+    // matter only a third of the way to ivory and the whole slice read as one
+    // flat tan — the grey/white contrast is most of what makes it legible.
+    float x = clamp(d, 0.0, 1.0);
+    vec3 c = mix(DEEP, CORTEX, smoothstep(0.02, 0.30, x));
+    return mix(c, WHITE, smoothstep(0.44, 0.62, x));
+}
 vec3 tempTint(float t){
     vec3 c = vec3(1.0);
     if (t < 0.5) { c.b = 1.0+(0.5-t); c.r = 1.0-(0.5-t)*0.6; }
@@ -592,7 +628,14 @@ void main() {
             float thr = mix(0.05, 0.42, uSliceDepth);
             float solid = smoothstep(thr, thr + 0.12, sd);
             if (solid > 0.003) {
-                acc.rgb += (1.0-acc.a) * vec3(pow(clamp(sd,0.0,1.0), 0.8)) * solid;
+                // The cut face is a windowed intensity slice — greyscale for
+                // every effect except Realistic, where a grey cross-section
+                // beside coloured tissue would break the illusion, so it runs
+                // through the same tissue ramp as the surface.
+                float sv = pow(clamp(sd,0.0,1.0), 0.8);
+                vec3 face = (uEffect==10) ? brainTissue(sv) * voxelTint(q)
+                                          : vec3(sv);
+                acc.rgb += (1.0-acc.a) * face * solid;
                 acc.a   += (1.0-acc.a) * solid;
             }
             t += dt;
@@ -643,6 +686,21 @@ void main() {
             float e = mix(bnd, edge, uEdgeMix);
             lit = edgeCol * (e * uBrighten + sp * uSpecular);
             a = e * (uEffect==2 ? 0.35 : 0.7);
+        } else if (uEffect==10) {                          // Realistic (living tissue)
+            // Same Phong response as Standard, but the base is tissue-coloured
+            // and gains two touches that sell "alive":
+            //  * a rim of subsurface red where the surface turns away from the
+            //    viewer, mimicking light scattering through thin tissue;
+            //  * a WHITE specular, because a wet surface reflects the light's
+            //    colour, not the tissue's — tinting it pink looks like plastic.
+            vec3 base = brainTissue(pow(d, 0.85));
+            // Subsurface warmth only at grazing angles, and gently: at the
+            // 0.45 it started out it tinted the whole surface salmon.
+            float rim = pow(1.0 - abs(nv.z), 4.0);
+            base = mix(base, base * vec3(1.14, 0.80, 0.75), 0.20 * rim);
+            lit = base * (uAmbient + uDiffuse*ndl) + vec3(1.0, 0.97, 0.94)*(sp*uSpecular);
+            lit *= 1.0 - 0.18 * depth01;
+            a = op;
         } else {                                           // fx1 = "Standard" label (flat Phong)
             vec3 base = vec3(mix(0.5, pow(d,0.8), 0.7));
             lit = base * (uAmbient + uDiffuse*ndl) + vec3(sp*uSpecular);

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -122,14 +122,16 @@ def gpu_available() -> bool:
 # parameter presets of Opacity peeling). The display label is decoupled from
 # the shader ``uEffect`` index via :data:`EFFECT_FX`, so labels/order can change
 # without touching the shader.
-EFFECTS = ["Standard", "Matte", "Glass", "X-ray", "MIP", "Edges",
-           "Opacity peeling", "Opacity peeling 2", "Shell", "Topography",
-           "Jelly", "Skull"]
+EFFECTS = ["Standard", "Matte", "Juicy shiny", "Glass", "X-ray",
+           "Jelly", "Skull", "MIP", "Edges",
+           "Opacity peeling", "Opacity peeling 2", "Shell", "Topography"]
 
 # Label -> shader effect index (uEffect). "Standard" = flat Phong (shader fx 1),
-# "Matte" = waxy matcap (shader fx 0). Jelly/Skull reuse Opacity peeling (fx 6).
+# "Matte" = waxy matcap (shader fx 0). "Juicy shiny" is a Standard preset;
+# Jelly/Skull reuse Opacity peeling (fx 6).
 EFFECT_FX: dict[str, int] = {
-    "Standard": 1, "Matte": 0, "Glass": 2, "X-ray": 3, "MIP": 4, "Edges": 5,
+    "Standard": 1, "Matte": 0, "Juicy shiny": 1, "Glass": 2, "X-ray": 3,
+    "MIP": 4, "Edges": 5,
     "Opacity peeling": 6, "Opacity peeling 2": 7, "Shell": 8, "Topography": 9,
     "Jelly": 6, "Skull": 6,
 }
@@ -149,6 +151,7 @@ _PEEL_PARAMS = _COMMON | {"density", "ambient", "diffuse", "specular", "shinines
 EFFECT_PARAMS: dict[str, set] = {
     "Standard":          _PHONG_PARAMS,     # flat Phong (was "Matte")
     "Matte":             _MATCAP_PARAMS,    # waxy matcap (was "Default")
+    "Juicy shiny":       _PHONG_PARAMS,     # Standard preset (wet, glossy tissue)
     "Glass":             _COMMON | {"specular", "shininess", "edgethresh",
                                     "boundthresh", "edgemix", "colortemp",
                                     "lightaz", "lightel"},
@@ -169,11 +172,17 @@ EFFECT_PARAMS: dict[str, set] = {
     "Skull":             _PEEL_PARAMS,
 }
 # Effects whose cut-face intensity slice is ON by default.
-SLICE_DEFAULT_ON = {"Standard", "Matte", "Topography"}
+SLICE_DEFAULT_ON = {"Standard", "Matte", "Juicy shiny", "Topography"}
 
 # Named parameter presets (control key -> value) applied when a preset effect
 # is selected. Derived from the reference MRIcroGL-style looks.
 EFFECT_PRESET: dict[str, dict] = {
+    # Wet, glossy surface with a bright cut-face slice — a Standard (flat
+    # Phong) preset. The clip plane is deliberately NOT part of the preset:
+    # it is global state driven by its own controls / slicer shortcuts.
+    "Juicy shiny": dict(lo=36, hi=303, density=150, ambient=94, diffuse=50,
+                        specular=50, shininess=20, lightaz=0, lightel=30,
+                        overlay=True, overlaydepth=68, quality=1024),
     # Translucent, glassy tissue — the brain shows through the skin.
     "Jelly": dict(lo=110, hi=400, density=7, ambient=115, diffuse=65,
                   specular=35, shininess=45, peel=1, tlow=13, thigh=82,
@@ -1201,6 +1210,11 @@ class Nifti3DControls(QWidget):
         # slider units are exactly what the presets in EFFECT_PRESET use.
         self._value_rows: list = []
         self._show_values = False
+        # Every effect keeps its OWN parameter values: label -> {key: value}.
+        # Switching effects stashes the outgoing set and restores the incoming
+        # one, so tweaks to one effect never leak into another.
+        self._effect_values: dict[str, dict] = {}
+        self._current_effect: Optional[str] = None
         self._build_widgets()
         self._layout()
         self._apply_clip()
@@ -1259,6 +1273,14 @@ class Nifti3DControls(QWidget):
 
         self._refresh_btn = self._btn("Refresh image", lambda: self.gl.refresh())
         self._reset_params_btn = self._btn("Reset parameters", self.reset_params)
+        self._reset_params_btn.setToolTip(
+            "Reset THIS effect's parameters to its defaults (or its preset). "
+            "Other effects keep their own values."
+        )
+        self._reset_all_btn = self._btn("Reset all effects", self.reset_all_params)
+        self._reset_all_btn.setToolTip(
+            "Reset the parameters of EVERY effect back to their defaults / presets."
+        )
         self._reset_view_btn = self._btn("Reset view", self.gl.reset_view)
 
     def _layout(self) -> None:
@@ -1295,7 +1317,8 @@ class Nifti3DControls(QWidget):
                          ("Clip depth", self._cdepth), ("Clip thickness", self._cthick)):
             outer.addWidget(self._stacked(lbl, wdg))
         outer.addSpacing(6)
-        for b in (self._refresh_btn, self._reset_params_btn, self._reset_view_btn):
+        for b in (self._refresh_btn, self._reset_params_btn,
+                  self._reset_all_btn, self._reset_view_btn):
             outer.addWidget(b)
         outer.addStretch(1)
         hint = self._chip("Left-drag rotate · right-drag pan · scroll zoom · O = cube")
@@ -1356,35 +1379,43 @@ class Nifti3DControls(QWidget):
     # -- slots -------------------------------------------------------------
 
     def _on_effect(self, i):
+        """Switch effects, keeping every effect's parameters independent.
+
+        The outgoing effect's slider values are stashed and the incoming one's
+        are restored, so tweaking (say) Jelly never disturbs Skull. An effect
+        seen for the first time starts from its baseline — its preset if it has
+        one, otherwise the global defaults.
+        """
         label = EFFECTS[int(i)]
+        if self._current_effect is not None and self._current_effect != label:
+            self._effect_values[self._current_effect] = self._capture_values()
+        self._current_effect = label
         self.gl.effect = EFFECT_FX[label]         # display label -> shader fx
         self._sync_effect_params()
-        preset = EFFECT_PRESET.get(label)
-        if preset:                                # Jelly / Skull apply a preset
-            self._apply_values(preset)
+        self._apply_values(self._stored_values(label))
+        # setChecked/setValue only signal on a *change*, so push the overlay
+        # state explicitly — the incoming effect may share the outgoing one's
+        # checkbox state while the GL still holds a stale value.
+        self.gl.slice_overlay = 1 if self._overlay_en.isChecked() else 0
         self.gl.update()
 
     def _apply_values(self, values: dict) -> None:
-        """Push a preset's control values into the widgets (drives the GL)."""
-        setters = self._param_setters()
+        """Push control values into the widgets (which drive the GL)."""
+        widgets = self._param_widgets()
         for key, val in values.items():
-            if key in setters:
-                setters[key][0](val)
+            if key in widgets:
+                self._widget_set(widgets[key][0], val)
 
     def _sync_effect_params(self) -> None:
+        """Show only the rows this effect uses. The slice-overlay state itself
+        is per-effect parameter state (its baseline is :data:`SLICE_DEFAULT_ON`)
+        and is restored by :meth:`_apply_values`."""
         name = EFFECTS[self._effect.currentIndex()]
         keys = EFFECT_PARAMS[name]
         for key, row in self._rows.items():
             if key == "effect":
                 continue
             row.setVisible(key in keys)
-        # Per-effect default for the cut-face slice overlay (MRIcroGL-style):
-        # on for the opaque surface effects, off elsewhere.
-        want = name in SLICE_DEFAULT_ON
-        if self._overlay_en.isChecked() != want:
-            self._overlay_en.setChecked(want)     # slot pushes to gl
-        else:
-            self.gl.slice_overlay = 1 if want else 0
 
     def _on_light(self, i): self.gl.set_matcap(LIGHTINGS[int(i)])
 
@@ -1471,51 +1502,116 @@ class Nifti3DControls(QWidget):
             self._clip_en.setChecked(True)
         self.gl.invert_clip()           # Shift+X
 
-    # Control key -> (widget setter, default value). Used to reset only the
-    # parameters that belong to the currently-selected effect.
+    # -- per-effect parameter state ----------------------------------------
+
+    def _param_widgets(self):
+        """Control key -> (widget, default). Single source of truth for the
+        per-effect parameter state: getters, setters and defaults derive from
+        it, so a new parameter only has to be registered once."""
+        return {
+            "light": (self._light, DEFAULTS["light"]),
+            "lo": (self._lo, DEFAULTS["lo"]),
+            "hi": (self._hi, DEFAULTS["hi"]),
+            "density": (self._den, DEFAULTS["density"]),
+            "brighten": (self._bright, DEFAULTS["brighten"]),
+            "surface": (self._surf, DEFAULTS["surface"]),
+            "ambient": (self._amb, DEFAULTS["ambient"]),
+            "diffuse": (self._dif, DEFAULTS["diffuse"]),
+            "specular": (self._spec, DEFAULTS["specular"]),
+            "shininess": (self._shin, DEFAULTS["shininess"]),
+            "boundthresh": (self._bound, DEFAULTS["boundthresh"]),
+            "edgethresh": (self._edge, DEFAULTS["edgethresh"]),
+            "edgemix": (self._emix, DEFAULTS["edgemix"]),
+            "colortemp": (self._ctemp, DEFAULTS["colortemp"]),
+            "gradientmix": (self._gmix, DEFAULTS["gradientmix"]),
+            "intensitymix": (self._imix, DEFAULTS["intensitymix"]),
+            "hardness": (self._hard, DEFAULTS["hardness"]),
+            "peel": (self._peel, DEFAULTS["peel"]),
+            "tlow": (self._tlow, DEFAULTS["tlow"]),
+            "thigh": (self._thigh, DEFAULTS["thigh"]),
+            "lightaz": (self._laz, DEFAULTS["lightaz"]),
+            "lightel": (self._lel, DEFAULTS["lightel"]),
+            "overlay": (self._overlay_en, DEFAULTS["overlay"]),
+            "overlaydepth": (self._odepth, DEFAULTS["overlaydepth"]),
+            "quality": (self._q, DEFAULTS["quality"]),
+        }
+
+    @staticmethod
+    def _widget_get(w):
+        if isinstance(w, QSlider):
+            return w.value()
+        if isinstance(w, QComboBox):
+            return w.currentIndex()
+        return w.isChecked()            # QCheckBox
+
+    @staticmethod
+    def _widget_set(w, val) -> None:
+        if isinstance(w, QSlider):
+            w.setValue(int(val))
+        elif isinstance(w, QComboBox):
+            w.setCurrentIndex(int(val))
+        else:
+            w.setChecked(bool(val))     # QCheckBox
+
+    def _baseline_values(self, label: str) -> dict:
+        """Every parameter's starting value for ``label`` — its preset value if
+        the effect defines one, the per-effect slice-overlay default for
+        ``overlay``, otherwise the global default."""
+        preset = EFFECT_PRESET.get(label) or {}
+        vals = {}
+        for key, (_w, default) in self._param_widgets().items():
+            if key in preset:
+                vals[key] = preset[key]
+            elif key == "overlay":
+                vals[key] = label in SLICE_DEFAULT_ON
+            else:
+                vals[key] = default
+        return vals
+
+    def _capture_values(self) -> dict:
+        """Snapshot the current widget values (the active effect's state)."""
+        return {key: self._widget_get(w)
+                for key, (w, _d) in self._param_widgets().items()}
+
+    def _stored_values(self, label: str) -> dict:
+        """The remembered values for ``label``, seeded from its baseline."""
+        vals = self._effect_values.get(label)
+        if vals is None:
+            vals = self._baseline_values(label)
+            self._effect_values[label] = vals
+        return vals
+
+    # Control key -> (widget setter, default value). Derived from
+    # :meth:`_param_widgets` so the registry lives in exactly one place.
     def _param_setters(self):
         return {
-            "light": (self._light.setCurrentIndex, DEFAULTS["light"]),
-            "lo": (self._lo.setValue, DEFAULTS["lo"]),
-            "hi": (self._hi.setValue, DEFAULTS["hi"]),
-            "density": (self._den.setValue, DEFAULTS["density"]),
-            "brighten": (self._bright.setValue, DEFAULTS["brighten"]),
-            "surface": (self._surf.setValue, DEFAULTS["surface"]),
-            "ambient": (self._amb.setValue, DEFAULTS["ambient"]),
-            "diffuse": (self._dif.setValue, DEFAULTS["diffuse"]),
-            "specular": (self._spec.setValue, DEFAULTS["specular"]),
-            "shininess": (self._shin.setValue, DEFAULTS["shininess"]),
-            "boundthresh": (self._bound.setValue, DEFAULTS["boundthresh"]),
-            "edgethresh": (self._edge.setValue, DEFAULTS["edgethresh"]),
-            "edgemix": (self._emix.setValue, DEFAULTS["edgemix"]),
-            "colortemp": (self._ctemp.setValue, DEFAULTS["colortemp"]),
-            "gradientmix": (self._gmix.setValue, DEFAULTS["gradientmix"]),
-            "intensitymix": (self._imix.setValue, DEFAULTS["intensitymix"]),
-            "hardness": (self._hard.setValue, DEFAULTS["hardness"]),
-            "peel": (self._peel.setValue, DEFAULTS["peel"]),
-            "tlow": (self._tlow.setValue, DEFAULTS["tlow"]),
-            "thigh": (self._thigh.setValue, DEFAULTS["thigh"]),
-            "lightaz": (self._laz.setValue, DEFAULTS["lightaz"]),
-            "lightel": (self._lel.setValue, DEFAULTS["lightel"]),
-            "overlay": (self._overlay_en.setChecked, DEFAULTS["overlay"]),
-            "overlaydepth": (self._odepth.setValue, DEFAULTS["overlaydepth"]),
-            "quality": (self._q.setValue, DEFAULTS["quality"]),
+            key: ((lambda v, _w=w: self._widget_set(_w, v)), default)
+            for key, (w, default) in self._param_widgets().items()
         }
 
     def reset_params(self) -> None:
         """Reset ONLY the parameters that belong to the current effect back to
         their defaults (or, for a preset effect like Jelly/Skull, back to the
-        preset). The effect itself, the clip plane and the camera are left as
-        they are (there is a separate Reset view button)."""
+        preset). Other effects keep their own values, and the effect itself,
+        the clip plane and the camera are left as they are (there is a separate
+        Reset view button)."""
         label = EFFECTS[self._effect.currentIndex()]
-        keys = EFFECT_PARAMS[label]
-        preset = EFFECT_PRESET.get(label)
-        setters = self._param_setters()
-        for key in keys:
-            if key in setters:
-                setter, default = setters[key]
-                val = preset[key] if (preset and key in preset) else default
-                setter(val)
+        baseline = self._baseline_values(label)
+        stored = self._stored_values(label)
+        widgets = self._param_widgets()
+        for key in EFFECT_PARAMS[label]:
+            if key in baseline:
+                stored[key] = baseline[key]
+                self._widget_set(widgets[key][0], baseline[key])
+
+    def reset_all_params(self) -> None:
+        """Reset EVERY effect's parameters back to its baseline, then re-apply
+        the current effect's. Use when the per-effect tweaks have drifted and
+        you want a clean slate across the whole effect list."""
+        self._effect_values = {label: self._baseline_values(label)
+                               for label in EFFECTS}
+        label = EFFECTS[self._effect.currentIndex()]
+        self._apply_values(self._effect_values[label])
 
 
 # --------------------------------------------------------------------------

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -122,16 +122,16 @@ def gpu_available() -> bool:
 # parameter presets of Opacity peeling). The display label is decoupled from
 # the shader ``uEffect`` index via :data:`EFFECT_FX`, so labels/order can change
 # without touching the shader.
-EFFECTS = ["Standard", "Matte", "Juicy shiny", "Glass", "X-ray",
-           "Jelly", "Skull", "MIP", "Edges",
+EFFECTS = ["Standard", "Matte", "Juicy shiny", "Juicy shiny 2", "Glass",
+           "X-ray", "Jelly", "Skull", "MIP", "Edges",
            "Opacity peeling", "Opacity peeling 2", "Shell", "Topography"]
 
 # Label -> shader effect index (uEffect). "Standard" = flat Phong (shader fx 1),
 # "Matte" = waxy matcap (shader fx 0). "Juicy shiny" is a Standard preset;
 # Jelly/Skull reuse Opacity peeling (fx 6).
 EFFECT_FX: dict[str, int] = {
-    "Standard": 1, "Matte": 0, "Juicy shiny": 1, "Glass": 2, "X-ray": 3,
-    "MIP": 4, "Edges": 5,
+    "Standard": 1, "Matte": 0, "Juicy shiny": 1, "Juicy shiny 2": 1,
+    "Glass": 2, "X-ray": 3, "MIP": 4, "Edges": 5,
     "Opacity peeling": 6, "Opacity peeling 2": 7, "Shell": 8, "Topography": 9,
     "Jelly": 6, "Skull": 6,
 }
@@ -152,6 +152,7 @@ EFFECT_PARAMS: dict[str, set] = {
     "Standard":          _PHONG_PARAMS,     # flat Phong (was "Matte")
     "Matte":             _MATCAP_PARAMS,    # waxy matcap (was "Default")
     "Juicy shiny":       _PHONG_PARAMS,     # Standard preset (wet, glossy tissue)
+    "Juicy shiny 2":     _PHONG_PARAMS,     # sharper, harder highlight
     "Glass":             _COMMON | {"specular", "shininess", "edgethresh",
                                     "boundthresh", "edgemix", "colortemp",
                                     "lightaz", "lightel"},
@@ -172,7 +173,8 @@ EFFECT_PARAMS: dict[str, set] = {
     "Skull":             _PEEL_PARAMS,
 }
 # Effects whose cut-face intensity slice is ON by default.
-SLICE_DEFAULT_ON = {"Standard", "Matte", "Juicy shiny", "Topography"}
+SLICE_DEFAULT_ON = {"Standard", "Matte", "Juicy shiny", "Juicy shiny 2",
+                    "Topography"}
 
 # Named parameter presets (control key -> value) applied when a preset effect
 # is selected. Derived from the reference MRIcroGL-style looks.
@@ -183,6 +185,10 @@ EFFECT_PRESET: dict[str, dict] = {
     "Juicy shiny": dict(lo=36, hi=303, density=150, ambient=94, diffuse=50,
                         specular=50, shininess=20, lightaz=0, lightel=30,
                         overlay=True, overlaydepth=68, quality=1024),
+    # Same window, but a much tighter/harder specular — a sharper wet sheen.
+    "Juicy shiny 2": dict(lo=36, hi=303, density=150, ambient=94, diffuse=23,
+                          specular=96, shininess=100, lightaz=0, lightel=30,
+                          overlay=True, overlaydepth=68, quality=1024),
     # Translucent, glassy tissue — the brain shows through the skin.
     "Jelly": dict(lo=110, hi=400, density=7, ambient=115, diffuse=65,
                   specular=35, shininess=45, peel=1, tlow=13, thigh=82,
@@ -734,7 +740,10 @@ class RaycastGLWidget(QOpenGLWidget):
         self._recompute_clip()
         self.slice_overlay = 1
         self.slice_depth = DEFAULTS["overlaydepth"] / 100.0
-        self._bg = (0.05, 0.06, 0.08)
+        # Pure black, matching the 2-D slice canvas. The shader composites
+        # partially-transparent rays against this, so it is both the clear
+        # colour and the "empty space" colour.
+        self._bg = (0.0, 0.0, 0.0)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
     # -- public API --------------------------------------------------------

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -175,12 +175,12 @@ SLICE_DEFAULT_ON = {"Standard", "Matte", "Topography"}
 # is selected. Derived from the reference MRIcroGL-style looks.
 EFFECT_PRESET: dict[str, dict] = {
     # Translucent, glassy tissue — the brain shows through the skin.
-    "Jelly": dict(lo=110, hi=400, density=22, ambient=115, diffuse=65,
-                  specular=35, shininess=45, peel=1, tlow=18, thigh=82,
+    "Jelly": dict(lo=110, hi=400, density=7, ambient=115, diffuse=65,
+                  specular=35, shininess=45, peel=1, tlow=13, thigh=82,
                   lightaz=0, lightel=25, quality=1024),
     # Peel the skin to reveal the deeper (facial / orbital / bony) anatomy.
-    "Skull": dict(lo=140, hi=560, density=150, ambient=95, diffuse=50,
-                  specular=50, shininess=20, peel=1, tlow=25, thigh=80,
+    "Skull": dict(lo=36, hi=303, density=150, ambient=95, diffuse=50,
+                  specular=50, shininess=20, peel=1, tlow=19, thigh=80,
                   lightaz=0, lightel=30, quality=1024),
 }
 
@@ -302,9 +302,17 @@ def _make_matcap(name: str, size: int = 256) -> np.ndarray:
     return (col * 255.0).astype(np.uint8)
 
 
-def _make_cube_atlas(size: int = 96) -> np.ndarray:
-    """Render the 6 orientation letters into a 3×2 RGBA atlas (numpy)."""
+def _make_cube_atlas(size: int = 96, flip=(1.0, 1.0, 1.0)) -> np.ndarray:
+    """Render the 6 orientation letters into a 3×2 RGBA atlas (numpy).
+
+    ``flip`` (per L/R, A/P, S/I axis; -1 flips) swaps the letter pair on that
+    axis so a mirrored render shows the correct label upright — the cube is
+    never geometrically reflected (that would mirror the glyphs).
+    """
     letters = [["R", "A", "S"], ["L", "P", "I"]]
+    for col, f in enumerate(flip):
+        if f < 0:
+            letters[0][col], letters[1][col] = letters[1][col], letters[0][col]
     img = QImage(size * 3, size * 2, QImage.Format.Format_RGBA8888)
     img.fill(QColor(38, 44, 54))
     p = QPainter(img)
@@ -665,6 +673,13 @@ class RaycastGLWidget(QOpenGLWidget):
         self._matcaps: dict[str, np.ndarray] = {}
         self._matcap_dirty = True
         self._show_cube = True
+        # Display flip along the canonical RAS axes (L/R, A/P, S/I). Driven by
+        # the pane's RAS (native orientation) and Radiological toggles so the
+        # 3-D render mirrors in lock-step with the 2-D slices. (1, 1, 1) is the
+        # neurological RAS default. The orientation cube's letters are swapped
+        # to match rather than mirrored, so they always read upright.
+        self._flip = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+        self._cube_flip = (1.0, 1.0, 1.0)   # last flip baked into the atlas
 
         self._az, self._el, self._dist = -0.6, 0.3, 1.9
         self._target = np.zeros(3, np.float32)
@@ -747,6 +762,20 @@ class RaycastGLWidget(QOpenGLWidget):
 
     def set_show_cube(self, on: bool) -> None:
         self._show_cube = bool(on)
+        self.update()
+
+    def set_flip(self, fx: float, fy: float, fz: float) -> None:
+        """Mirror the render along the canonical RAS axes (L/R, A/P, S/I).
+
+        Each argument is +1 (keep) or -1 (flip). Drives the volume mirror and
+        the orientation-cube letter swap so the 3-D view matches the 2-D
+        slices under the RAS / Radiological toggles.
+        """
+        self._flip = np.array(
+            [1.0 if fx >= 0 else -1.0,
+             1.0 if fy >= 0 else -1.0,
+             1.0 if fz >= 0 else -1.0], dtype=np.float32,
+        )
         self.update()
 
     def refresh(self) -> None:
@@ -867,8 +896,17 @@ class RaycastGLWidget(QOpenGLWidget):
         eye = self._eye()
         view = _look_at(eye, self._target, np.array([0, 0, 1], np.float32))
         proj = _perspective(45.0, w / h, 0.01, 20.0)
-        inv_vp = np.linalg.inv(proj @ view).astype(np.float32)
-        rot = np.ascontiguousarray(view[:3, :3], np.float32)
+        # Mirror the volume along the flipped canonical axes by folding a
+        # diagonal reflection into the view. Rays are cast in the (axis-aligned)
+        # box space, so sampling and the lit normal both reflect consistently.
+        r4 = np.eye(4, dtype=np.float32)
+        r4[0, 0], r4[1, 1], r4[2, 2] = self._flip
+        vm = view @ r4
+        inv_vp = np.linalg.inv(proj @ vm).astype(np.float32)
+        rot = np.ascontiguousarray(vm[:3, :3], np.float32)
+        # The cube is NOT reflected (that mirrors the glyphs); its atlas letters
+        # are swapped instead, so pass the un-flipped camera rotation.
+        cube_rot = np.ascontiguousarray(view[:3, :3], np.float32)
 
         GL.glUseProgram(self._prog)
         self._set_mat4(self._prog, "uInvViewProj", inv_vp)
@@ -916,9 +954,19 @@ class RaycastGLWidget(QOpenGLWidget):
         GL.glBindVertexArray(0)
 
         if self._show_cube and self._cube_prog:
-            self._draw_cube(rot, dpr)
+            self._draw_cube(cube_rot, dpr)
 
     def _draw_cube(self, rot: np.ndarray, dpr: float) -> None:
+        flip = tuple(float(v) for v in self._flip)
+        if flip != self._cube_flip and self._cube_tex:
+            atlas = _make_cube_atlas(96, flip)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, self._cube_tex)
+            GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
+            GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA8,
+                            atlas.shape[1], atlas.shape[0], 0,
+                            GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,
+                            np.ascontiguousarray(atlas))
+            self._cube_flip = flip
         s = int(96 * dpr)
         GL.glViewport(int(8 * dpr), int(8 * dpr), s, s)
         GL.glEnable(GL.GL_DEPTH_TEST)
@@ -1148,6 +1196,11 @@ class Nifti3DControls(QWidget):
         self.gl = gl
         self._vertical = vertical
         self._rows: dict[str, QWidget] = {}     # key -> label+widget container
+        # Slider value read-out: (slider, chip-label, base-text) per slider row,
+        # so "Show values" can append the live integer to each label. The raw
+        # slider units are exactly what the presets in EFFECT_PRESET use.
+        self._value_rows: list = []
+        self._show_values = False
         self._build_widgets()
         self._layout()
         self._apply_clip()
@@ -1196,6 +1249,14 @@ class Nifti3DControls(QWidget):
         self._cdepth = self._sl(0, 1000, DEFAULTS["depth"], self._on_clip)
         self._cthick = self._sl(0, 1000, DEFAULTS["thick"], self._on_clip)
 
+        self._values_en = QCheckBox("Show values")
+        self._values_en.setChecked(self._show_values)
+        self._values_en.setToolTip(
+            "Append each slider's current value to its label — read off exact "
+            "numbers to build presets."
+        )
+        self._values_en.stateChanged.connect(self._on_show_values)
+
         self._refresh_btn = self._btn("Refresh image", lambda: self.gl.refresh())
         self._reset_params_btn = self._btn("Reset parameters", self.reset_params)
         self._reset_view_btn = self._btn("Reset view", self.gl.reset_view)
@@ -1204,6 +1265,7 @@ class Nifti3DControls(QWidget):
         outer = QVBoxLayout(self)
         outer.setContentsMargins(12, 10, 12, 10)
         outer.setSpacing(8)
+        outer.addWidget(self._values_en)
         specs = [
             ("effect", "Effect", self._effect), ("light", "Lighting", self._light),
             ("lo", "Threshold low", self._lo), ("hi", "Threshold high", self._hi),
@@ -1251,9 +1313,24 @@ class Nifti3DControls(QWidget):
         box = QVBoxLayout(w)
         box.setContentsMargins(0, 0, 0, 0)
         box.setSpacing(2)
-        box.addWidget(self._chip(text))
+        chip = self._chip(text)
+        box.addWidget(chip)
         box.addWidget(wdg)
+        # Register sliders so "Show values" can live-append their value.
+        if isinstance(wdg, QSlider):
+            self._value_rows.append((wdg, chip, text))
+            wdg.valueChanged.connect(
+                lambda _v, c=chip, b=text, s=wdg: self._update_value_label(c, b, s)
+            )
         return w
+
+    def _update_value_label(self, chip, base, slider) -> None:
+        chip.setText(f"{base}   {slider.value()}" if self._show_values else base)
+
+    def _on_show_values(self) -> None:
+        self._show_values = self._values_en.isChecked()
+        for slider, chip, base in self._value_rows:
+            self._update_value_label(chip, base, slider)
 
     @staticmethod
     def _wrap(wdg):

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -35,7 +35,7 @@ import logging
 from typing import Optional
 
 import numpy as np
-from PyQt6.QtCore import Qt, QPoint
+from PyQt6.QtCore import Qt, QPoint, pyqtSignal
 from PyQt6.QtGui import QSurfaceFormat, QImage, QPainter, QColor, QFont
 from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 from PyQt6.QtWidgets import (
@@ -53,12 +53,22 @@ from PyQt6.QtWidgets import (
 log = logging.getLogger(__name__)
 
 
-def request_gl_format() -> QSurfaceFormat:
-    """Return (and register as default) a portable OpenGL 3.3 core format."""
+def _gl_format() -> QSurfaceFormat:
+    """A portable OpenGL 3.3 core surface format (does not touch the default)."""
     fmt = QSurfaceFormat()
     fmt.setVersion(3, 3)
     fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
     fmt.setDepthBufferSize(24)
+    return fmt
+
+
+def request_gl_format() -> QSurfaceFormat:
+    """Register the 3.3 core format as the app default (call once, pre-app).
+
+    Widgets use :func:`_gl_format` for their own context so the default is not
+    re-set after the shared context exists (which Qt warns about).
+    """
+    fmt = _gl_format()
     QSurfaceFormat.setDefaultFormat(fmt)
     return fmt
 
@@ -83,7 +93,7 @@ def gpu_available() -> bool:
         from PyQt6.QtGui import QOffscreenSurface, QOpenGLContext
         if QApplication.instance() is None:
             return False
-        fmt = request_gl_format()
+        fmt = _gl_format()
         surf = QOffscreenSurface()
         surf.setFormat(fmt)
         surf.create()
@@ -107,21 +117,38 @@ def gpu_available() -> bool:
     return _GPU_CACHE
 
 
-# Effects (index == uEffect in the shader).
-EFFECTS = ["Default", "Matte", "Glass", "X-ray", "MIP", "Edges",
-           "Opacity peeling", "Opacity peeling 2", "Shell", "Topography"]
+# Effect dropdown labels (display order). "Standard" is the default. Some
+# entries are *presets* of an existing shader effect (Jelly / Skull are named
+# parameter presets of Opacity peeling). The display label is decoupled from
+# the shader ``uEffect`` index via :data:`EFFECT_FX`, so labels/order can change
+# without touching the shader.
+EFFECTS = ["Standard", "Matte", "Glass", "X-ray", "MIP", "Edges",
+           "Opacity peeling", "Opacity peeling 2", "Shell", "Topography",
+           "Jelly", "Skull"]
+
+# Label -> shader effect index (uEffect). "Standard" = flat Phong (shader fx 1),
+# "Matte" = waxy matcap (shader fx 0). Jelly/Skull reuse Opacity peeling (fx 6).
+EFFECT_FX: dict[str, int] = {
+    "Standard": 1, "Matte": 0, "Glass": 2, "X-ray": 3, "MIP": 4, "Edges": 5,
+    "Opacity peeling": 6, "Opacity peeling 2": 7, "Shell": 8, "Topography": 9,
+    "Jelly": 6, "Skull": 6,
+}
 
 # Which control keys each effect uses (others are greyed out in the panel).
 # "overlay"/"overlaydepth" (the cut-face intensity slice) only appear for the
 # opaque surface effects where a cross-section reads sensibly.
 _COMMON = {"lo", "hi", "quality"}
 _OVERLAY = {"overlay", "overlaydepth"}
+_MATCAP_PARAMS = _COMMON | _OVERLAY | {"density", "light", "brighten", "surface",
+                                       "ambient", "diffuse", "specular",
+                                       "shininess", "lightaz", "lightel"}
+_PHONG_PARAMS = _COMMON | _OVERLAY | {"density", "ambient", "diffuse", "specular",
+                                      "shininess", "lightaz", "lightel"}
+_PEEL_PARAMS = _COMMON | {"density", "ambient", "diffuse", "specular", "shininess",
+                          "peel", "tlow", "thigh", "lightaz", "lightel"}
 EFFECT_PARAMS: dict[str, set] = {
-    "Default":           _COMMON | _OVERLAY | {"density", "light", "brighten",
-                                               "surface", "lightaz", "lightel"},
-    "Matte":             _COMMON | _OVERLAY | {"density", "ambient", "diffuse",
-                                               "specular", "shininess",
-                                               "lightaz", "lightel"},
+    "Standard":          _PHONG_PARAMS,     # flat Phong (was "Matte")
+    "Matte":             _MATCAP_PARAMS,    # waxy matcap (was "Default")
     "Glass":             _COMMON | {"specular", "shininess", "edgethresh",
                                     "boundthresh", "edgemix", "colortemp",
                                     "lightaz", "lightel"},
@@ -130,21 +157,32 @@ EFFECT_PARAMS: dict[str, set] = {
     "Edges":             _COMMON | {"density", "light", "brighten", "surface",
                                     "boundthresh", "edgethresh", "edgemix",
                                     "lightaz", "lightel"},
-    "Opacity peeling":   _COMMON | {"density", "ambient", "diffuse", "specular",
-                                    "shininess", "peel", "tlow", "thigh",
-                                    "lightaz", "lightel"},
-    "Opacity peeling 2": _COMMON | {"density", "ambient", "diffuse", "specular",
-                                    "shininess", "peel", "tlow", "thigh",
-                                    "lightaz", "lightel"},
+    "Opacity peeling":   _PEEL_PARAMS,
+    "Opacity peeling 2": _PEEL_PARAMS,
     "Shell":             _COMMON | {"boundthresh", "edgethresh", "edgemix",
                                     "colortemp", "specular", "lightaz", "lightel"},
     "Topography":        _COMMON | _OVERLAY | {"density", "light", "brighten",
                                                "surface", "gradientmix",
                                                "intensitymix", "hardness",
                                                "lightaz", "lightel"},
+    "Jelly":             _PEEL_PARAMS,
+    "Skull":             _PEEL_PARAMS,
 }
 # Effects whose cut-face intensity slice is ON by default.
-SLICE_DEFAULT_ON = {"Default", "Matte", "Topography"}
+SLICE_DEFAULT_ON = {"Standard", "Matte", "Topography"}
+
+# Named parameter presets (control key -> value) applied when a preset effect
+# is selected. Derived from the reference MRIcroGL-style looks.
+EFFECT_PRESET: dict[str, dict] = {
+    # Translucent, glassy tissue — the brain shows through the skin.
+    "Jelly": dict(lo=110, hi=400, density=22, ambient=115, diffuse=65,
+                  specular=35, shininess=45, peel=1, tlow=18, thigh=82,
+                  lightaz=0, lightel=25, quality=1024),
+    # Peel the skin to reveal the deeper (facial / orbital / bony) anatomy.
+    "Skull": dict(lo=140, hi=560, density=150, ambient=95, diffuse=50,
+                  specular=50, shininess=20, peel=1, tlow=25, thigh=80,
+                  lightaz=0, lightel=30, quality=1024),
+}
 
 # Matcap "lighting" materials: (ambient, key, fill, spec_power, spec_int, tint).
 _LIGHTINGS: dict[str, tuple] = {
@@ -163,7 +201,7 @@ DEFAULTS = dict(
     ambient=60, diffuse=55, specular=30, shininess=40,
     boundthresh=30, edgethresh=12, edgemix=65, colortemp=50,
     gradientmix=60, intensitymix=35, hardness=50,
-    peel=1, tlow=25, thigh=85, lightaz=210, lightel=40, overlay=True, overlaydepth=40,
+    peel=1, tlow=25, thigh=85, lightaz=0, lightel=0, overlay=True, overlaydepth=28,
     quality=1024, clip=False, clipaz=0, clipel=0, depth=500, thick=1000, cube=True,
 )
 
@@ -473,30 +511,34 @@ void main() {
         if (clipped(p)) { prevClip = true; t += dt; continue; }
         float d = samp(p);
 
-        // Cut face -> intensity slice WITH depth. Bright tissue saturates fast
-        // (reads as a crisp slice); dark CSF/ventricles have low per-step
-        // opacity so the ray penetrates and reveals interior structure. The
-        // integration depth is user-controlled (uSliceDepth).
+        // Cut face -> hybrid cross-section. SOLID tissue at the plane is drawn
+        // as a clean flat intensity slice; low-intensity CSF / air is treated
+        // as EMPTY (transparent) so the lit 3-D render behind shows through —
+        // a ventricle becomes a real, shaded recess (that is the "depth"). The
+        // overlay-depth slider raises the emptiness threshold; smoothstep keeps
+        // the boundary smooth so there are no black-dot speckles. We do NOT
+        // break: the loop continues and the normal surface shading below fills
+        // the transparent parts. Scoped entirely to this block.
         if (uSliceOverlay==1 && uClipActive==1 && prevClip) {
             prevClip = false;
-            if (d > 0.04) {
-                vec4 s = vec4(0.0);
-                vec3 q = p;
-                int ns = int(mix(18.0, 180.0, uSliceDepth));
-                for (int k=0;k<220;++k){
-                    if (k >= ns) break;
-                    float sd = samp(q);
-                    float sv = pow(clamp(sd,0.0,1.0), 0.72);        // contrasty tone
-                    float sa = smoothstep(0.03, 0.14, sd) * 0.11;   // deep penetration
-                    s.rgb += (1.0-s.a) * vec3(sv) * sa;
-                    s.a   += (1.0-s.a) * sa;
-                    if (s.a > 0.985) break;
-                    q += duvw;
-                    if (any(lessThan(q, vec3(0.0))) || any(greaterThan(q, vec3(1.0)))) break;
-                }
-                acc.rgb += (1.0-acc.a) * s.rgb;
-                acc.a = 1.0; break;
+            // De-jitter: snap to the exact clip-plane crossing for a clean value.
+            vec3 q = p;
+            float denom = dot(uClipNormal, duvw);
+            if (abs(denom) > 1e-6) {
+                float sdp = dot(uClipNormal, p - vec3(0.5));
+                float tgt = (abs(sdp - uClipDepth) <= abs(sdp - (uClipDepth+uClipThick)))
+                            ? uClipDepth : (uClipDepth + uClipThick);
+                q = clamp(p + duvw * ((tgt - sdp) / denom), vec3(0.0), vec3(1.0));
             }
+            float sd = samp(q);
+            float thr = mix(0.05, 0.42, uSliceDepth);
+            float solid = smoothstep(thr, thr + 0.12, sd);
+            if (solid > 0.003) {
+                acc.rgb += (1.0-acc.a) * vec3(pow(clamp(sd,0.0,1.0), 0.8)) * solid;
+                acc.a   += (1.0-acc.a) * solid;
+            }
+            t += dt;
+            continue;   // let the lit 3-D volume fill the empty (cavity) parts
         }
         prevClip = false;
 
@@ -509,11 +551,14 @@ void main() {
         float sp = pow(max(dot(reflect(-uLightDir, nv), viewDir), 0.0), max(uShininess,1.0));
 
         vec3 lit; float a = op;
-        if (uEffect==0) {                                  // Default: waxy matcap
+        if (uEffect==0) {                                  // fx0 = "Matte" label (waxy matcap)
             vec3 mc = texture(uMatcap, nv.xy*0.5+0.5).rgb;
             vec3 surf = mix(vec3(0.74), vec3(pow(d,0.72)), uSurface);
-            lit = mc * surf * uBrighten;
-            lit += vec3(1.0, 0.98, 0.94) * sp * 0.6;       // controllable glossy highlight
+            // Waxy matcap base lit with the SAME Phong model as Matte
+            // (ambient + diffuse*N·L, plus specular/shininess), so the lighting
+            // controls behave identically between Default and Matte.
+            vec3 base = mc * surf * uBrighten;
+            lit = base * (uAmbient + uDiffuse * ndl) + vec3(sp * uSpecular);
             lit *= 1.0 - 0.18 * depth01;
             a = op * 0.92;
         } else if (uEffect==9) {                           // Topography
@@ -540,7 +585,7 @@ void main() {
             float e = mix(bnd, edge, uEdgeMix);
             lit = edgeCol * (e * uBrighten + sp * uSpecular);
             a = e * (uEffect==2 ? 0.35 : 0.7);
-        } else {                                           // Matte: Phong + depth cue
+        } else {                                           // fx1 = "Standard" label (flat Phong)
             vec3 base = vec3(mix(0.5, pow(d,0.8), 0.7));
             lit = base * (uAmbient + uDiffuse*ndl) + vec3(sp*uSpecular);
             lit *= 1.0 - 0.30 * depth01;
@@ -595,9 +640,14 @@ void main(){
 class RaycastGLWidget(QOpenGLWidget):
     """QOpenGLWidget hosting the single-pass volume raycaster (no controls)."""
 
+    # Emitted when the clip plane is changed from *inside* the widget (keyboard
+    # shortcuts / Shift-drag / Shift-scroll), so the controls panel can mirror
+    # its sliders. Not emitted for changes driven by the controls themselves.
+    clip_changed = pyqtSignal()
+
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
-        self.setFormat(request_gl_format())
+        self.setFormat(_gl_format())
         self._prog = 0
         self._vao = 0
         self._tex = 0
@@ -616,12 +666,12 @@ class RaycastGLWidget(QOpenGLWidget):
         self._matcap_dirty = True
         self._show_cube = True
 
-        self._az, self._el, self._dist = 0.6, 0.3, 2.6
+        self._az, self._el, self._dist = -0.6, 0.3, 1.9
         self._target = np.zeros(3, np.float32)
         self._last: Optional[QPoint] = None
         self._drag = "rotate"
 
-        self.effect = DEFAULTS["effect"]
+        self.effect = EFFECT_FX[EFFECTS[DEFAULTS["effect"]]]   # shader fx of default
         self.thresh_lo = DEFAULTS["lo"] / 1000.0
         self.thresh_hi = DEFAULTS["hi"] / 1000.0
         self.density = DEFAULTS["density"] / 100.0
@@ -644,10 +694,20 @@ class RaycastGLWidget(QOpenGLWidget):
         self.light_dir = light_dir_view(DEFAULTS["lightaz"], DEFAULTS["lightel"])
         self.steps = DEFAULTS["quality"]
         self.matcap_name = LIGHTINGS[0]
+        # Clip plane. Logical state (azimuth/elevation/position/thickness/flip)
+        # is the source of truth; the shader-ready normal/depth/thick are
+        # recomputed from it. Both the controls and the keyboard/mouse slice
+        # shortcuts drive the logical state.
         self.clip_active = 0
+        self.clip_az = float(DEFAULTS["clipaz"])
+        self.clip_el = float(DEFAULTS["clipel"])
+        self.clip_pos = DEFAULTS["depth"] / 1000.0
+        self.clip_thick_frac = DEFAULTS["thick"] / 1000.0
+        self.clip_flip = False
         self.clip_normal = (0.0, 1.0, 0.0)
         self.clip_depth = 0.0
         self.clip_thick = 3.0
+        self._recompute_clip()
         self.slice_overlay = 1
         self.slice_depth = DEFAULTS["overlaydepth"] / 100.0
         self._bg = (0.05, 0.06, 0.08)
@@ -711,8 +771,56 @@ class RaycastGLWidget(QOpenGLWidget):
             self.update()
 
     def reset_view(self) -> None:
-        self._az, self._el, self._dist = 0.6, 0.3, 2.6
+        self._az, self._el, self._dist = -0.6, 0.3, 1.9
         self._target = np.zeros(3, np.float32)
+        self.update()
+
+    # -- clip plane (logical state -> shader uniforms) ---------------------
+
+    def _recompute_clip(self) -> None:
+        n = clip_normal_from(self.clip_az, self.clip_el)
+        if self.clip_flip:
+            n = (-n[0], -n[1], -n[2])
+        self.clip_normal = n
+        self.clip_depth = (self.clip_pos - 0.5) * 1.8
+        self.clip_thick = 0.02 + self.clip_thick_frac * 2.98
+
+    def toggle_clip(self) -> None:
+        """Shift+Y — activate / deactivate the slicer."""
+        self.clip_active = 0 if self.clip_active else 1
+        self.clip_changed.emit()
+        self.update()
+
+    def set_clip_axis(self, az: float, el: float) -> None:
+        """Shift+A/S/C — snap the cut to an anatomical plane (and enable it)."""
+        self.clip_active = 1
+        self.clip_flip = False
+        self.clip_az, self.clip_el = float(az), float(el)
+        self._recompute_clip()
+        self.clip_changed.emit()
+        self.update()
+
+    def invert_clip(self) -> None:
+        """Shift+X — invert (flip) the cut direction."""
+        self.clip_active = 1
+        self.clip_flip = not self.clip_flip
+        self._recompute_clip()
+        self.clip_changed.emit()
+        self.update()
+
+    def nudge_clip_pos(self, delta: float) -> None:
+        """Shift+wheel — move the cut plane through the volume."""
+        self.clip_pos = float(np.clip(self.clip_pos + delta, 0.0, 1.0))
+        self._recompute_clip()
+        self.clip_changed.emit()
+        self.update()
+
+    def drag_clip_azel(self, d_az: float, d_el: float) -> None:
+        """Shift+drag — orient the cut plane freely."""
+        self.clip_az = (self.clip_az + d_az) % 360.0
+        self.clip_el = float(np.clip(self.clip_el + d_el, -90.0, 90.0))
+        self._recompute_clip()
+        self.clip_changed.emit()
         self.update()
 
     # -- GL lifecycle ------------------------------------------------------
@@ -967,9 +1075,13 @@ class RaycastGLWidget(QOpenGLWidget):
     def mousePressEvent(self, ev) -> None:
         self.setFocus(Qt.FocusReason.MouseFocusReason)
         self._last = ev.position().toPoint()
-        pan = (ev.button() in (Qt.MouseButton.RightButton, Qt.MouseButton.MiddleButton)
-               or bool(ev.modifiers() & Qt.KeyboardModifier.ShiftModifier))
-        self._drag = "pan" if pan else "rotate"
+        shift = bool(ev.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        if shift and self.clip_active:
+            self._drag = "clip"          # Shift-drag orients the cut plane
+        elif ev.button() in (Qt.MouseButton.RightButton, Qt.MouseButton.MiddleButton):
+            self._drag = "pan"
+        else:
+            self._drag = "rotate"
 
     def mouseMoveEvent(self, ev) -> None:
         if self._last is None:
@@ -978,6 +1090,9 @@ class RaycastGLWidget(QOpenGLWidget):
         dx = p.x() - self._last.x()
         dy = p.y() - self._last.y()
         self._last = p
+        if self._drag == "clip":
+            self.drag_clip_azel(dx * 0.6, -dy * 0.6)   # emits + updates
+            return
         if self._drag == "pan":
             r, u = self._camera_basis()
             scale = 0.0022 * self._dist
@@ -991,8 +1106,20 @@ class RaycastGLWidget(QOpenGLWidget):
         self._last = None
 
     def wheelEvent(self, ev) -> None:
-        factor = 0.9 if ev.angleDelta().y() > 0 else 1.1
-        self._dist = float(np.clip(self._dist * factor, 0.5, 12.0))
+        ad, pd = ev.angleDelta(), ev.pixelDelta()
+        # Unified scroll magnitude in "notches": a mouse-wheel notch is ±1, a
+        # trackpad's many tiny events are fractional — so BOTH the zoom and the
+        # slice navigator scale with it and neither is hyper-sensitive. A mouse
+        # Shift+scroll is remapped to a *horizontal* scroll by many platforms,
+        # so read both axes (and pixelDelta as a trackpad fallback).
+        a = ad.y() or ad.x()
+        steps = (a / 120.0) if a != 0 else ((pd.y() or pd.x()) / 320.0)
+        if steps == 0.0:
+            return
+        if (ev.modifiers() & Qt.KeyboardModifier.ShiftModifier) and self.clip_active:
+            self.nudge_clip_pos(0.02 * steps)          # slice navigator
+            return
+        self._dist = float(np.clip(self._dist * (0.9 ** steps), 0.5, 12.0))  # zoom
         self.update()
 
 
@@ -1019,7 +1146,10 @@ class Nifti3DControls(QWidget):
         self._build_widgets()
         self._layout()
         self._apply_clip()
-        self._sync_effect_params()
+        self._on_effect(self._effect.currentIndex())   # set shader fx + graying
+        # Keyboard / Shift-drag changes to the clip on the GL widget mirror back
+        # into these sliders.
+        self.gl.clip_changed.connect(self._sync_clip_from_gl)
 
     def _build_widgets(self) -> None:
         self._effect = QComboBox(); self._effect.addItems(EFFECTS)
@@ -1144,7 +1274,20 @@ class Nifti3DControls(QWidget):
     # -- slots -------------------------------------------------------------
 
     def _on_effect(self, i):
-        self.gl.effect = int(i); self._sync_effect_params(); self.gl.update()
+        label = EFFECTS[int(i)]
+        self.gl.effect = EFFECT_FX[label]         # display label -> shader fx
+        self._sync_effect_params()
+        preset = EFFECT_PRESET.get(label)
+        if preset:                                # Jelly / Skull apply a preset
+            self._apply_values(preset)
+        self.gl.update()
+
+    def _apply_values(self, values: dict) -> None:
+        """Push a preset's control values into the widgets (drives the GL)."""
+        setters = self._param_setters()
+        for key, val in values.items():
+            if key in setters:
+                setters[key][0](val)
 
     def _sync_effect_params(self) -> None:
         name = EFFECTS[self._effect.currentIndex()]
@@ -1206,42 +1349,91 @@ class Nifti3DControls(QWidget):
         on = self._clip_en.isChecked()
         for w in (self._caz, self._cel, self._cdepth, self._cthick):
             w.setEnabled(on)
-        if not on:
-            self.gl.clip_active = 0
-        else:
-            self.gl.clip_active = 1
-            self.gl.clip_normal = clip_normal_from(self._caz.value(), self._cel.value())
-            self.gl.clip_depth = (self._cdepth.value() / 1000.0 - 0.5) * 1.8
-            self.gl.clip_thick = 0.02 + (self._cthick.value() / 1000.0) * 2.98
+        self.gl.clip_active = 1 if on else 0
+        self.gl.clip_az = float(self._caz.value())
+        self.gl.clip_el = float(self._cel.value())
+        self.gl.clip_pos = self._cdepth.value() / 1000.0
+        self.gl.clip_thick_frac = self._cthick.value() / 1000.0
+        self.gl._recompute_clip()
         self.gl.update()
 
-    def reset_params(self) -> None:
+    def _sync_clip_from_gl(self) -> None:
+        """Mirror the clip sliders after a keyboard/Shift-drag change on the GL."""
         pairs = (
-            (self._effect.setCurrentIndex, DEFAULTS["effect"]),
-            (self._light.setCurrentIndex, DEFAULTS["light"]),
-            (self._lo.setValue, DEFAULTS["lo"]), (self._hi.setValue, DEFAULTS["hi"]),
-            (self._den.setValue, DEFAULTS["density"]),
-            (self._bright.setValue, DEFAULTS["brighten"]), (self._surf.setValue, DEFAULTS["surface"]),
-            (self._amb.setValue, DEFAULTS["ambient"]), (self._dif.setValue, DEFAULTS["diffuse"]),
-            (self._spec.setValue, DEFAULTS["specular"]), (self._shin.setValue, DEFAULTS["shininess"]),
-            (self._bound.setValue, DEFAULTS["boundthresh"]), (self._edge.setValue, DEFAULTS["edgethresh"]),
-            (self._emix.setValue, DEFAULTS["edgemix"]), (self._ctemp.setValue, DEFAULTS["colortemp"]),
-            (self._gmix.setValue, DEFAULTS["gradientmix"]), (self._imix.setValue, DEFAULTS["intensitymix"]),
-            (self._hard.setValue, DEFAULTS["hardness"]),
-            (self._peel.setValue, DEFAULTS["peel"]), (self._tlow.setValue, DEFAULTS["tlow"]),
-            (self._thigh.setValue, DEFAULTS["thigh"]),
-            (self._laz.setValue, DEFAULTS["lightaz"]), (self._lel.setValue, DEFAULTS["lightel"]),
-            (self._odepth.setValue, DEFAULTS["overlaydepth"]),
-            (self._q.setValue, DEFAULTS["quality"]),
-            (self._caz.setValue, DEFAULTS["clipaz"]), (self._cel.setValue, DEFAULTS["clipel"]),
-            (self._cdepth.setValue, DEFAULTS["depth"]), (self._cthick.setValue, DEFAULTS["thick"]),
-            (self._clip_en.setChecked, DEFAULTS["clip"]),
+            (self._caz, int(round(self.gl.clip_az))),
+            (self._cel, int(round(self.gl.clip_el))),
+            (self._cdepth, int(round(self.gl.clip_pos * 1000))),
+            (self._cthick, int(round(self.gl.clip_thick_frac * 1000))),
         )
-        for setter, val in pairs:
-            setter(val)
-        self._apply_clip()
-        self._sync_effect_params()
-        self.gl.reset_view()
+        for w, val in pairs:
+            was = w.blockSignals(True)
+            w.setValue(val)
+            w.setEnabled(bool(self.gl.clip_active))
+            w.blockSignals(was)
+        was = self._clip_en.blockSignals(True)
+        self._clip_en.setChecked(bool(self.gl.clip_active))
+        self._clip_en.blockSignals(was)
+
+    # -- keyboard slicer shortcuts (driven from the pane) ------------------
+
+    def kbd_toggle_clip(self) -> None:
+        self._clip_en.toggle()          # Shift+Y — drives _apply_clip
+
+    def kbd_set_axis(self, az: int, el: int) -> None:
+        self._clip_en.setChecked(True)  # Shift+A/S/C
+        self._caz.setValue(int(az))
+        self._cel.setValue(int(el))
+
+    def kbd_invert(self) -> None:
+        if not self._clip_en.isChecked():
+            self._clip_en.setChecked(True)
+        self.gl.invert_clip()           # Shift+X
+
+    # Control key -> (widget setter, default value). Used to reset only the
+    # parameters that belong to the currently-selected effect.
+    def _param_setters(self):
+        return {
+            "light": (self._light.setCurrentIndex, DEFAULTS["light"]),
+            "lo": (self._lo.setValue, DEFAULTS["lo"]),
+            "hi": (self._hi.setValue, DEFAULTS["hi"]),
+            "density": (self._den.setValue, DEFAULTS["density"]),
+            "brighten": (self._bright.setValue, DEFAULTS["brighten"]),
+            "surface": (self._surf.setValue, DEFAULTS["surface"]),
+            "ambient": (self._amb.setValue, DEFAULTS["ambient"]),
+            "diffuse": (self._dif.setValue, DEFAULTS["diffuse"]),
+            "specular": (self._spec.setValue, DEFAULTS["specular"]),
+            "shininess": (self._shin.setValue, DEFAULTS["shininess"]),
+            "boundthresh": (self._bound.setValue, DEFAULTS["boundthresh"]),
+            "edgethresh": (self._edge.setValue, DEFAULTS["edgethresh"]),
+            "edgemix": (self._emix.setValue, DEFAULTS["edgemix"]),
+            "colortemp": (self._ctemp.setValue, DEFAULTS["colortemp"]),
+            "gradientmix": (self._gmix.setValue, DEFAULTS["gradientmix"]),
+            "intensitymix": (self._imix.setValue, DEFAULTS["intensitymix"]),
+            "hardness": (self._hard.setValue, DEFAULTS["hardness"]),
+            "peel": (self._peel.setValue, DEFAULTS["peel"]),
+            "tlow": (self._tlow.setValue, DEFAULTS["tlow"]),
+            "thigh": (self._thigh.setValue, DEFAULTS["thigh"]),
+            "lightaz": (self._laz.setValue, DEFAULTS["lightaz"]),
+            "lightel": (self._lel.setValue, DEFAULTS["lightel"]),
+            "overlay": (self._overlay_en.setChecked, DEFAULTS["overlay"]),
+            "overlaydepth": (self._odepth.setValue, DEFAULTS["overlaydepth"]),
+            "quality": (self._q.setValue, DEFAULTS["quality"]),
+        }
+
+    def reset_params(self) -> None:
+        """Reset ONLY the parameters that belong to the current effect back to
+        their defaults (or, for a preset effect like Jelly/Skull, back to the
+        preset). The effect itself, the clip plane and the camera are left as
+        they are (there is a separate Reset view button)."""
+        label = EFFECTS[self._effect.currentIndex()]
+        keys = EFFECT_PARAMS[label]
+        preset = EFFECT_PRESET.get(label)
+        setters = self._param_setters()
+        for key in keys:
+            if key in setters:
+                setter, default = setters[key]
+                val = preset[key] if (preset and key in preset) else default
+                setter(val)
 
 
 # --------------------------------------------------------------------------

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -417,6 +417,7 @@ in  vec2 vNdc;
 out vec4 FragColor;
 
 uniform sampler3D uVol;
+uniform int   uIsRGB;      // 1 when uVol carries colour (e.g. colour-FA)
 uniform sampler2D uMatcap;
 uniform mat4  uInvViewProj;
 uniform mat3  uNormalMatrix;
@@ -446,7 +447,23 @@ bool intersectBox(vec3 ro, vec3 rd, out float tN, out float tF) {
     tF = min(min(b.x, b.y), b.z);
     return tF >= max(tN, 0.0);
 }
-float samp(vec3 p) { return texture(uVol, p).r; }
+// Scalar density at p. For an RGB volume (colour-FA and friends) the three
+// channels are a direction scaled by anisotropy, so the VECTOR LENGTH is the
+// direction-independent magnitude — exactly the FA for a colour-FA map. A
+// luminance weighting would be wrong here: it would make green (A-P) fibres
+// several times denser than blue (S-I) ones purely because of their hue.
+float samp(vec3 p) {
+    vec4 t = texture(uVol, p);
+    return uIsRGB == 1 ? clamp(length(t.rgb), 0.0, 1.0) : t.r;
+}
+// Voxel hue, normalised to full brightness so lighting (not the raw channel
+// magnitude) sets how light or dark the surface reads. White for scalar data.
+vec3 voxelTint(vec3 p) {
+    if (uIsRGB == 0) return vec3(1.0);
+    vec3 c = texture(uVol, p).rgb;
+    float m = max(max(c.r, c.g), c.b);
+    return m > 0.0031 ? c / m : vec3(1.0);
+}
 bool clipped(vec3 p) {
     if (uClipActive == 0) return false;
     float sd = dot(uClipNormal, p - vec3(0.5));
@@ -486,19 +503,25 @@ void main() {
 
     // ---- MIP ----
     if (uEffect == 4) {
-        float mx = 0.0, t = t0;
+        float mx = 0.0, t = t0; vec3 tint = vec3(1.0);
         for (int i=0;i<4096;++i){ if(t>tF)break; vec3 p=(ro+rd*t+uBoxHalf)/boxSize;
-            if(!clipped(p)) mx=max(mx,samp(p)); t+=dt; }
+            // Carry the hue of the brightest voxel so a colour-FA MIP keeps
+            // its direction colouring instead of collapsing to grey.
+            if(!clipped(p)){ float s=samp(p); if(s>mx){ mx=s; tint=voxelTint(p);} } t+=dt; }
         float w = clamp((mx-e0)/(e1-e0),0.0,1.0);
-        FragColor = vec4(mix(uBg, vec3(1.0), w), 1.0); return;
+        FragColor = vec4(mix(uBg, tint, w), 1.0); return;
     }
     // ---- X-ray ----
     if (uEffect == 3) {
-        float sum=0.0, t=t0;
+        float sum=0.0, t=t0; vec3 csum = vec3(0.0);
         for (int i=0;i<4096;++i){ if(t>tF)break; vec3 p=(ro+rd*t+uBoxHalf)/boxSize;
-            if(!clipped(p)){ float d=samp(p); if(d>e0) sum+=(d-e0)*uDensity; } t+=dt; }
+            if(!clipped(p)){ float d=samp(p);
+                if(d>e0){ float w=(d-e0)*uDensity; sum+=w; csum+=voxelTint(p)*w; } }
+            t+=dt; }
         float a = 1.0 - exp(-sum*dt*6.0);
-        FragColor = vec4(mix(uBg, vec3(1.0), clamp(a,0.0,1.0)), 1.0); return;
+        // Density-weighted mean hue along the ray (white for scalar volumes).
+        vec3 tint = sum > 1e-6 ? csum / sum : vec3(1.0);
+        FragColor = vec4(mix(uBg, tint, clamp(a,0.0,1.0)), 1.0); return;
     }
 
     vec3 viewDir = vec3(0.0, 0.0, 1.0);
@@ -520,7 +543,7 @@ void main() {
                 float ndl = max(dot(nv, uLightDir), 0.0);
                 float sp = pow(max(dot(reflect(-uLightDir,nv),viewDir),0.0), max(uShininess,1.0))*uSpecular;
                 vec3 base = vec3(pow(d,0.8));
-                vec3 lit = base*(uAmbient + uDiffuse*ndl) + vec3(sp);
+                vec3 lit = (base*(uAmbient + uDiffuse*ndl) + vec3(sp)) * voxelTint(p);
                 acc.rgb += (1.0-acc.a)*lit*a; acc.a += (1.0-acc.a)*a;
             }
             if (acc.a > uThigh && a < uTlow) {            // filled a layer, then exited it
@@ -626,6 +649,7 @@ void main() {
             lit *= 1.0 - 0.30 * depth01;
             a = op;
         }
+        lit *= voxelTint(p);          // white for scalar data, hue for colour-FA
         if (a > 0.0008) {
             a = 1.0 - pow(1.0 - clamp(a,0.0,1.0), dt/refStep);
             acc.rgb += (1.0-acc.a) * lit * a;
@@ -766,8 +790,20 @@ class RaycastGLWidget(QOpenGLWidget):
     def has_volume(self) -> bool:
         return self._volume is not None
 
+    def is_rgb_volume(self) -> bool:
+        """Whether the loaded volume carries colour rather than a scalar."""
+        return self._volume is not None and self._volume[0].ndim == 4
+
     def set_volume(self, u8: np.ndarray, spacing: tuple[float, float, float]) -> None:
-        self._volume = (np.ascontiguousarray(u8, dtype=np.uint8), spacing)
+        """Upload a volume: ``(X, Y, Z)`` scalar or ``(X, Y, Z, 3)`` colour."""
+        arr = np.ascontiguousarray(u8, dtype=np.uint8)
+        if arr.ndim == 4:
+            if arr.shape[3] < 3:
+                raise ValueError(f"colour volume needs 3+ channels, got {arr.shape}")
+            arr = np.ascontiguousarray(arr[..., :3])   # drop any alpha
+        elif arr.ndim != 3:
+            raise ValueError(f"volume must be 3-D or 4-D colour, got {arr.shape}")
+        self._volume = (arr, spacing)
         if self._prog and self._gl_ok and self._make_current():
             try:
                 self._upload_volume()
@@ -776,7 +812,23 @@ class RaycastGLWidget(QOpenGLWidget):
             self.update()
 
     def set_volume_float(self, vol, spacing) -> None:
-        self.set_volume(normalize_to_u8(vol), spacing)
+        """Normalise and upload. ``(X, Y, Z)`` scalar or ``(X, Y, Z, 3+)`` colour.
+
+        Colour volumes are scaled by ONE window across all channels, so the
+        hue of each voxel survives; windowing per channel would recolour the
+        data (a colour-FA map's direction encoding would be lost).
+        """
+        arr = np.asarray(vol)
+        if arr.ndim == 4:
+            rgb = arr[..., :3].astype(np.float32)
+            hi = float(np.nanmax(rgb)) if rgb.size else 0.0
+            if not np.isfinite(hi) or hi <= 0:
+                hi = 1.0
+            scale = 255.0 if hi <= 1.0 + 1e-6 else 255.0 / hi
+            u8 = np.clip(np.nan_to_num(rgb) * scale, 0, 255).astype(np.uint8)
+            self.set_volume(u8, spacing)
+            return
+        self.set_volume(normalize_to_u8(arr), spacing)
 
     def set_matcap(self, name: str) -> None:
         if name not in _LIGHTINGS:
@@ -947,6 +999,7 @@ class RaycastGLWidget(QOpenGLWidget):
         self._set_vec3(self._prog, "uLightDir", np.array(self.light_dir, np.float32))
         u = lambda n: GL.glGetUniformLocation(self._prog, n)
         GL.glUniform1i(u("uEffect"), int(self.effect))
+        GL.glUniform1i(u("uIsRGB"), 1 if self.is_rgb_volume() else 0)
         GL.glUniform1f(u("uThreshLo"), float(self.thresh_lo))
         GL.glUniform1f(u("uThreshHi"), float(self.thresh_hi))
         GL.glUniform1f(u("uDensity"), float(self.density))
@@ -1099,11 +1152,15 @@ class RaycastGLWidget(QOpenGLWidget):
         if self._volume is None:
             return
         u8, spacing = self._volume
-        x, y, z = u8.shape
+        # (X, Y, Z) scalar, or (X, Y, Z, 3) colour (colour-FA and friends).
+        rgb = u8.ndim == 4
+        x, y, z = u8.shape[:3]
         self._tex_dims = (x, y, z)
         extent = np.array([x*spacing[0], y*spacing[1], z*spacing[2]], np.float32)
         self._box_half = (0.5 * extent / float(extent.max())).astype(np.float32)
-        data = np.ascontiguousarray(u8.transpose(2, 1, 0))
+        data = np.ascontiguousarray(
+            u8.transpose(2, 1, 0, 3) if rgb else u8.transpose(2, 1, 0)
+        )
         if self._tex:
             GL.glDeleteTextures([self._tex])
         self._tex = GL.glGenTextures(1)
@@ -1113,8 +1170,12 @@ class RaycastGLWidget(QOpenGLWidget):
             GL.glTexParameteri(GL.GL_TEXTURE_3D, pn, GL.GL_CLAMP_TO_EDGE)
         GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
         GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
-        GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_R8, x, y, z, 0,
-                        GL.GL_RED, GL.GL_UNSIGNED_BYTE, data)
+        if rgb:
+            GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_RGB8, x, y, z, 0,
+                            GL.GL_RGB, GL.GL_UNSIGNED_BYTE, data)
+        else:
+            GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_R8, x, y, z, 0,
+                            GL.GL_RED, GL.GL_UNSIGNED_BYTE, data)
 
     def _build_program(self, vsrc: str, fsrc: str) -> int:
         def compile_stage(src, stage):

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -1,0 +1,938 @@
+"""GPU volume-raycasting 3-D view for the NIfTI viewer.
+
+Companion to :class:`bidsmgr.gui.widgets.NiftiViewerPane`. Renders the
+current volume with a single-pass OpenGL ray-caster — the technique
+MRIcroGL uses — with only the dependencies BIDS-Manager already ships
+(PyQt6 + PyOpenGL). No VTK, no WebGL, no new wheels.
+
+Rendering effects (``uEffect``), à la MRIcroGL's shader menu:
+    * **Surface** — matcap-lit iso-surface compositing (``Default.glsl``).
+    * **MIP**     — maximum-intensity projection (``MIP.glsl``).
+    * **Glass**   — translucent surface with a Fresnel rim (``Glass.glsl``).
+    * **X-ray**   — integrated attenuation (additive, see-through).
+    * **Edges**   — gradient-magnitude silhouettes (``Edges.glsl``).
+
+Lighting is a **matcap** (material-capture) texture sampled by the
+view-space gradient normal — MRIcroGL's approach. Several studio materials
+are generated procedurally (Shiny White, Clay, Matte, Titanium, Gold, Blue).
+
+**Clip plane** (MRIcroGL ``applyClip``): an oblique plane set by Azimuth /
+Elevation / Depth / Thickness. Where the plane cuts through tissue the
+exposed face is drawn as a smooth *intensity slice* (like a 2-D cross-
+section) rather than a noisy interior iso-surface — the key to MRIcroGL's
+clean cut look.
+
+Robustness: the GL context is created lazily and every GL entry point is
+guarded, so a missing driver / headless ``offscreen`` platform degrades to
+an inert widget instead of crashing. The last volume is retained so the
+render survives context loss (window detach / re-attach → ``initializeGL``
+re-runs and re-uploads it).
+
+Interaction: left-drag orbit · right/middle-drag pan · wheel zoom.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+from PyQt6.QtCore import Qt, QPoint
+from PyQt6.QtGui import QSurfaceFormat
+from PyQt6.QtOpenGLWidgets import QOpenGLWidget
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+log = logging.getLogger(__name__)
+
+
+def request_gl_format() -> QSurfaceFormat:
+    """Return (and register as default) an OpenGL 3.3 core surface format.
+
+    macOS only exposes the modern ``#version 330`` shading language through
+    a *core-profile* context; the compatibility profile is stuck at 2.1.
+    Register this before the ``QApplication`` is built. Safe to call twice.
+    """
+    fmt = QSurfaceFormat()
+    fmt.setVersion(3, 3)
+    fmt.setProfile(QSurfaceFormat.OpenGLContextProfile.CoreProfile)
+    fmt.setDepthBufferSize(24)
+    QSurfaceFormat.setDefaultFormat(fmt)
+    return fmt
+
+
+# Effects (index == uEffect in the shader).
+EFFECTS = ["Surface", "MIP", "Glass", "X-ray", "Edges"]
+
+# Matcap "lighting" materials: (ambient, key, fill, spec_power, spec_int, tint).
+_LIGHTINGS: dict[str, tuple] = {
+    "Shiny White": (0.34, 0.78, 0.26, 90.0, 1.05, (1.00, 0.99, 0.97)),
+    "Clay":        (0.38, 0.64, 0.28, 12.0, 0.16, (0.86, 0.78, 0.70)),
+    "Matte":       (0.48, 0.54, 0.32,  4.0, 0.00, (0.82, 0.82, 0.84)),
+    "Titanium":    (0.24, 0.82, 0.22, 96.0, 0.95, (0.72, 0.75, 0.80)),
+    "Gold":        (0.30, 0.74, 0.22, 44.0, 0.85, (0.96, 0.80, 0.36)),
+    "Blue":        (0.30, 0.68, 0.28, 34.0, 0.60, (0.56, 0.69, 0.96)),
+}
+LIGHTINGS = list(_LIGHTINGS)
+
+# Default control values (used by "Reset parameters").
+DEFAULTS = dict(
+    effect=0, light=0, lo=120, hi=420, den=100, bright=140, surf=65, q=512,
+    clip=False, az=0, el=0, depth=500, thick=1000,
+)
+
+
+# --------------------------------------------------------------------------
+# Volume normalisation + matrix helpers
+# --------------------------------------------------------------------------
+
+def normalize_to_u8(vol: np.ndarray) -> np.ndarray:
+    """Window a float volume to uint8 on a robust 0.5–99.5 percentile range."""
+    v = np.ascontiguousarray(vol, dtype=np.float32)
+    lo, hi = np.percentile(v, (0.5, 99.5))
+    if not np.isfinite(lo) or not np.isfinite(hi) or hi <= lo:
+        lo, hi = float(np.nanmin(v)), float(np.nanmax(v))
+        if hi <= lo:
+            hi = lo + 1.0
+    return (np.clip((v - lo) / (hi - lo), 0.0, 1.0) * 255.0).astype(np.uint8)
+
+
+def _normalize(v: np.ndarray) -> np.ndarray:
+    n = np.linalg.norm(v)
+    return v / n if n > 0 else v
+
+
+def clip_normal_from(az_deg: float, el_deg: float) -> tuple[float, float, float]:
+    """Unit clip-plane normal from azimuth/elevation (RAS texcoord space)."""
+    az, el = np.radians(az_deg), np.radians(el_deg)
+    ce = np.cos(el)
+    n = np.array([ce * np.sin(az), ce * np.cos(az), np.sin(el)], np.float32)
+    n = _normalize(n)
+    return float(n[0]), float(n[1]), float(n[2])
+
+
+def _perspective(fovy_deg: float, aspect: float, near: float, far: float) -> np.ndarray:
+    f = 1.0 / np.tan(np.radians(fovy_deg) / 2.0)
+    m = np.zeros((4, 4), dtype=np.float32)
+    m[0, 0] = f / max(aspect, 1e-6)
+    m[1, 1] = f
+    m[2, 2] = (far + near) / (near - far)
+    m[2, 3] = (2.0 * far * near) / (near - far)
+    m[3, 2] = -1.0
+    return m
+
+
+def _look_at(eye: np.ndarray, center: np.ndarray, up: np.ndarray) -> np.ndarray:
+    f = _normalize(center - eye)
+    s = _normalize(np.cross(f, up))
+    u = np.cross(s, f)
+    m = np.eye(4, dtype=np.float32)
+    m[0, :3] = s
+    m[1, :3] = u
+    m[2, :3] = -f
+    m[0, 3] = -np.dot(s, eye)
+    m[1, 3] = -np.dot(u, eye)
+    m[2, 3] = np.dot(f, eye)
+    return m
+
+
+def _make_matcap(name: str, size: int = 256) -> np.ndarray:
+    """Procedural studio-lit sphere → an RGB matcap (``size×size×3`` uint8).
+
+    A matcap encodes the shaded appearance of a unit sphere: for a screen-
+    space normal ``(nx, ny)`` the lit colour is read straight out of this
+    image. Two directional lights + ambient + a Blinn-Phong highlight give
+    MRIcroGL's soft "clay / shiny / metal" looks — parameterised per material
+    in :data:`_LIGHTINGS`. A broad soft key plus a tight bright hotspot give
+    "Shiny White" the glossy sheen MRIcroGL's default has.
+    """
+    amb, key_i, fill_i, spow, spec_i, tint = _LIGHTINGS[name]
+    ax = np.linspace(-1.0, 1.0, size, dtype=np.float32)
+    u, v = np.meshgrid(ax, ax)
+    r2 = u * u + v * v
+    inside = r2 <= 1.0
+    z = np.sqrt(np.clip(1.0 - r2, 0.0, 1.0))
+    n = np.stack([u, v, z], axis=-1)
+
+    key = _normalize(np.array([0.35, 0.55, 0.75], np.float32))
+    fill = _normalize(np.array([-0.6, 0.10, 0.55], np.float32))
+    view = np.array([0.0, 0.0, 1.0], np.float32)
+    half = _normalize(key + view)
+
+    ndl_key = np.clip((n * key).sum(-1), 0.0, 1.0)
+    ndl_fill = np.clip((n * fill).sum(-1), 0.0, 1.0)
+    nh = np.clip((n * half).sum(-1), 0.0, 1.0)
+    spec = nh ** spow + 0.25 * (nh ** (spow * 0.25))   # tight hotspot + soft sheen
+
+    # Wrap-diffuse (soft terminator) reads more like MRIcroGL than hard N·L.
+    wrap = np.clip((ndl_key + 0.35) / 1.35, 0.0, 1.0)
+    lum = amb + key_i * wrap + fill_i * ndl_fill
+    col = lum[..., None] * np.array(tint, np.float32)
+    col = col + spec[..., None] * (spec_i * np.array([1.0, 1.0, 1.0], np.float32))
+    col = np.clip(col, 0.0, 1.0)
+    col[~inside] = 0.0
+    return (col * 255.0).astype(np.uint8)
+
+
+# --------------------------------------------------------------------------
+# Shaders
+# --------------------------------------------------------------------------
+
+_VERT = """
+#version 330 core
+out vec2 vNdc;
+void main() {
+    vec2 pos = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+    vNdc = pos * 2.0 - 1.0;
+    gl_Position = vec4(vNdc, 0.0, 1.0);
+}
+"""
+
+_FRAG = """
+#version 330 core
+in  vec2 vNdc;
+out vec4 FragColor;
+
+uniform sampler3D uVol;
+uniform sampler2D uMatcap;
+uniform mat4  uInvViewProj;
+uniform mat3  uNormalMatrix;
+uniform vec3  uBoxHalf;
+uniform vec3  uTexSize;
+uniform int   uEffect;         // 0 Surface, 1 MIP, 2 Glass, 3 X-ray, 4 Edges
+uniform float uThreshLo;
+uniform float uThreshHi;
+uniform float uDensity;
+uniform float uBrighten;
+uniform float uSurface;
+uniform int   uSteps;
+uniform vec3  uBg;
+uniform int   uClipActive;
+uniform vec3  uClipNormal;
+uniform float uClipDepth;      // signed distance of the near cut plane
+uniform float uClipThick;      // slab thickness removed
+
+bool intersectBox(vec3 ro, vec3 rd, out float tNear, out float tFar) {
+    vec3 inv = 1.0 / rd;
+    vec3 t0 = (-uBoxHalf - ro) * inv;
+    vec3 t1 = ( uBoxHalf - ro) * inv;
+    vec3 tsm = min(t0, t1), tbg = max(t0, t1);
+    tNear = max(max(tsm.x, tsm.y), tsm.z);
+    tFar  = min(min(tbg.x, tbg.y), tbg.z);
+    return tFar >= max(tNear, 0.0);
+}
+
+float samp(vec3 uvw) { return texture(uVol, uvw).r; }
+
+bool clipped(vec3 uvw) {
+    if (uClipActive == 0) return false;
+    float sd = dot(uClipNormal, uvw - vec3(0.5));
+    return sd > uClipDepth && sd < uClipDepth + uClipThick;
+}
+
+vec3 gradient(vec3 uvw) {
+    vec3 e = 1.0 / uTexSize;
+    return vec3(
+        samp(uvw + vec3(e.x, 0, 0)) - samp(uvw - vec3(e.x, 0, 0)),
+        samp(uvw + vec3(0, e.y, 0)) - samp(uvw - vec3(0, e.y, 0)),
+        samp(uvw + vec3(0, 0, e.z)) - samp(uvw - vec3(0, 0, e.z)));
+}
+
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
+void main() {
+    vec4 pn = uInvViewProj * vec4(vNdc, -1.0, 1.0);
+    vec4 pf = uInvViewProj * vec4(vNdc,  1.0, 1.0);
+    vec3 ro = pn.xyz / pn.w;
+    vec3 rd = normalize(pf.xyz / pf.w - ro);
+
+    float tNear, tFar;
+    if (!intersectBox(ro, rd, tNear, tFar)) { FragColor = vec4(uBg, 1.0); return; }
+    tNear = max(tNear, 0.0);
+
+    vec3  boxSize = 2.0 * uBoxHalf;
+    float dt      = length(boxSize) / float(uSteps);
+    float refStep = length(boxSize) / 512.0;
+    float t0      = tNear + hash(gl_FragCoord.xy) * dt;
+
+    // Guard the transfer-function window so a lo>=hi drag can't invert the
+    // smoothstep and paint the whole box (the "black square" bug).
+    float e0 = min(uThreshLo, uThreshHi);
+    float e1 = max(uThreshLo, uThreshHi);
+    if (e1 <= e0) e1 = e0 + 1e-3;
+
+    // ---- MIP ----
+    if (uEffect == 1) {
+        float mx = 0.0, t = t0;
+        for (int i = 0; i < 4096; ++i) {
+            if (t > tFar) break;
+            vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
+            if (!clipped(uvw)) mx = max(mx, samp(uvw));
+            t += dt;
+        }
+        float w = clamp((mx - e0) / (e1 - e0), 0.0, 1.0);
+        FragColor = vec4(mix(uBg, vec3(1.0), w), 1.0);
+        return;
+    }
+
+    // ---- X-ray ----
+    if (uEffect == 3) {
+        float sum = 0.0, t = t0;
+        for (int i = 0; i < 4096; ++i) {
+            if (t > tFar) break;
+            vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
+            if (!clipped(uvw)) { float d = samp(uvw); if (d > e0) sum += (d - e0) * uDensity; }
+            t += dt;
+        }
+        float a = 1.0 - exp(-sum * dt * 6.0);
+        FragColor = vec4(mix(uBg, vec3(1.0), clamp(a, 0.0, 1.0)), 1.0);
+        return;
+    }
+
+    // ---- Surface (0) / Glass (2) / Edges (4): compositing ----
+    bool glass = (uEffect == 2);
+    bool edges = (uEffect == 4);
+    float aScale = glass ? 0.4 : 1.0;
+    vec4 acc = vec4(0.0);
+    float t = t0;
+    bool prevClip = false;
+    for (int i = 0; i < 4096; ++i) {
+        if (t > tFar || (acc.a > 0.985 && !glass)) break;
+        vec3 uvw = (ro + rd * t + uBoxHalf) / boxSize;
+        if (clipped(uvw)) { prevClip = true; t += dt; continue; }
+        float d = samp(uvw);
+
+        // Cut face: first kept sample right after crossing the clip plane.
+        // Show a smooth intensity cross-section (MRIcroGL slice look) where
+        // tissue is present; fall through to the 3-D surface where it's air.
+        if (uClipActive == 1 && prevClip && !edges) {
+            prevClip = false;
+            if (d > 0.05) {
+                float sv = pow(clamp(d, 0.0, 1.0), 0.8);
+                acc.rgb += (1.0 - acc.a) * vec3(sv);
+                acc.a = 1.0;
+                break;
+            }
+        }
+        prevClip = false;
+
+        float a = smoothstep(e0, e1, d) * uDensity * aScale;
+        if (a > 0.001) {
+            a = 1.0 - pow(1.0 - a, dt / refStep);
+            vec3 nw = normalize(-gradient(uvw) + 1e-6);
+            vec3 nv = normalize(uNormalMatrix * nw);
+            float fres = pow(1.0 - abs(nv.z), 2.5);
+            vec3 lit;
+            if (edges) {
+                lit = vec3(fres) * uBrighten;
+            } else {
+                vec3 mc = texture(uMatcap, nv.xy * 0.5 + 0.5).rgb;
+                vec3 surf = mix(vec3(0.5), vec3(pow(d, 0.8)), uSurface);
+                lit = mc * surf * uBrighten;
+                if (glass) lit += vec3(0.5) * fres;
+                // Depth cue: dim samples deeper into the volume for shape.
+                float depth01 = clamp((t - tNear) / max(tFar - tNear, 1e-3), 0.0, 1.0);
+                lit *= 1.0 - 0.3 * depth01;
+            }
+            acc.rgb += (1.0 - acc.a) * lit * a;
+            acc.a   += (1.0 - acc.a) * a;
+        }
+        t += dt;
+    }
+    FragColor = vec4(acc.rgb + (1.0 - acc.a) * uBg, 1.0);
+}
+"""
+
+
+# --------------------------------------------------------------------------
+# GL widget (bare canvas)
+# --------------------------------------------------------------------------
+
+class RaycastGLWidget(QOpenGLWidget):
+    """QOpenGLWidget hosting the single-pass volume raycaster (no controls)."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setFormat(request_gl_format())
+
+        self._prog = 0
+        self._vao = 0
+        self._tex = 0
+        self._matcap_tex = 0
+        self._tex_dims = (1, 1, 1)
+        self._box_half = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+        self._gl_ok = False
+        self._gl_error = ""
+        # Retained so the render survives context loss (detach / re-attach):
+        # ``initializeGL`` re-runs on the new context and re-uploads this.
+        self._volume: Optional[tuple[np.ndarray, tuple[float, float, float]]] = None
+        self._matcaps: dict[str, np.ndarray] = {}
+        self._matcap_dirty = True
+
+        # Camera: orbit (azimuth/elevation/distance) about a pannable target.
+        self._az = 0.6
+        self._el = 0.3
+        self._dist = 2.6
+        self._target = np.zeros(3, np.float32)
+        self._last: Optional[QPoint] = None
+        self._drag = "rotate"
+
+        # Shader-driven display state (mutated by Nifti3DControls).
+        self.effect = DEFAULTS["effect"]
+        self.thresh_lo = DEFAULTS["lo"] / 1000.0
+        self.thresh_hi = DEFAULTS["hi"] / 1000.0
+        self.density = DEFAULTS["den"] / 100.0
+        self.brighten = DEFAULTS["bright"] / 100.0
+        self.surface = DEFAULTS["surf"] / 100.0
+        self.steps = DEFAULTS["q"]
+        self.matcap_name = LIGHTINGS[0]
+        self.clip_active = 0
+        self.clip_normal = (0.0, 1.0, 0.0)
+        self.clip_depth = 0.0
+        self.clip_thick = 3.0
+        self._bg = (0.05, 0.06, 0.08)
+
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+    # -- public API --------------------------------------------------------
+
+    def gl_ok(self) -> bool:
+        return self._gl_ok
+
+    def has_volume(self) -> bool:
+        return self._volume is not None
+
+    def set_volume(self, u8: np.ndarray, spacing: tuple[float, float, float]) -> None:
+        """Bind a uint8 volume; retained + uploaded when GL is ready."""
+        self._volume = (np.ascontiguousarray(u8, dtype=np.uint8), spacing)
+        if self._prog and self._gl_ok and self._make_current():
+            try:
+                self._upload_volume()
+            finally:
+                self.doneCurrent()
+            self.update()
+
+    def set_volume_float(self, vol: np.ndarray,
+                         spacing: tuple[float, float, float]) -> None:
+        self.set_volume(normalize_to_u8(vol), spacing)
+
+    def set_matcap(self, name: str) -> None:
+        if name not in _LIGHTINGS:
+            return
+        self.matcap_name = name
+        self._matcap_dirty = True
+        if self._prog and self._gl_ok and self._make_current():
+            try:
+                self._refresh_matcap()
+            finally:
+                self.doneCurrent()
+            self.update()
+
+    def refresh(self) -> None:
+        """Re-upload the matcap + volume and repaint (manual recovery)."""
+        self._matcap_dirty = True
+        if self._prog and self._gl_ok and self._make_current():
+            try:
+                self._refresh_matcap()
+                if self._volume is not None:
+                    self._upload_volume()
+            finally:
+                self.doneCurrent()
+        self.update()
+
+    def clear(self) -> None:
+        self._volume = None
+        if self._tex and self._make_current():
+            try:
+                self._safe(lambda: GL.glDeleteTextures([self._tex]))
+                self._tex = 0
+            finally:
+                self.doneCurrent()
+            self.update()
+
+    def reset_view(self) -> None:
+        self._az, self._el, self._dist = 0.6, 0.3, 2.6
+        self._target = np.zeros(3, np.float32)
+        self.update()
+
+    # -- GL lifecycle ------------------------------------------------------
+
+    def initializeGL(self) -> None:
+        # A fresh context (first show, or after a detach/re-attach) invalidates
+        # every prior GL object — rebuild them all and re-upload the volume.
+        self._gl_ok = False
+        self._tex = 0
+        try:
+            self._import_gl()
+            self._prog = self._build_program(_VERT, _FRAG)
+            self._vao = GL.glGenVertexArrays(1)
+            self._matcap_tex = GL.glGenTextures(1)
+            self._matcap_dirty = True
+            self._refresh_matcap()
+            GL.glDisable(GL.GL_DEPTH_TEST)
+            GL.glClearColor(*self._bg, 1.0)
+            self._gl_ok = True
+            if self._volume is not None:
+                self._upload_volume()
+        except Exception as exc:  # noqa: BLE001 - degrade, never crash the app
+            self._gl_ok = False
+            self._gl_error = str(exc)
+            log.warning("3-D GL initialisation failed: %s", exc)
+
+    def resizeGL(self, w: int, h: int) -> None:
+        if self._gl_ok:
+            GL.glViewport(0, 0, w, h)
+
+    def paintGL(self) -> None:
+        if not self._gl_ok:
+            return
+        GL.glClearColor(*self._bg, 1.0)
+        GL.glClear(GL.GL_COLOR_BUFFER_BIT)
+        if not self._tex:
+            return
+
+        w = max(self.width(), 1)
+        h = max(self.height(), 1)
+        eye = self._eye()
+        view = _look_at(eye, self._target, np.array([0, 0, 1], np.float32))
+        proj = _perspective(45.0, w / h, 0.01, 20.0)
+        inv_vp = np.linalg.inv(proj @ view).astype(np.float32)
+        normal_mat = np.ascontiguousarray(view[:3, :3], np.float32)
+
+        GL.glUseProgram(self._prog)
+        self._set_mat4("uInvViewProj", inv_vp)
+        self._set_mat3("uNormalMatrix", normal_mat)
+        self._set_vec3("uBoxHalf", self._box_half)
+        self._set_vec3("uTexSize", np.array(self._tex_dims, np.float32))
+        self._set_vec3("uBg", np.array(self._bg, np.float32))
+        GL.glUniform1i(self._loc("uEffect"), int(self.effect))
+        GL.glUniform1f(self._loc("uThreshLo"), float(self.thresh_lo))
+        GL.glUniform1f(self._loc("uThreshHi"), float(self.thresh_hi))
+        GL.glUniform1f(self._loc("uDensity"), float(self.density))
+        GL.glUniform1f(self._loc("uBrighten"), float(self.brighten))
+        GL.glUniform1f(self._loc("uSurface"), float(self.surface))
+        GL.glUniform1i(self._loc("uSteps"), int(self.steps))
+        GL.glUniform1i(self._loc("uClipActive"), int(self.clip_active))
+        self._set_vec3("uClipNormal", np.array(self.clip_normal, np.float32))
+        GL.glUniform1f(self._loc("uClipDepth"), float(self.clip_depth))
+        GL.glUniform1f(self._loc("uClipThick"), float(self.clip_thick))
+
+        GL.glActiveTexture(GL.GL_TEXTURE0)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, self._tex)
+        GL.glUniform1i(self._loc("uVol"), 0)
+        GL.glActiveTexture(GL.GL_TEXTURE1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._matcap_tex)
+        GL.glUniform1i(self._loc("uMatcap"), 1)
+
+        GL.glBindVertexArray(self._vao)
+        GL.glDrawArrays(GL.GL_TRIANGLES, 0, 3)
+        GL.glBindVertexArray(0)
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _import_gl() -> None:
+        global GL
+        from OpenGL import GL as _GL
+        GL = _GL
+
+    def _make_current(self) -> bool:
+        try:
+            self.makeCurrent()
+            return self.context() is not None and self.context().isValid()
+        except Exception:  # noqa: BLE001
+            return False
+
+    def _safe(self, fn):
+        try:
+            return fn()
+        except Exception as exc:  # noqa: BLE001
+            log.debug("GL call failed: %s", exc)
+            return None
+
+    def _eye(self) -> np.ndarray:
+        ce = np.cos(self._el)
+        d = np.array([ce * np.sin(self._az), ce * np.cos(self._az), np.sin(self._el)])
+        return (self._target + self._dist * d).astype(np.float32)
+
+    def _camera_basis(self) -> tuple[np.ndarray, np.ndarray]:
+        eye = self._eye()
+        up = np.array([0, 0, 1], np.float32)
+        f = _normalize(self._target - eye)
+        r = _normalize(np.cross(f, up))
+        u = np.cross(r, f)
+        return r, u
+
+    def _refresh_matcap(self) -> None:
+        if not self._matcap_dirty or not self._matcap_tex:
+            return
+        mc = self._matcaps.get(self.matcap_name)
+        if mc is None:
+            mc = _make_matcap(self.matcap_name, 256)
+            self._matcaps[self.matcap_name] = mc
+        h, w = mc.shape[:2]
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._matcap_tex)
+        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGB8, w, h, 0,
+                        GL.GL_RGB, GL.GL_UNSIGNED_BYTE, np.ascontiguousarray(mc))
+        self._matcap_dirty = False
+
+    def _upload_volume(self) -> None:
+        if self._volume is None:
+            return
+        u8, spacing = self._volume
+        x, y, z = u8.shape
+        self._tex_dims = (x, y, z)
+        extent = np.array([x * spacing[0], y * spacing[1], z * spacing[2]], np.float32)
+        self._box_half = (0.5 * extent / float(extent.max())).astype(np.float32)
+        data = np.ascontiguousarray(u8.transpose(2, 1, 0))  # x fastest for GL
+        if self._tex:
+            GL.glDeleteTextures([self._tex])
+        self._tex = GL.glGenTextures(1)
+        GL.glBindTexture(GL.GL_TEXTURE_3D, self._tex)
+        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
+        for pname in (GL.GL_TEXTURE_WRAP_S, GL.GL_TEXTURE_WRAP_T, GL.GL_TEXTURE_WRAP_R):
+            GL.glTexParameteri(GL.GL_TEXTURE_3D, pname, GL.GL_CLAMP_TO_EDGE)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+        GL.glTexParameteri(GL.GL_TEXTURE_3D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+        GL.glTexImage3D(GL.GL_TEXTURE_3D, 0, GL.GL_R8, x, y, z, 0,
+                        GL.GL_RED, GL.GL_UNSIGNED_BYTE, data)
+
+    def _build_program(self, vsrc: str, fsrc: str) -> int:
+        def compile_stage(src: str, stage: int) -> int:
+            sh = GL.glCreateShader(stage)
+            GL.glShaderSource(sh, src)
+            GL.glCompileShader(sh)
+            if not GL.glGetShaderiv(sh, GL.GL_COMPILE_STATUS):
+                raise RuntimeError(GL.glGetShaderInfoLog(sh).decode())
+            return sh
+
+        vs = compile_stage(vsrc, GL.GL_VERTEX_SHADER)
+        fs = compile_stage(fsrc, GL.GL_FRAGMENT_SHADER)
+        prog = GL.glCreateProgram()
+        GL.glAttachShader(prog, vs)
+        GL.glAttachShader(prog, fs)
+        GL.glLinkProgram(prog)
+        if not GL.glGetProgramiv(prog, GL.GL_LINK_STATUS):
+            raise RuntimeError(GL.glGetProgramInfoLog(prog).decode())
+        GL.glDeleteShader(vs)
+        GL.glDeleteShader(fs)
+        return prog
+
+    def _loc(self, name: str) -> int:
+        return GL.glGetUniformLocation(self._prog, name)
+
+    def _set_mat4(self, name: str, m: np.ndarray) -> None:
+        GL.glUniformMatrix4fv(self._loc(name), 1, GL.GL_TRUE,
+                              np.ascontiguousarray(m, np.float32))
+
+    def _set_mat3(self, name: str, m: np.ndarray) -> None:
+        GL.glUniformMatrix3fv(self._loc(name), 1, GL.GL_TRUE,
+                              np.ascontiguousarray(m, np.float32))
+
+    def _set_vec3(self, name: str, v: np.ndarray) -> None:
+        GL.glUniform3f(self._loc(name), float(v[0]), float(v[1]), float(v[2]))
+
+    # -- interaction -------------------------------------------------------
+
+    def mousePressEvent(self, ev) -> None:
+        self.setFocus(Qt.FocusReason.MouseFocusReason)
+        self._last = ev.position().toPoint()
+        btn = ev.button()
+        pan = (btn in (Qt.MouseButton.RightButton, Qt.MouseButton.MiddleButton)
+               or ev.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        self._drag = "pan" if pan else "rotate"
+
+    def mouseMoveEvent(self, ev) -> None:
+        if self._last is None:
+            return
+        p = ev.position().toPoint()
+        dx = p.x() - self._last.x()
+        dy = p.y() - self._last.y()
+        self._last = p
+        if self._drag == "pan":
+            r, u = self._camera_basis()
+            scale = 0.0022 * self._dist
+            self._target += (-dx * r + dy * u) * scale
+        else:
+            # Drag right -> volume turns right (camera orbits the other way).
+            self._az += dx * 0.01
+            self._el = float(np.clip(self._el + dy * 0.01, -1.55, 1.55))
+        self.update()
+
+    def mouseReleaseEvent(self, ev) -> None:
+        self._last = None
+
+    def wheelEvent(self, ev) -> None:
+        factor = 0.9 if ev.angleDelta().y() > 0 else 1.1
+        self._dist = float(np.clip(self._dist * factor, 0.5, 12.0))
+        self.update()
+
+
+# --------------------------------------------------------------------------
+# Controls (bound to a RaycastGLWidget; laid out as a vertical column)
+# --------------------------------------------------------------------------
+
+_THRESH_GAP = 20  # min separation (slider units) between lo and hi
+
+
+class Nifti3DControls(QWidget):
+    """Effect / lighting / transfer-function / clip controls for a render.
+
+    Bound to a :class:`RaycastGLWidget` and stacked vertically so the growing
+    control set (now including the MRIcroGL-style clip Azimuth / Elevation /
+    Depth / Thickness) stays legible; used inside a scroll area by the pane.
+    ``vertical`` is retained for API symmetry (layout is always a column).
+    """
+
+    def __init__(self, gl: RaycastGLWidget, *, vertical: bool = True,
+                 parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("sidecar-toolbar")
+        self.gl = gl
+        self._vertical = vertical
+        self._build_widgets()
+        self._layout()
+        self._apply_clip()
+
+    # -- widget construction ----------------------------------------------
+
+    def _build_widgets(self) -> None:
+        self._effect = QComboBox()
+        self._effect.addItems(EFFECTS)
+        self._effect.setToolTip("Rendering effect (Surface, MIP, Glass, X-ray, Edges).")
+        self._effect.currentIndexChanged.connect(self._on_effect)
+
+        self._light = QComboBox()
+        self._light.addItems(LIGHTINGS)
+        self._light.setToolTip("Lighting material (matcap).")
+        self._light.currentIndexChanged.connect(self._on_light)
+
+        self._lo = self._slider(0, 1000, DEFAULTS["lo"], self._on_lo)
+        self._hi = self._slider(0, 1000, DEFAULTS["hi"], self._on_hi)
+        self._den = self._slider(0, 300, DEFAULTS["den"], self._on_den)
+        self._bright = self._slider(50, 300, DEFAULTS["bright"], self._on_bright)
+        self._surf = self._slider(0, 100, DEFAULTS["surf"], self._on_surf)
+        self._q = self._slider(64, 1024, DEFAULTS["q"], self._on_q)
+
+        # Clip: MRIcroGL-style oblique plane (enable + az / el / depth / thick).
+        self._clip_enable = QCheckBox("Enable clip plane")
+        self._clip_enable.setToolTip("Slice into the volume to reveal interior.")
+        self._clip_enable.stateChanged.connect(self._on_clip_change)
+        self._az = self._slider(0, 360, DEFAULTS["az"], self._on_clip_change)
+        self._el = self._slider(-90, 90, DEFAULTS["el"], self._on_clip_change)
+        self._depth = self._slider(0, 1000, DEFAULTS["depth"], self._on_clip_change)
+        self._thick = self._slider(0, 1000, DEFAULTS["thick"], self._on_clip_change)
+
+        self._refresh_btn = QPushButton("Refresh image")
+        self._refresh_btn.setObjectName("tb-btn-toggle")
+        self._refresh_btn.setToolTip("Re-upload + repaint the render.")
+        self._refresh_btn.clicked.connect(lambda: self.gl.refresh())
+
+        self._reset_params_btn = QPushButton("Reset parameters")
+        self._reset_params_btn.setObjectName("tb-btn-toggle")
+        self._reset_params_btn.setToolTip("Restore all render settings to defaults.")
+        self._reset_params_btn.clicked.connect(self.reset_params)
+
+        self._reset_view_btn = QPushButton("Reset view")
+        self._reset_view_btn.setObjectName("tb-btn-toggle")
+        self._reset_view_btn.setToolTip("Recentre the camera.")
+        self._reset_view_btn.clicked.connect(self.gl.reset_view)
+
+    def _layout(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(12, 10, 12, 10)
+        outer.setSpacing(9)
+        for lbl, wdg in (
+            ("Effect", self._effect), ("Lighting", self._light),
+            ("Threshold low", self._lo), ("Threshold high", self._hi),
+            ("Density", self._den), ("Brightness", self._bright),
+            ("Surface colour", self._surf), ("Quality", self._q),
+        ):
+            outer.addLayout(self._stacked(lbl, wdg))
+
+        outer.addSpacing(4)
+        outer.addWidget(self._clip_enable)
+        for lbl, wdg in (
+            ("Clip azimuth", self._az), ("Clip elevation", self._el),
+            ("Clip depth", self._depth), ("Clip thickness", self._thick),
+        ):
+            outer.addLayout(self._stacked(lbl, wdg))
+
+        outer.addSpacing(6)
+        outer.addWidget(self._refresh_btn)
+        outer.addWidget(self._reset_params_btn)
+        outer.addWidget(self._reset_view_btn)
+        outer.addStretch(1)
+        hint = self._chip("Left-drag rotate · right-drag pan · scroll zoom")
+        hint.setWordWrap(True)
+        outer.addWidget(hint)
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _chip(text: str) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setObjectName("sidecar-footer-summary")
+        return lbl
+
+    def _stacked(self, text: str, wdg: QWidget) -> QVBoxLayout:
+        box = QVBoxLayout()
+        box.setContentsMargins(0, 0, 0, 0)
+        box.setSpacing(2)
+        box.addWidget(self._chip(text))
+        box.addWidget(wdg)
+        return box
+
+    @staticmethod
+    def _slider(lo: int, hi: int, val: int, cb) -> QSlider:
+        s = QSlider(Qt.Orientation.Horizontal)
+        s.setRange(lo, hi)
+        s.setValue(val)
+        s.setFixedWidth(180)
+        s.valueChanged.connect(cb)
+        return s
+
+    # -- slots -------------------------------------------------------------
+
+    def _on_effect(self, i: int) -> None:
+        self.gl.effect = int(i)
+        self.gl.update()
+
+    def _on_light(self, i: int) -> None:
+        self.gl.set_matcap(LIGHTINGS[int(i)])
+
+    def _on_lo(self, v: int) -> None:
+        if v > self._hi.value() - _THRESH_GAP:
+            self._hi.blockSignals(True)
+            self._hi.setValue(min(1000, v + _THRESH_GAP))
+            self._hi.blockSignals(False)
+            self.gl.thresh_hi = self._hi.value() / 1000.0
+        self.gl.thresh_lo = v / 1000.0
+        self.gl.update()
+
+    def _on_hi(self, v: int) -> None:
+        if v < self._lo.value() + _THRESH_GAP:
+            self._lo.blockSignals(True)
+            self._lo.setValue(max(0, v - _THRESH_GAP))
+            self._lo.blockSignals(False)
+            self.gl.thresh_lo = self._lo.value() / 1000.0
+        self.gl.thresh_hi = v / 1000.0
+        self.gl.update()
+
+    def _on_den(self, v: int) -> None:
+        self.gl.density = v / 100.0
+        self.gl.update()
+
+    def _on_bright(self, v: int) -> None:
+        self.gl.brighten = v / 100.0
+        self.gl.update()
+
+    def _on_surf(self, v: int) -> None:
+        self.gl.surface = v / 100.0
+        self.gl.update()
+
+    def _on_q(self, v: int) -> None:
+        self.gl.steps = int(v)
+        self.gl.update()
+
+    def _on_clip_change(self, *_args) -> None:
+        self._apply_clip()
+
+    def _apply_clip(self) -> None:
+        on = self._clip_enable.isChecked()
+        for w in (self._az, self._el, self._depth, self._thick):
+            w.setEnabled(on)
+        if not on:
+            self.gl.clip_active = 0
+        else:
+            self.gl.clip_active = 1
+            self.gl.clip_normal = clip_normal_from(self._az.value(), self._el.value())
+            self.gl.clip_depth = (self._depth.value() / 1000.0 - 0.5) * 1.8
+            self.gl.clip_thick = 0.02 + (self._thick.value() / 1000.0) * 2.98
+        self.gl.update()
+
+    def reset_params(self) -> None:
+        """Restore every control (and the GL state it drives) to defaults."""
+        specs = (
+            (self._effect.setCurrentIndex, DEFAULTS["effect"]),
+            (self._light.setCurrentIndex, DEFAULTS["light"]),
+            (self._lo.setValue, DEFAULTS["lo"]),
+            (self._hi.setValue, DEFAULTS["hi"]),
+            (self._den.setValue, DEFAULTS["den"]),
+            (self._bright.setValue, DEFAULTS["bright"]),
+            (self._surf.setValue, DEFAULTS["surf"]),
+            (self._q.setValue, DEFAULTS["q"]),
+            (self._az.setValue, DEFAULTS["az"]),
+            (self._el.setValue, DEFAULTS["el"]),
+            (self._depth.setValue, DEFAULTS["depth"]),
+            (self._thick.setValue, DEFAULTS["thick"]),
+            (self._clip_enable.setChecked, DEFAULTS["clip"]),
+        )
+        for setter, val in specs:
+            setter(val)
+        self._apply_clip()
+        self.gl.reset_view()
+
+
+# --------------------------------------------------------------------------
+# Composite view: canvas + vertical controls (pure-3-D mode)
+# --------------------------------------------------------------------------
+
+class Nifti3DView(QWidget):
+    """GL canvas + a vertical controls panel (scrollable), the pane's "3D" mode."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("pane-dark")
+        self.gl = RaycastGLWidget()
+        self.controls = Nifti3DControls(self.gl, vertical=True)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setWidget(self.controls)
+        scroll.setFixedWidth(224)
+
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(2)
+        root.addWidget(self.gl, 1)
+        root.addWidget(scroll)
+
+    def set_volume(self, vol: np.ndarray, spacing: tuple[float, float, float]) -> None:
+        self.gl.set_volume_float(vol, spacing)
+
+    def clear(self) -> None:
+        self.gl.clear()
+
+    def reset_view(self) -> None:
+        self.gl.reset_view()
+
+
+__all__ = [
+    "Nifti3DControls",
+    "Nifti3DView",
+    "RaycastGLWidget",
+    "request_gl_format",
+    "normalize_to_u8",
+    "clip_normal_from",
+    "EFFECTS",
+    "LIGHTINGS",
+    "DEFAULTS",
+]

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -178,25 +178,30 @@ SLICE_DEFAULT_ON = {"Standard", "Matte", "Juicy shiny", "Juicy shiny 2",
 
 # Named parameter presets (control key -> value) applied when a preset effect
 # is selected. Derived from the reference MRIcroGL-style looks.
+#
+# Presets deliberately leave out two things, so each has ONE source of truth:
+#   * "quality" — a performance knob, not a look; every effect starts at
+#     DEFAULTS["quality"] (50%) and the user raises it when they want.
+#   * the clip plane — global state driven by its own controls / slicer
+#     shortcuts; baking it in would hijack the slicer on every effect change.
 EFFECT_PRESET: dict[str, dict] = {
     # Wet, glossy surface with a bright cut-face slice — a Standard (flat
-    # Phong) preset. The clip plane is deliberately NOT part of the preset:
-    # it is global state driven by its own controls / slicer shortcuts.
+    # Phong) preset.
     "Juicy shiny": dict(lo=36, hi=303, density=150, ambient=94, diffuse=50,
                         specular=50, shininess=20, lightaz=0, lightel=30,
-                        overlay=True, overlaydepth=68, quality=1024),
+                        overlay=True, overlaydepth=68),
     # Same window, but a much tighter/harder specular — a sharper wet sheen.
     "Juicy shiny 2": dict(lo=36, hi=303, density=150, ambient=94, diffuse=23,
                           specular=96, shininess=100, lightaz=0, lightel=30,
-                          overlay=True, overlaydepth=68, quality=1024),
+                          overlay=True, overlaydepth=68),
     # Translucent, glassy tissue — the brain shows through the skin.
     "Jelly": dict(lo=110, hi=400, density=7, ambient=115, diffuse=65,
                   specular=35, shininess=45, peel=1, tlow=13, thigh=82,
-                  lightaz=0, lightel=25, quality=1024),
+                  lightaz=0, lightel=25),
     # Peel the skin to reveal the deeper (facial / orbital / bony) anatomy.
     "Skull": dict(lo=36, hi=303, density=150, ambient=95, diffuse=50,
                   specular=50, shininess=20, peel=1, tlow=19, thigh=80,
-                  lightaz=0, lightel=30, quality=1024),
+                  lightaz=0, lightel=30),
 }
 
 # Matcap "lighting" materials: (ambient, key, fill, spec_power, spec_int, tint).
@@ -210,14 +215,21 @@ _LIGHTINGS: dict[str, tuple] = {
 }
 LIGHTINGS = list(_LIGHTINGS)
 
-# Default control values ("Reset parameters"). Quality defaults to the max.
+# Slider range for Quality (ray-march steps). QUALITY_DEFAULT is half of the
+# maximum: every effect starts at 50% so the first render is responsive on
+# modest GPUs, and the user can push the slider to full when they want it.
+QUALITY_MIN, QUALITY_MAX = 64, 1024
+QUALITY_DEFAULT = QUALITY_MAX // 2
+
+# Default control values ("Reset parameters").
 DEFAULTS = dict(
     effect=0, light=0, lo=100, hi=420, density=100, brighten=150, surface=70,
     ambient=60, diffuse=55, specular=30, shininess=40,
     boundthresh=30, edgethresh=12, edgemix=65, colortemp=50,
     gradientmix=60, intensitymix=35, hardness=50,
     peel=1, tlow=25, thigh=85, lightaz=0, lightel=0, overlay=True, overlaydepth=28,
-    quality=1024, clip=False, clipaz=0, clipel=0, depth=500, thick=1000, cube=True,
+    quality=QUALITY_DEFAULT, clip=False, clipaz=0, clipel=0, depth=500,
+    thick=1000, cube=True,
 )
 
 
@@ -1257,7 +1269,7 @@ class Nifti3DControls(QWidget):
         self._peel = self._sl(0, 6, DEFAULTS["peel"], self._on_peel)
         self._tlow = self._sl(0, 100, DEFAULTS["tlow"], self._on_tlow)
         self._thigh = self._sl(0, 100, DEFAULTS["thigh"], self._on_thigh)
-        self._q = self._sl(64, 1024, DEFAULTS["quality"], self._on_q)
+        self._q = self._sl(QUALITY_MIN, QUALITY_MAX, DEFAULTS["quality"], self._on_q)
         self._laz = self._sl(0, 360, DEFAULTS["lightaz"], self._on_light_dir)
         self._lel = self._sl(-90, 90, DEFAULTS["lightel"], self._on_light_dir)
         self._overlay_en = QCheckBox("Slice overlay")

--- a/bidsmgr/gui/widgets/nifti_gl_view.py
+++ b/bidsmgr/gui/widgets/nifti_gl_view.py
@@ -1222,7 +1222,10 @@ class Nifti3DControls(QWidget):
 
     def __init__(self, gl: RaycastGLWidget, *, vertical: bool = True, parent=None) -> None:
         super().__init__(parent)
-        self.setObjectName("sidecar-toolbar")
+        # Own identity (it used to borrow "sidecar-toolbar", a QFrame rule that
+        # never matched this QWidget — so the panel painted nothing and the
+        # black canvas behind showed through).
+        self.setObjectName("nifti-3d-controls")
         self.gl = gl
         self._vertical = vertical
         self._rows: dict[str, QWidget] = {}     # key -> label+widget container

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -179,27 +179,22 @@ def _load_nifti(path: Path) -> tuple[Any, np.ndarray, dict]:
 
     raw = nib.load(str(path))
     native_flip = _native_flip_from_affine(np.asarray(raw.affine))
-    img = raw
-    try:
-        img = nib.as_closest_canonical(img)
-        data = img.get_fdata()
-        return img, data, {"native_flip": native_flip}
-    except Exception as exc:
-        is_dtype_error = (
-            exc.__class__.__name__ == "DTypePromotionError"
-            or "VoidDType" in str(exc)
-        )
-        if not is_dtype_error:
-            raise
+    img = nib.as_closest_canonical(raw)
+
+    # Structured voxels (colour-FA and friends: dtype [('R','u1'),('G','u1'),
+    # ('B','u1')]) cannot go through get_fdata() — it tries to cast the record
+    # dtype to float64. Detect them from the DTYPE up front rather than by
+    # catching and sniffing the failure: the exception's class and message vary
+    # across numpy/nibabel versions (numpy 2.x raises a plain TypeError,
+    # "Cannot cast array data from dtype([('R','u1'),...])"), so the old
+    # message-matching guard let colour-FA files fail to open.
+    if getattr(img.dataobj.dtype, "fields", None) is None:
+        return img, img.get_fdata(), {"native_flip": native_flip}
 
     # Structured / RGB voxels: flatten components into the last axis.
     from numpy.lib import recfunctions as rfn
 
     dataobj = np.asanyarray(img.dataobj)
-    if not getattr(dataobj.dtype, "fields", None):
-        raise RuntimeError(
-            f"NIfTI {path} has an unsupported dtype: {dataobj.dtype}"
-        )
     unstructured = rfn.structured_to_unstructured(dataobj)
     vector_length = (
         int(unstructured.shape[-1])
@@ -207,6 +202,7 @@ def _load_nifti(path: Path) -> tuple[Any, np.ndarray, dict]:
         else 1
     )
     meta = {
+        "native_flip": native_flip,
         "vector_axis": len(img.shape),
         "vector_length": vector_length,
         "is_rgb": (
@@ -1105,7 +1101,8 @@ class NiftiViewerPane(QWidget):
             grid.setColumnStretch(i, 1)
         outer.addWidget(grid_host, 1)
 
-        ctrl_slot = self._slot()        # the shared controls are mounted here
+        # Opaque (see #nifti-ctrl-slot): the canvas behind is black.
+        ctrl_slot = self._slot("nifti-ctrl-slot")   # shared controls mount here
         ctrl_slot.setFixedWidth(226)
         outer.addWidget(ctrl_slot)
 
@@ -1416,6 +1413,12 @@ class NiftiViewerPane(QWidget):
         self._gl.set_flip(*self._gl_flip())
         self._gl_controls = Nifti3DControls(self._gl, vertical=True)
         self._gl_controls_scroll = QScrollArea()
+        # Name the scroll area AND its viewport so both paint the panel colour.
+        # Without this the black image canvas behind shows through the
+        # scrollbar gutter as a stripe down the controls column (very visible
+        # in the light theme).
+        self._gl_controls_scroll.setObjectName("nifti-ctrl-scroll")
+        self._gl_controls_scroll.viewport().setObjectName("nifti-ctrl-viewport")
         self._gl_controls_scroll.setWidgetResizable(True)
         self._gl_controls_scroll.setFrameShape(QFrame.Shape.NoFrame)
         self._gl_controls_scroll.setHorizontalScrollBarPolicy(
@@ -1433,8 +1436,10 @@ class NiftiViewerPane(QWidget):
         self._mount_gl("3d")   # park it in the pure-3-D page by default
 
     @staticmethod
-    def _slot() -> QWidget:
+    def _slot(name: str = "") -> QWidget:
         w = QWidget()
+        if name:
+            w.setObjectName(name)
         lay = QVBoxLayout(w)
         lay.setContentsMargins(0, 0, 0, 0)
         lay.setSpacing(0)
@@ -1461,7 +1466,7 @@ class NiftiViewerPane(QWidget):
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(2)
         gl_slot = self._slot()
-        ctrl_slot = self._slot()
+        ctrl_slot = self._slot("nifti-ctrl-slot")
         ctrl_slot.setFixedWidth(226)
         h.addWidget(gl_slot, 1)
         h.addWidget(ctrl_slot)

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -73,6 +73,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QMenu,
     QPushButton,
+    QScrollArea,
     QSizePolicy,
     QSlider,
     QSpinBox,
@@ -227,6 +228,29 @@ class NiftiViewerPane(QWidget):
         # Layout mode flags.
         self._tri_view: bool = False
         self._graph_visible: bool = False
+        # 3-D GPU raycast view. Built lazily on first toggle so users who
+        # never open it pay no OpenGL-context cost (and headless test runs
+        # stay clear of GL entirely). ``_gl_page_index`` is its slot in
+        # ``_image_stack`` once created.
+        self._three_d: bool = False
+        self._gl_view = None
+        self._gl_page_index: Optional[int] = None
+        self._is_3d_capable: bool = False
+        # Combined "Ortho 3D" mode: the three orthogonal slices plus the GPU
+        # render in one 2×2 grid, with all render controls in a vertical side
+        # panel. Its own bare GL canvas (``_combo_gl``) + controls + slice
+        # labels, all built lazily. ``_combo_view`` is the active flag.
+        self._combo_view: bool = False
+        self._combo_gl = None
+        self._combo_controls = None
+        self._combo_page_index: Optional[int] = None
+        self._combo_labels: dict[int, ImageLabel] = {}
+        self._combo_edge: dict = {}
+        # Global display window (intensity low/high) for 2-D slices, computed
+        # once per load so every slice shares one window (crisper + consistent,
+        # like MRIcroGL) instead of per-slice min/max stretching.
+        self._disp_lo: float = 0.0
+        self._disp_hi: float = 1.0
         # Wheel-scroll state. ``_h_key_down`` mirrors the H key: while held,
         # the wheel drives the 4-D volume (time) axis instead of the slice.
         # It's tracked via an app-level event filter (installed at the end of
@@ -454,12 +478,17 @@ class NiftiViewerPane(QWidget):
             # New file lost its 4th dimension — close the graph.
             self._graph_btn.setChecked(False)
 
+        # 3D modes — GPU raycasting needs a scalar 3-D (or 4-D non-RGB)
+        # volume. Colour/RGB voxels aren't meaningful as a density field.
+        self._is_3d_capable = data.ndim >= 3 and not self._is_rgb
+
         # Reset brightness / contrast to defaults when a new file is
         # bound so the previous file's settings don't leak.
         self._bright_slider.setValue(0)
         self._contrast_slider.setValue(100)
 
         self._set_orientation(self._orientation, refresh=False)
+        self._compute_display_window()
         self._toolbar.setVisible(True)
         self._footer.setVisible(True)
         self._stack.setCurrentWidget(self._canvas)
@@ -467,6 +496,13 @@ class NiftiViewerPane(QWidget):
         self._refresh()
         if self._graph_visible:
             self._update_graph()
+        # If a 3-D mode is open, feed it the new volume; if the new file
+        # can't be rendered in 3-D (e.g. RGB), drop back to plain 2-D.
+        if (self._three_d or self._combo_view) and not self._is_3d_capable:
+            self._set_view_mode("single")
+        else:
+            self._apply_mode_controls()
+            self._push_volume_to_3d()
         self.loaded.emit(path)
 
     def _on_load_failed(self, path: Path, error: str) -> None:
@@ -566,6 +602,35 @@ class NiftiViewerPane(QWidget):
         )
         self._graph_btn.toggled.connect(self._on_graph_toggled)
         row1.addWidget(self._graph_btn)
+
+        # 3D toggle — GPU volume raycasting. Enabled only for 3-D (or 4-D
+        # non-RGB) data; disabled state is set on load.
+        self._td_btn = QPushButton("3D")
+        self._td_btn.setObjectName("tb-btn-toggle")
+        self._td_btn.setCheckable(True)
+        self._td_btn.setEnabled(False)
+        self._td_btn.setToolTip(
+            "GPU volume rendering (ray-cast 3-D view).\n"
+            "Drag to rotate, scroll to zoom. For 4-D data the Volume "
+            "slider still selects which volume is rendered.\n"
+            "Shortcut: D"
+        )
+        self._td_btn.toggled.connect(self._on_3d_toggled)
+        row1.addWidget(self._td_btn)
+
+        # Ortho 3D — the three 2-D planes plus the GPU render in one 2×2 grid.
+        self._quad_btn = QPushButton("Ortho 3D")
+        self._quad_btn.setObjectName("tb-btn-toggle")
+        self._quad_btn.setCheckable(True)
+        self._quad_btn.setEnabled(False)
+        self._quad_btn.setToolTip(
+            "Show the three orthogonal slices and the GPU volume render "
+            "together in a 2×2 grid.\n"
+            "Click / scroll a slice to move the crosshair; drag the render "
+            "to rotate it.  Shortcut: P"
+        )
+        self._quad_btn.toggled.connect(self._on_combo_toggled)
+        row1.addWidget(self._quad_btn)
 
         row1.addSpacing(12)
 
@@ -858,6 +923,86 @@ class NiftiViewerPane(QWidget):
         self._apply_orient_label_visibility()
         return w
 
+    def _build_combo_image(self) -> QWidget:
+        """Build the Ortho-3D page: 2×2 grid (3 slices + render) + side panel.
+
+        Grid mirrors MRIcroGL's default — Axial (top-left), Coronal
+        (top-right), Sagittal (bottom-left) and the volume render
+        (bottom-right). The three slice panels reuse the crosshair voxel and
+        render path of Multi view; the render is a bare
+        :class:`RaycastGLWidget`. All of its controls live in a vertical
+        :class:`Nifti3DControls` panel on the right (in a scroll area so they
+        never crowd the render), so the render gets the room it needs.
+        """
+        from .nifti_gl_view import Nifti3DControls, RaycastGLWidget
+
+        page = QWidget()
+        outer = QHBoxLayout(page)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(2)
+
+        grid_host = QWidget()
+        grid = QGridLayout(grid_host)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setSpacing(2)
+        placements = {
+            _AXIS_AXIAL: (0, 0),
+            _AXIS_CORONAL: (0, 1),
+            _AXIS_SAGITTAL: (1, 0),
+        }
+        for axis, (r, c) in placements.items():
+            cell = QWidget()
+            cv = QVBoxLayout(cell)
+            cv.setContentsMargins(0, 0, 0, 0)
+            cv.setSpacing(0)
+            caption = QLabel(_AXIS_LABELS[axis])
+            caption.setObjectName("sidecar-footer-summary")
+            caption.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            cv.addWidget(caption)
+
+            label = ImageLabel(
+                update_fn=lambda a=axis: self._render_axis_into_combo(a),
+                click_fn=lambda ev, a=axis: self._on_image_clicked(
+                    ev, a, self._combo_labels[a],
+                ),
+                wheel_fn=lambda ev, a=axis: self._handle_wheel(ev, a),
+            )
+            label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            label.setSizePolicy(
+                QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Ignored,
+            )
+            label.setMinimumSize(1, 1)
+            overlay, edges = self._make_orientation_overlay(label)
+            for side, text in _ORIENT_LABELS[axis].items():
+                edges[side].setText(text)
+            self._combo_edge[axis] = edges
+            cv.addWidget(overlay, 1)
+            grid.addWidget(cell, r, c)
+            self._combo_labels[axis] = label
+
+        self._combo_gl = RaycastGLWidget()
+        grid.addWidget(self._combo_gl, 1, 1)
+        for i in range(2):
+            grid.setRowStretch(i, 1)
+            grid.setColumnStretch(i, 1)
+        outer.addWidget(grid_host, 1)
+
+        # Vertical control column on the right, in a scroll area so it stays
+        # usable when the pane is short.
+        self._combo_controls = Nifti3DControls(self._combo_gl, vertical=True)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        scroll.setWidget(self._combo_controls)
+        scroll.setFixedWidth(212)
+        outer.addWidget(scroll)
+
+        self._apply_orient_label_visibility()
+        return page
+
     def _build_graph_panel(self) -> QWidget:
         """Build the 4-D time-series plot panel (pyqtgraph).
 
@@ -984,16 +1129,7 @@ class NiftiViewerPane(QWidget):
     # ------------------------------------------------------------------
 
     def _on_tri_toggled(self, checked: bool) -> None:
-        self._tri_view = checked
-        # The orientation pills + slice slider only steer the
-        # single-pane view. Greying them out (rather than hiding) keeps
-        # the toolbar layout stable across toggles.
-        for btn in (self._sa_btn, self._co_btn, self._ax_btn):
-            btn.setEnabled(not checked)
-        self._slice_slider.setEnabled(not checked and self._data is not None)
-        self._image_stack.setCurrentIndex(1 if checked else 0)
-        if self._data is not None:
-            self._refresh()
+        self._set_view_mode("multi" if checked else "single")
 
     def _on_graph_toggled(self, checked: bool) -> None:
         self._graph_visible = checked
@@ -1008,6 +1144,164 @@ class NiftiViewerPane(QWidget):
                 self._update_graph()
 
     # ------------------------------------------------------------------
+    # 3-D GPU raycast view + view-mode switching
+    # ------------------------------------------------------------------
+    #
+    # There are four mutually-exclusive "big view" modes, all routed through
+    # :meth:`_set_view_mode`:
+    #   single  — one 2-D slice (the default)
+    #   multi   — three 2-D slices side by side (the "Multi view" toggle)
+    #   3d      — the GPU volume render only (the "3D" toggle)
+    #   combo   — three slices + the render in a 2×2 grid ("Ortho 3D")
+    # Centralising the switch keeps the three checkable buttons in sync
+    # without the pairwise-exclusion tangle (each toggle slot just names the
+    # target mode; button states are re-synced here with signals blocked).
+
+    def _on_3d_toggled(self, checked: bool) -> None:
+        self._set_view_mode("3d" if checked else "single")
+
+    def _on_combo_toggled(self, checked: bool) -> None:
+        self._set_view_mode("combo" if checked else "single")
+
+    def _set_view_mode(self, mode: str) -> None:
+        # Lazily build whatever GL page the target mode needs; if that fails
+        # (no GL driver / headless), fall back to plain single-pane 2-D.
+        if mode == "3d":
+            try:
+                self._ensure_gl_view()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("Could not open the 3-D view: %s", exc)
+                mode = "single"
+        elif mode == "combo":
+            try:
+                self._ensure_combo_view()
+            except Exception as exc:  # noqa: BLE001
+                log.warning("Could not open the Ortho-3D view: %s", exc)
+                mode = "single"
+
+        self._tri_view = mode == "multi"
+        self._three_d = mode == "3d"
+        self._combo_view = mode == "combo"
+
+        # Re-sync the three toggle buttons without re-entering their slots.
+        for btn, on in (
+            (self._tri_btn, self._tri_view),
+            (self._td_btn, self._three_d),
+            (self._quad_btn, self._combo_view),
+        ):
+            if btn.isChecked() != on:
+                was = btn.blockSignals(True)
+                btn.setChecked(on)
+                btn.blockSignals(was)
+
+        self._apply_mode_controls()
+
+        if self._three_d and self._gl_page_index is not None:
+            self._image_stack.setCurrentIndex(self._gl_page_index)
+        elif self._combo_view and self._combo_page_index is not None:
+            self._image_stack.setCurrentIndex(self._combo_page_index)
+        elif self._tri_view:
+            self._image_stack.setCurrentIndex(1)
+        else:
+            self._image_stack.setCurrentIndex(0)
+
+        if self._data is not None:
+            self._refresh()
+            self._push_volume_to_3d()
+
+    def _apply_mode_controls(self) -> None:
+        """Enable/disable toolbar controls for the current view mode.
+
+        * orientation pills + slice slider — single-pane 2-D only.
+        * brightness / contrast / crosshair / labels — any mode that shows
+          slices (single / multi / combo), i.e. not the pure 3-D render.
+        * graph — 4-D and a slice is shown.
+        * the three view-mode toggles stay live whenever their data
+          precondition holds, so the user can switch straight between them.
+        """
+        has_data = self._data is not None
+        multi_like = self._tri_view or self._combo_view
+        slices_shown = has_data and not self._three_d
+        is_4d = has_data and self._data.ndim == 4 and not self._is_rgb
+
+        single_2d = has_data and not self._three_d and not multi_like
+        for btn in (self._sa_btn, self._co_btn, self._ax_btn):
+            btn.setEnabled(single_2d)
+        if single_2d:
+            self._slice_slider.setEnabled(self._slice_slider.maximum() > 0)
+        else:
+            self._slice_slider.setEnabled(False)
+
+        for w in (self._bright_slider, self._contrast_slider,
+                  self._crosshair_swatch, self._crosshair_thickness_spin,
+                  self._labels_btn):
+            w.setEnabled(slices_shown)
+        self._graph_btn.setEnabled(slices_shown and is_4d)
+
+        self._tri_btn.setEnabled(has_data)
+        self._td_btn.setEnabled(has_data and self._is_3d_capable)
+        self._quad_btn.setEnabled(has_data and self._is_3d_capable)
+
+    def _toggle_3d(self) -> None:
+        """'D' shortcut — flip the 3D button when it applies."""
+        if self._td_btn.isEnabled():
+            self._td_btn.toggle()
+
+    def _toggle_combo(self) -> None:
+        """'P' shortcut — flip the Ortho-3D button when it applies."""
+        if self._quad_btn.isEnabled():
+            self._quad_btn.toggle()
+
+    def _ensure_gl_view(self):
+        """Build the pure-3-D GL page on first use and add it to the stack.
+
+        Lazy so the OpenGL context is only created when the user actually
+        opens a 3-D mode — importing PyOpenGL / creating a QOpenGLWidget is
+        deferred out of the module import graph and the common path.
+        """
+        if self._gl_view is not None:
+            return self._gl_view
+        from .nifti_gl_view import Nifti3DView
+        self._gl_view = Nifti3DView()
+        self._gl_page_index = self._image_stack.addWidget(self._gl_view)
+        return self._gl_view
+
+    def _ensure_combo_view(self):
+        """Build the Ortho-3D (2×2 slices + render) page on first use."""
+        if self._combo_page_index is not None:
+            return
+        page = self._build_combo_image()
+        self._combo_page_index = self._image_stack.addWidget(page)
+
+    def _volume_spacing(self) -> tuple[float, float, float]:
+        """Voxel spacing (mm) of the loaded image, defaulting to isotropic."""
+        try:
+            zooms = self._img.header.get_zooms()[:3]
+            return tuple(
+                float(z) if z and z > 0 else 1.0 for z in zooms
+            )  # type: ignore[return-value]
+        except Exception:  # pragma: no cover - header always present in practice
+            return (1.0, 1.0, 1.0)
+
+    def _push_volume_to_3d(self) -> None:
+        """Send the current (4-D-aware) 3-D volume to the active GL view.
+
+        The pure-3-D page owns a :class:`Nifti3DView` (``set_volume`` windows
+        internally); the Ortho-3D page owns a bare
+        :class:`RaycastGLWidget` (``set_volume_float`` windows for it).
+        """
+        if self._data is None:
+            return
+        vol = self._current_volume()
+        if getattr(vol, "ndim", 0) != 3:
+            return
+        spacing = self._volume_spacing()
+        if self._three_d and self._gl_view is not None:
+            self._gl_view.set_volume(vol, spacing)
+        elif self._combo_view and self._combo_gl is not None:
+            self._combo_gl.set_volume_float(vol, spacing)
+
+    # ------------------------------------------------------------------
     # Orientation labels
     # ------------------------------------------------------------------
 
@@ -1020,7 +1314,11 @@ class NiftiViewerPane(QWidget):
 
     def _apply_orient_label_visibility(self) -> None:
         """Show/hide every edge label per :attr:`_show_orient_labels`."""
-        groups = [self._single_edge] + list(self._tri_edge.values())
+        groups = (
+            [self._single_edge]
+            + list(self._tri_edge.values())
+            + list(self._combo_edge.values())
+        )
         for group in groups:
             for lbl in group.values():
                 lbl.setVisible(self._show_orient_labels)
@@ -1030,16 +1328,25 @@ class NiftiViewerPane(QWidget):
         self._apply_orient_label_visibility()
 
     def _toggle_orient_labels(self) -> None:
-        """'O' shortcut — flip the Labels button (its slot does the work)."""
-        self._labels_btn.toggle()
+        """'O' shortcut — flip the Labels button (its slot does the work).
+
+        No-op in 3-D, where anatomical edge labels don't apply.
+        """
+        if self._labels_btn.isEnabled():
+            self._labels_btn.toggle()
 
     # ------------------------------------------------------------------
     # Keyboard shortcuts
     # ------------------------------------------------------------------
 
     def _toggle_multi_view(self) -> None:
-        """'M' shortcut — flip the Multi view button."""
-        self._tri_btn.toggle()
+        """'M' shortcut — flip the Multi view button when it applies.
+
+        Disabled while the 3-D view owns the canvas; toggling it there
+        would yank the view out from under the user.
+        """
+        if self._tri_btn.isEnabled():
+            self._tri_btn.toggle()
 
     def _toggle_graph(self) -> None:
         """'G' shortcut — flip the Graph button (only when it applies).
@@ -1053,10 +1360,11 @@ class NiftiViewerPane(QWidget):
     def _shortcut_orientation(self, axis: int) -> None:
         """'A' / 'S' / 'C' shortcuts — jump to a single-pane orientation.
 
-        Leaves Multi view if it's on so the requested plane fills the pane.
+        Leaves any multi-plane / 3-D mode so the requested plane fills the
+        pane.
         """
-        if self._tri_view:
-            self._tri_btn.setChecked(False)
+        if self._tri_view or self._three_d or self._combo_view:
+            self._set_view_mode("single")
         self._set_orientation(axis)
 
     def _install_shortcuts(self) -> None:
@@ -1073,6 +1381,8 @@ class NiftiViewerPane(QWidget):
             ("M", self._toggle_multi_view),
             ("G", self._toggle_graph),
             ("O", self._toggle_orient_labels),
+            ("D", self._toggle_3d),
+            ("P", self._toggle_combo),
         )
         for key, handler in specs:
             sc = QShortcut(QKeySequence(key), self)
@@ -1098,8 +1408,15 @@ class NiftiViewerPane(QWidget):
                 ("Sagittal view", "S"),
                 ("Coronal view", "C"),
                 ("Multi view (toggle)", "M"),
+                ("3D volume render (toggle)", "D"),
+                ("Ortho 3D — planes + render (toggle)", "P"),
                 ("Graph / time-series (toggle)", "G"),
                 ("Orientation labels (toggle)", "O"),
+            ]),
+            ("3D view", [
+                ("Rotate the volume", "Drag"),
+                ("Zoom in / out", "Scroll"),
+                ("Slice into the volume", "Clip plane controls"),
             ]),
         ]
 
@@ -1220,11 +1537,16 @@ class NiftiViewerPane(QWidget):
 
     def _on_vol_slider_changed(self, value: int) -> None:
         self._vol_val.setText(str(value))
+        # Different 4-D volumes can differ in intensity range — re-window.
+        self._compute_display_window()
         self._refresh()
         # In graph mode the y-data doesn't change with volume — only
         # the marker moves. Avoid the full curve redraw.
         if self._graph_visible:
             self._update_graph_marker()
+        # In a 3-D mode the selected volume is what gets raycast — re-upload.
+        if self._three_d or self._combo_view:
+            self._push_volume_to_3d()
 
     # ------------------------------------------------------------------
     # Slice rendering
@@ -1265,11 +1587,36 @@ class NiftiViewerPane(QWidget):
             return self._data[..., vol_idx]
         return self._data
 
+    def _compute_display_window(self) -> None:
+        """Set ``_disp_lo/_disp_hi`` from a robust percentile of the volume.
+
+        One window shared by every 2-D slice. Computed from a subsample so a
+        several-hundred-MB BOLD run stays instant; RGB data keeps the trivial
+        0..1 window (its slices are handled component-wise elsewhere).
+        """
+        self._disp_lo, self._disp_hi = 0.0, 1.0
+        if self._data is None or self._is_rgb:
+            return
+        vol = self._current_volume()
+        flat = np.asarray(vol, dtype=np.float32).ravel()
+        if flat.size > 500_000:
+            flat = flat[:: flat.size // 500_000]
+        finite = flat[np.isfinite(flat)]
+        if finite.size == 0:
+            return
+        lo, hi = np.percentile(finite, (1.0, 99.0))
+        if hi <= lo:
+            hi = lo + 1.0
+        self._disp_lo, self._disp_hi = float(lo), float(hi)
+
     def _refresh(self) -> None:
         """Repaint whichever canvas is currently visible."""
         if self._data is None or self._cross_voxel is None:
             return
-        if self._tri_view:
+        if self._combo_view:
+            for axis in _AXES:
+                self._render_axis_into_combo(axis)
+        elif self._tri_view:
             for axis in _AXES:
                 self._render_axis_into_tri(axis)
         else:
@@ -1285,6 +1632,14 @@ class NiftiViewerPane(QWidget):
         if self._data is None or self._cross_voxel is None:
             return
         label = self._tri_labels.get(axis)
+        if label is None:
+            return
+        self._render_axis_to_label(axis, label)
+
+    def _render_axis_into_combo(self, axis: int) -> None:
+        if self._data is None or self._cross_voxel is None:
+            return
+        label = self._combo_labels.get(axis)
         if label is None:
             return
         self._render_axis_to_label(axis, label)
@@ -1306,10 +1661,16 @@ class NiftiViewerPane(QWidget):
             slice_img = vol[:, :, slice_idx]
 
         arr = slice_img.astype(np.float32)
-        arr = arr - arr.min()
-        peak = arr.max()
-        if peak > 0:
-            arr = arr / peak
+        if arr.ndim == 2:
+            # Global intensity window (computed once per load) so every slice
+            # shares one mapping — crisp and consistent, like MRIcroGL —
+            # rather than each slice stretching its own min/max (flat, noisy).
+            lo, hi = self._disp_lo, self._disp_hi
+            arr = (arr - lo) / (hi - lo) if hi > lo else arr - lo
+        else:
+            # RGB / colour voxels: components are already display values.
+            arr = arr / 255.0 if arr.max() > 1.0 else arr
+        arr = np.clip(arr, 0, 1)
 
         b = self._bright_slider.value() / 100.0
         c = self._contrast_slider.value() / 100.0
@@ -1806,6 +2167,19 @@ class NiftiViewerPane(QWidget):
         if self._plot_layout is not None:
             self._plot_layout.clear()
         self._grid_cells = []
+        # Reset the 3-D modes: drop back to single-pane, disable the toggles,
+        # and free the GPU textures of both GL views.
+        self._is_3d_capable = False
+        self._tri_view = self._three_d = self._combo_view = False
+        for btn in (self._tri_btn, self._td_btn, self._quad_btn):
+            was = btn.blockSignals(True)
+            btn.setChecked(False)
+            btn.setEnabled(False)
+            btn.blockSignals(was)
+        self._image_stack.setCurrentIndex(0)
+        for view in (self._gl_view, self._combo_gl):
+            if view is not None:
+                view.clear()
         self._toolbar.setVisible(False)
         self._footer.setVisible(False)
         self._footer_path.setText("")

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -236,6 +236,14 @@ class NiftiViewerPane(QWidget):
         self._gl_view = None
         self._gl_page_index: Optional[int] = None
         self._is_3d_capable: bool = False
+        # Whether this host can drive the GPU raycaster (OpenGL 3.3 core on
+        # real hardware). When False the 3D / Ortho 3D toggles are hidden
+        # entirely — the viewer stays a pure 2-D tool.
+        try:
+            from .nifti_gl_view import gpu_available
+            self._gpu_ok: bool = gpu_available()
+        except Exception:  # noqa: BLE001 - never block the 2-D viewer
+            self._gpu_ok = False
         # Combined "Ortho 3D" mode: the three orthogonal slices plus the GPU
         # render in one 2×2 grid, with all render controls in a vertical side
         # panel. Its own bare GL canvas (``_combo_gl``) + controls + slice
@@ -632,6 +640,12 @@ class NiftiViewerPane(QWidget):
         self._quad_btn.toggled.connect(self._on_combo_toggled)
         row1.addWidget(self._quad_btn)
 
+        # No GPU (or no OpenGL 3.3) -> the viewer is 2-D only: hide both
+        # 3-D toggles so the options never appear.
+        if not self._gpu_ok:
+            self._td_btn.setVisible(False)
+            self._quad_btn.setVisible(False)
+
         row1.addSpacing(12)
 
         # Slice slider — current orientation depth.
@@ -981,6 +995,7 @@ class NiftiViewerPane(QWidget):
             self._combo_labels[axis] = label
 
         self._combo_gl = RaycastGLWidget()
+        self._combo_gl.set_show_cube(self._show_orient_labels)
         grid.addWidget(self._combo_gl, 1, 1)
         for i in range(2):
             grid.setRowStretch(i, 1)
@@ -1233,14 +1248,16 @@ class NiftiViewerPane(QWidget):
             self._slice_slider.setEnabled(False)
 
         for w in (self._bright_slider, self._contrast_slider,
-                  self._crosshair_swatch, self._crosshair_thickness_spin,
-                  self._labels_btn):
+                  self._crosshair_swatch, self._crosshair_thickness_spin):
             w.setEnabled(slices_shown)
+        # The orientation-labels toggle also drives the 3-D orientation cube,
+        # so it stays live in every mode once a volume is loaded.
+        self._labels_btn.setEnabled(has_data)
         self._graph_btn.setEnabled(slices_shown and is_4d)
 
         self._tri_btn.setEnabled(has_data)
-        self._td_btn.setEnabled(has_data and self._is_3d_capable)
-        self._quad_btn.setEnabled(has_data and self._is_3d_capable)
+        self._td_btn.setEnabled(has_data and self._is_3d_capable and self._gpu_ok)
+        self._quad_btn.setEnabled(has_data and self._is_3d_capable and self._gpu_ok)
 
     def _toggle_3d(self) -> None:
         """'D' shortcut — flip the 3D button when it applies."""
@@ -1263,6 +1280,7 @@ class NiftiViewerPane(QWidget):
             return self._gl_view
         from .nifti_gl_view import Nifti3DView
         self._gl_view = Nifti3DView()
+        self._gl_view.set_show_cube(self._show_orient_labels)
         self._gl_page_index = self._image_stack.addWidget(self._gl_view)
         return self._gl_view
 
@@ -1322,6 +1340,11 @@ class NiftiViewerPane(QWidget):
         for group in groups:
             for lbl in group.values():
                 lbl.setVisible(self._show_orient_labels)
+        # The same toggle drives the 3-D orientation cube on both GL views.
+        if self._gl_view is not None:
+            self._gl_view.set_show_cube(self._show_orient_labels)
+        if self._combo_gl is not None:
+            self._combo_gl.set_show_cube(self._show_orient_labels)
 
     def _on_labels_toggled(self, checked: bool) -> None:
         self._show_orient_labels = checked
@@ -1667,6 +1690,9 @@ class NiftiViewerPane(QWidget):
             # rather than each slice stretching its own min/max (flat, noisy).
             lo, hi = self._disp_lo, self._disp_hi
             arr = (arr - lo) / (hi - lo) if hi > lo else arr - lo
+            # Gentle gamma to lift the mid-tones for MRIcroGL-like vibrancy /
+            # contrast (brighter grey/white matter without clipping highlights).
+            arr = np.clip(arr, 0.0, 1.0) ** 0.8
         else:
             # RGB / colour voxels: components are already display values.
             arr = arr / 255.0 if arr.max() > 1.0 else arr

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -116,6 +116,37 @@ _ORIENT_LABELS = {
     _AXIS_AXIAL:    {"left": "L", "right": "R", "top": "A", "bottom": "P"},
 }
 
+# For each plane, which canonical axis (0=L/R, 1=A/P, 2=S/I) maps to the
+# on-screen horizontal and vertical of the displayed slice. Used to turn a
+# per-axis display flip into a slice mirror + label swap. Matches the display
+# transform in ``_voxel_to_arr`` / ``_ORIENT_LABELS`` above.
+_PLANE_HV = {
+    _AXIS_SAGITTAL: (1, 2),   # horizontal = A/P, vertical = S/I
+    _AXIS_CORONAL:  (0, 2),   # horizontal = L/R, vertical = S/I
+    _AXIS_AXIAL:    (0, 1),   # horizontal = L/R, vertical = A/P
+}
+
+
+def _native_flip_from_affine(affine: "np.ndarray") -> tuple[float, float, float]:
+    """Per canonical RAS axis, whether the file stores it reversed (-1) or not.
+
+    Derived from the raw (pre-canonical) affine: if the on-disk data increases
+    toward L/P/I instead of R/A/S on some axis, that axis is flagged -1. This
+    is what the "native storage orientation" view flips back. Axis permutations
+    (e.g. sagittally-stored volumes) are collapsed to their RAS axis, so the
+    anatomical L/R·A/P·S/I labels stay correct even for those.
+    """
+    try:
+        import nibabel as nib
+        ornt = nib.orientations.io_orientation(affine)  # per raw axis: [ras, flip]
+        flip = [1.0, 1.0, 1.0]
+        for ras_axis, sign in ornt:
+            if not np.isnan(ras_axis):
+                flip[int(ras_axis)] = float(sign)
+        return (flip[0], flip[1], flip[2])
+    except Exception:  # pragma: no cover - defensive
+        return (1.0, 1.0, 1.0)
+
 # Default crosshair colour — overridden per-user via AppSettings
 # (``nifti_crosshair_color``). Material light-blue 300 reads well on
 # both dark and bright slices.
@@ -146,11 +177,13 @@ def _load_nifti(path: Path) -> tuple[Any, np.ndarray, dict]:
     """
     import nibabel as nib  # local import: nibabel is heavy
 
-    img = nib.load(str(path))
+    raw = nib.load(str(path))
+    native_flip = _native_flip_from_affine(np.asarray(raw.affine))
+    img = raw
     try:
         img = nib.as_closest_canonical(img)
         data = img.get_fdata()
-        return img, data, {}
+        return img, data, {"native_flip": native_flip}
     except Exception as exc:
         is_dtype_error = (
             exc.__class__.__name__ == "DTypePromotionError"
@@ -278,6 +311,14 @@ class NiftiViewerPane(QWidget):
         # Anatomical edge labels (L/R·A/P·S/I) drawn around each panel.
         # On by default; toggled by the toolbar button and the "O" shortcut.
         self._show_orient_labels: bool = True
+        # Orientation display. ``_ras_on`` (default) shows canonical RAS; when
+        # off, the file's raw on-disk orientation is shown (2-D + 3-D + labels).
+        # ``_radio_on`` mirrors left/right (radiological convention). Both fold
+        # into one per-axis flip (:meth:`_display_flip`). ``_native_flip`` is
+        # the raw storage flip discovered at load (identity for RAS files).
+        self._ras_on: bool = True
+        self._radio_on: bool = False
+        self._native_flip: tuple[float, float, float] = (1.0, 1.0, 1.0)
         # Edge-label widgets: ``_single_edge`` for the single pane and one
         # dict per axis in ``_tri_edge`` for Multi view.
         self._single_edge: dict = {}
@@ -482,6 +523,7 @@ class NiftiViewerPane(QWidget):
         self._data = data
         self._meta = meta or {}
         self._is_rgb = bool(self._meta.get("is_rgb"))
+        self._native_flip = self._meta.get("native_flip", (1.0, 1.0, 1.0))
         # Default crosshair: centre voxel.
         if data.ndim >= 3:
             self._cross_voxel = [
@@ -516,6 +558,9 @@ class NiftiViewerPane(QWidget):
         self._contrast_slider.setValue(100)
 
         self._set_orientation(self._orientation, refresh=False)
+        # Re-apply edge labels for this file's flip (native mode differs per
+        # file's storage orientation; the fixed-plane panels bake theirs once).
+        self._refresh_all_orient_labels()
         self._compute_display_window()
         self._toolbar.setVisible(True)
         self._footer.setVisible(True)
@@ -715,6 +760,34 @@ class NiftiViewerPane(QWidget):
         )
         self._labels_btn.toggled.connect(self._on_labels_toggled)
         row2.addWidget(self._labels_btn)
+
+        # RAS toggle — show canonical RAS orientation (on) or the file's raw
+        # on-disk orientation (off). Affects the 2-D slices, the 3-D render and
+        # the anatomical labels together. No visible change for RAS-stored files.
+        self._ras_btn = QPushButton("RAS")
+        self._ras_btn.setObjectName("tb-btn-toggle")
+        self._ras_btn.setCheckable(True)
+        self._ras_btn.setChecked(self._ras_on)
+        self._ras_btn.setToolTip(
+            "On: show canonical RAS orientation.  Off: show the file's raw "
+            "on-disk orientation (2-D slices, 3-D render and labels).  No "
+            "visible change for files already stored in RAS."
+        )
+        self._ras_btn.toggled.connect(self._on_ras_toggled)
+        row2.addWidget(self._ras_btn)
+
+        # Radiological — mirror left/right (radiological vs. neurological).
+        self._radio_btn = QPushButton("Radiological")
+        self._radio_btn.setObjectName("tb-btn-toggle")
+        self._radio_btn.setCheckable(True)
+        self._radio_btn.setChecked(self._radio_on)
+        self._radio_btn.setToolTip(
+            "Mirror left/right (radiological convention: patient-left on the "
+            "image right).  Off = neurological.  Applies to the 2-D slices, "
+            "3-D render and L/R labels."
+        )
+        self._radio_btn.toggled.connect(self._on_radio_toggled)
+        row2.addWidget(self._radio_btn)
 
         row2.addSpacing(8)
 
@@ -948,7 +1021,7 @@ class NiftiViewerPane(QWidget):
             overlay, edges = self._make_orientation_overlay(label)
             # Each Multi-view panel shows a fixed plane, so its markers
             # never change — set them once here.
-            for side, text in _ORIENT_LABELS[axis].items():
+            for side, text in self._display_labels(axis).items():
                 edges[side].setText(text)
             self._tri_edge[axis] = edges
             cv.addWidget(overlay, 1)
@@ -1001,7 +1074,7 @@ class NiftiViewerPane(QWidget):
             )
             label.setMinimumSize(1, 1)
             overlay, edges = self._make_orientation_overlay(label)
-            for side, text in _ORIENT_LABELS[axis].items():
+            for side, text in self._display_labels(axis).items():
                 edges[side].setText(text)
             self._combo_edge[axis] = edges
             cv.addWidget(overlay, 1)
@@ -1259,6 +1332,10 @@ class NiftiViewerPane(QWidget):
         self._tri_btn.setEnabled(has_data)
         self._td_btn.setEnabled(has_data and self._is_3d_capable and self._gpu_ok)
         self._quad_btn.setEnabled(has_data and self._is_3d_capable and self._gpu_ok)
+        # RAS / Radiological reorient the 2-D slices and labels too, so they are
+        # live whenever a volume is loaded (independent of the GPU 3-D views).
+        self._ras_btn.setEnabled(has_data)
+        self._radio_btn.setEnabled(has_data)
 
     def _toggle_3d(self) -> None:
         """'D' shortcut — flip the 3D button when it applies."""
@@ -1319,6 +1396,7 @@ class NiftiViewerPane(QWidget):
         from .nifti_gl_view import Nifti3DControls, RaycastGLWidget
         self._gl = RaycastGLWidget()
         self._gl.set_show_cube(self._show_orient_labels)
+        self._gl.set_flip(*self._gl_flip())
         self._gl_controls = Nifti3DControls(self._gl, vertical=True)
         self._gl_controls_scroll = QScrollArea()
         self._gl_controls_scroll.setWidgetResizable(True)
@@ -1389,17 +1467,58 @@ class NiftiViewerPane(QWidget):
         vol = self._current_volume()
         if getattr(vol, "ndim", 0) != 3:
             return
+        self._gl.set_flip(*self._gl_flip())
         self._gl.set_volume_float(vol, self._volume_spacing())
 
     # ------------------------------------------------------------------
     # Orientation labels
     # ------------------------------------------------------------------
 
+    def _display_flip(self) -> tuple[float, float, float]:
+        """Per canonical axis (L/R, A/P, S/I) display flip, folding the RAS
+        (native-orientation) and Radiological toggles together."""
+        nf = (1.0, 1.0, 1.0) if self._ras_on else self._native_flip
+        rx = -1.0 if self._radio_on else 1.0   # radiological mirrors L/R only
+        return (nf[0] * rx, nf[1], nf[2])
+
+    def _gl_flip(self) -> tuple[float, float, float]:
+        """Flip vector for the 3-D render.
+
+        It carries a constant extra L/R mirror versus the 2-D flip: a 3-D
+        look-at view of the volume is the mirror image of a 2-D slice shown in
+        the neurological convention, so this keeps the 3-D render's left/right
+        aligned with the 2-D slices under both RAS/native and radiological.
+        """
+        fx, fy, fz = self._display_flip()
+        return (-fx, fy, fz)
+
+    def _display_labels(self, axis: int) -> dict:
+        """Anatomical edge labels for ``axis`` with the display flip applied."""
+        lab = dict(_ORIENT_LABELS[axis])
+        h, v = _PLANE_HV[axis]
+        f = self._display_flip()
+        if f[h] < 0:
+            lab["left"], lab["right"] = lab["right"], lab["left"]
+        if f[v] < 0:
+            lab["top"], lab["bottom"] = lab["bottom"], lab["top"]
+        return lab
+
+    def _refresh_all_orient_labels(self) -> None:
+        """Re-apply edge labels everywhere (the fixed-plane Multi-Planar and
+        combo panels bake theirs once, so a flip toggle must reset them)."""
+        self._update_single_orient_labels()
+        for axis, edges in self._tri_edge.items():
+            for side, text in self._display_labels(axis).items():
+                edges[side].setText(text)
+        for axis, edges in self._combo_edge.items():
+            for side, text in self._display_labels(axis).items():
+                edges[side].setText(text)
+
     def _update_single_orient_labels(self) -> None:
         """Set the single pane's edge glyphs for the current orientation."""
         if not self._single_edge:
             return
-        for side, text in _ORIENT_LABELS[self._orientation].items():
+        for side, text in self._display_labels(self._orientation).items():
             self._single_edge[side].setText(text)
 
     def _apply_orient_label_visibility(self) -> None:
@@ -1419,6 +1538,24 @@ class NiftiViewerPane(QWidget):
     def _on_labels_toggled(self, checked: bool) -> None:
         self._show_orient_labels = checked
         self._apply_orient_label_visibility()
+
+    def _on_ras_toggled(self, checked: bool) -> None:
+        """RAS on = canonical orientation; off = the file's raw storage order."""
+        self._ras_on = checked
+        self._apply_display_flip()
+
+    def _on_radio_toggled(self, checked: bool) -> None:
+        """Radiological (mirror L/R) vs. neurological convention."""
+        self._radio_on = checked
+        self._apply_display_flip()
+
+    def _apply_display_flip(self) -> None:
+        """Re-render 2-D + labels and re-orient the 3-D render after a toggle."""
+        self._refresh_all_orient_labels()
+        if self._gl is not None:
+            self._gl.set_flip(*self._gl_flip())
+        if self._data is not None:
+            self._refresh()
 
     def _toggle_orient_labels(self) -> None:
         """'O' shortcut — flip the Labels button (its slot does the work).
@@ -1792,6 +1929,16 @@ class NiftiViewerPane(QWidget):
         arr = (arr * 255).astype(np.uint8)
         arr = np.rot90(arr)
 
+        # Mirror the displayed slice to match the orientation flip (RAS/native +
+        # radiological). Rows are screen-vertical, columns screen-horizontal.
+        f = self._display_flip()
+        h_ax, v_ax = _PLANE_HV[axis]
+        if f[h_ax] < 0:
+            arr = arr[:, ::-1]
+        if f[v_ax] < 0:
+            arr = arr[::-1, :]
+        arr = np.ascontiguousarray(arr)
+
         if arr.ndim == 2:
             h, w = arr.shape
             img = QImage(
@@ -1924,6 +2071,7 @@ class NiftiViewerPane(QWidget):
         # Slice index along the clicked axis stays fixed (you can't
         # change depth by clicking inside a 2-D slice). The crosshair
         # moves in the plane.
+        x, y = self._unflip_arr_coords(x, y, axis, vol)
         i, j, k = self._cross_voxel
         if axis == _AXIS_SAGITTAL:
             j = x
@@ -1935,6 +2083,19 @@ class NiftiViewerPane(QWidget):
             i = x
             j = vol.shape[1] - 1 - y
         return i, j, k
+
+    def _flip_arr_coords(self, x: int, y: int, axis: int, vol) -> tuple[int, int]:
+        """Apply the display flip to in-plane (x, y) slice coordinates."""
+        f = self._display_flip()
+        h_ax, v_ax = _PLANE_HV[axis]
+        if f[h_ax] < 0:
+            x = (vol.shape[h_ax] - 1) - x
+        if f[v_ax] < 0:
+            y = (vol.shape[v_ax] - 1) - y
+        return x, y
+
+    # The flip is its own inverse, so mapping a click back is the same op.
+    _unflip_arr_coords = _flip_arr_coords
 
     def _voxel_to_arr(self, voxel, axis: int) -> tuple[int, int]:
         i, j, k = voxel
@@ -1948,7 +2109,7 @@ class NiftiViewerPane(QWidget):
         else:
             x = i
             y = vol.shape[1] - 1 - j
-        return x, y
+        return self._flip_arr_coords(x, y, axis, vol)
 
     # ------------------------------------------------------------------
     # Scroll on image -> step through the slice / volume stack

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -886,6 +886,10 @@ class NiftiViewerPane(QWidget):
 
         # Top: image area (single-pane OR tri-pane).
         self._image_stack = QStackedWidget()
+        # Pure-black visualization area (see #nifti-canvas in theme.qss). The
+        # pages inside are plain QWidgets that paint no background of their
+        # own, so this shows through behind every view mode.
+        self._image_stack.setObjectName("nifti-canvas")
         self._image_stack.addWidget(self._build_single_image())  # idx 0
         self._image_stack.addWidget(self._build_tri_image())     # idx 1
         self._image_stack.setCurrentIndex(0)
@@ -1439,7 +1443,7 @@ class NiftiViewerPane(QWidget):
     def _build_3d_page(self):
         """The pure "3D" page: full-width render + right-hand controls slot."""
         page = QWidget()
-        page.setObjectName("pane-dark")
+        page.setObjectName("nifti-canvas")
         h = QHBoxLayout(page)
         h.setContentsMargins(0, 0, 0, 0)
         h.setSpacing(2)

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -549,9 +549,15 @@ class NiftiViewerPane(QWidget):
             # New file lost its 4th dimension — close the graph.
             self._graph_btn.setChecked(False)
 
-        # 3D modes — GPU raycasting needs a scalar 3-D (or 4-D non-RGB)
-        # volume. Colour/RGB voxels aren't meaningful as a density field.
-        self._is_3d_capable = data.ndim >= 3 and not self._is_rgb
+        # 3D modes — the raycaster takes a scalar 3-D (or 4-D non-RGB) volume,
+        # or a colour volume: for RGB the shader uses the vector length as the
+        # density (the FA of a colour-FA map) and the hue to tint the surface,
+        # like MRIcroGL. 3 or 4 components only; a 5-component "colour" is not
+        # something the shader can map.
+        self._is_3d_capable = bool(
+            data.ndim >= 3
+            and (not self._is_rgb or (data.ndim == 4 and data.shape[3] in (3, 4)))
+        )
 
         # Reset brightness / contrast to defaults when a new file is
         # bound so the previous file's settings don't leak.
@@ -1487,7 +1493,12 @@ class NiftiViewerPane(QWidget):
         if self._data is None or self._gl is None:
             return
         vol = self._current_volume()
-        if getattr(vol, "ndim", 0) != 3:
+        ndim = getattr(vol, "ndim", 0)
+        # Scalar volume, or a colour one (RGB/RGBA) the shader renders tinted.
+        ok = ndim == 3 or (
+            ndim == 4 and self._is_rgb and vol.shape[3] in (3, 4)
+        )
+        if not ok:
             return
         self._gl.set_flip(*self._gl_flip())
         self._gl.set_volume_float(vol, self._volume_spacing())

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -293,6 +293,11 @@ class NiftiViewerPane(QWidget):
         self._ctrl_slot_combo = None
         self._gl_page_index: Optional[int] = None
         self._combo_page_index: Optional[int] = None
+        # The FIRST volume of the session lands in a default view — Multi-Planar
+        # 3-D when a GPU is available, plain Multi-Planar otherwise. Applied
+        # once; after that whichever view the user is in persists as they move
+        # between scans.
+        self._initial_view_applied: bool = False
         self._combo_labels: dict[int, ImageLabel] = {}
         self._combo_edge: dict = {}
         # Global display window (intensity low/high) for 2-D slices, computed
@@ -569,6 +574,14 @@ class NiftiViewerPane(QWidget):
         self._refresh()
         if self._graph_visible:
             self._update_graph()
+        # First real volume of the session opens in the default view; every
+        # later scan keeps whatever view the user is currently in.
+        if not self._initial_view_applied and data.ndim >= 3:
+            self._initial_view_applied = True
+            self._set_view_mode(
+                "combo" if (self._is_3d_capable and self._gpu_ok) else "multi"
+            )
+
         # If a 3-D mode is open, feed it the new volume; if the new file
         # can't be rendered in 3-D (e.g. RGB), drop back to plain 2-D.
         if (self._three_d or self._combo_view) and not self._is_3d_capable:

--- a/bidsmgr/gui/widgets/nifti_viewer_pane.py
+++ b/bidsmgr/gui/widgets/nifti_viewer_pane.py
@@ -233,24 +233,32 @@ class NiftiViewerPane(QWidget):
         # stay clear of GL entirely). ``_gl_page_index`` is its slot in
         # ``_image_stack`` once created.
         self._three_d: bool = False
-        self._gl_view = None
-        self._gl_page_index: Optional[int] = None
+        self._combo_view: bool = False
         self._is_3d_capable: bool = False
         # Whether this host can drive the GPU raycaster (OpenGL 3.3 core on
-        # real hardware). When False the 3D / Ortho 3D toggles are hidden
+        # real hardware). When False the 3D / Multi-Planar 3D toggles are hidden
         # entirely — the viewer stays a pure 2-D tool.
         try:
             from .nifti_gl_view import gpu_available
             self._gpu_ok: bool = gpu_available()
         except Exception:  # noqa: BLE001 - never block the 2-D viewer
             self._gpu_ok = False
-        # Combined "Ortho 3D" mode: the three orthogonal slices plus the GPU
-        # render in one 2×2 grid, with all render controls in a vertical side
-        # panel. Its own bare GL canvas (``_combo_gl``) + controls + slice
-        # labels, all built lazily. ``_combo_view`` is the active flag.
-        self._combo_view: bool = False
-        self._combo_gl = None
-        self._combo_controls = None
+        # The two 3-D modes ("3D" = full render, "Multi-Planar 3D" = the three
+        # planes + render in a grid) share ONE render + ONE control panel, so
+        # they are always the SAME view (effect / lighting / clip / camera) —
+        # not independent. The single ``_gl`` canvas + ``_gl_controls`` are
+        # reparented into whichever page is active (both pages live in the same
+        # window, so the GL context is preserved across the move).
+        self._gl = None
+        self._gl_controls = None
+        self._gl_controls_scroll = None
+        self._page_3d = None
+        self._page_combo = None
+        self._gl_slot_3d = None
+        self._ctrl_slot_3d = None
+        self._gl_slot_combo = None
+        self._ctrl_slot_combo = None
+        self._gl_page_index: Optional[int] = None
         self._combo_page_index: Optional[int] = None
         self._combo_labels: dict[int, ImageLabel] = {}
         self._combo_edge: dict = {}
@@ -364,6 +372,18 @@ class NiftiViewerPane(QWidget):
         # which the canvas grabs on click / scroll.
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self._install_shortcuts()
+
+        # Eagerly realise the 3-D GL page at construction (when a GPU is
+        # present). The pane is built before the main window is shown, so the
+        # host window is created render-to-texture-capable from the start.
+        # Adding the first QOpenGLWidget to an already-visible window otherwise
+        # forces Qt to recreate the native window — the "GUI closes and
+        # reopens" the first time 3-D is opened on Windows / Linux.
+        if self._gpu_ok:
+            try:
+                self._ensure_gl()
+            except Exception as exc:  # noqa: BLE001 - never block the 2-D viewer
+                log.warning("Could not pre-create the 3-D view: %s", exc)
 
     def _teardown_event_filter(self) -> None:
         app = QApplication.instance()
@@ -586,8 +606,8 @@ class NiftiViewerPane(QWidget):
 
         row1.addSpacing(8)
 
-        # Multi view toggle — sagittal+coronal+axial side by side.
-        self._tri_btn = QPushButton("Multi view")
+        # Multi-Planar toggle — sagittal+coronal+axial side by side.
+        self._tri_btn = QPushButton("Multi-Planar")
         self._tri_btn.setObjectName("tb-btn-toggle")
         self._tri_btn.setCheckable(True)
         self._tri_btn.setToolTip(
@@ -626,8 +646,8 @@ class NiftiViewerPane(QWidget):
         self._td_btn.toggled.connect(self._on_3d_toggled)
         row1.addWidget(self._td_btn)
 
-        # Ortho 3D — the three 2-D planes plus the GPU render in one 2×2 grid.
-        self._quad_btn = QPushButton("Ortho 3D")
+        # Multi-Planar 3D — the three 2-D planes plus the GPU render in one grid.
+        self._quad_btn = QPushButton("Multi-Planar 3D")
         self._quad_btn.setObjectName("tb-btn-toggle")
         self._quad_btn.setCheckable(True)
         self._quad_btn.setEnabled(False)
@@ -937,19 +957,13 @@ class NiftiViewerPane(QWidget):
         self._apply_orient_label_visibility()
         return w
 
-    def _build_combo_image(self) -> QWidget:
-        """Build the Ortho-3D page: 2×2 grid (3 slices + render) + side panel.
-
-        Grid mirrors MRIcroGL's default — Axial (top-left), Coronal
-        (top-right), Sagittal (bottom-left) and the volume render
-        (bottom-right). The three slice panels reuse the crosshair voxel and
-        render path of Multi view; the render is a bare
-        :class:`RaycastGLWidget`. All of its controls live in a vertical
-        :class:`Nifti3DControls` panel on the right (in a scroll area so they
-        never crowd the render), so the render gets the room it needs.
+    def _build_combo_page(self):
+        """The "Multi-Planar 3D" page: 2×2 grid (3 slices + a render slot) +
+        a controls slot on the right. The render + controls slots are filled
+        with the SHARED GL widget / controls by :meth:`_mount_gl`, so this view
+        and the pure "3D" view are always identical. Returns
+        ``(page, gl_slot, ctrl_slot)``.
         """
-        from .nifti_gl_view import Nifti3DControls, RaycastGLWidget
-
         page = QWidget()
         outer = QHBoxLayout(page)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -994,29 +1008,19 @@ class NiftiViewerPane(QWidget):
             grid.addWidget(cell, r, c)
             self._combo_labels[axis] = label
 
-        self._combo_gl = RaycastGLWidget()
-        self._combo_gl.set_show_cube(self._show_orient_labels)
-        grid.addWidget(self._combo_gl, 1, 1)
+        gl_slot = self._slot()          # the shared render is mounted here
+        grid.addWidget(gl_slot, 1, 1)
         for i in range(2):
             grid.setRowStretch(i, 1)
             grid.setColumnStretch(i, 1)
         outer.addWidget(grid_host, 1)
 
-        # Vertical control column on the right, in a scroll area so it stays
-        # usable when the pane is short.
-        self._combo_controls = Nifti3DControls(self._combo_gl, vertical=True)
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.Shape.NoFrame)
-        scroll.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        scroll.setWidget(self._combo_controls)
-        scroll.setFixedWidth(212)
-        outer.addWidget(scroll)
+        ctrl_slot = self._slot()        # the shared controls are mounted here
+        ctrl_slot.setFixedWidth(226)
+        outer.addWidget(ctrl_slot)
 
         self._apply_orient_label_visibility()
-        return page
+        return page, gl_slot, ctrl_slot
 
     def _build_graph_panel(self) -> QWidget:
         """Build the 4-D time-series plot panel (pyqtgraph).
@@ -1179,19 +1183,16 @@ class NiftiViewerPane(QWidget):
         self._set_view_mode("combo" if checked else "single")
 
     def _set_view_mode(self, mode: str) -> None:
-        # Lazily build whatever GL page the target mode needs; if that fails
-        # (no GL driver / headless), fall back to plain single-pane 2-D.
-        if mode == "3d":
+        # Build the shared GL render/controls on demand; if that fails (no GL
+        # driver / headless), fall back to plain single-pane 2-D. Then mount
+        # the shared render into the active 3-D page so both 3-D modes show the
+        # very same view.
+        if mode in ("3d", "combo"):
             try:
-                self._ensure_gl_view()
+                self._ensure_gl()
+                self._mount_gl(mode)
             except Exception as exc:  # noqa: BLE001
                 log.warning("Could not open the 3-D view: %s", exc)
-                mode = "single"
-        elif mode == "combo":
-            try:
-                self._ensure_combo_view()
-            except Exception as exc:  # noqa: BLE001
-                log.warning("Could not open the Ortho-3D view: %s", exc)
                 mode = "single"
 
         self._tri_view = mode == "multi"
@@ -1265,31 +1266,111 @@ class NiftiViewerPane(QWidget):
             self._td_btn.toggle()
 
     def _toggle_combo(self) -> None:
-        """'P' shortcut — flip the Ortho-3D button when it applies."""
+        """'P' shortcut — flip the Multi-Planar 3D button when it applies."""
         if self._quad_btn.isEnabled():
             self._quad_btn.toggle()
 
-    def _ensure_gl_view(self):
-        """Build the pure-3-D GL page on first use and add it to the stack.
+    # -- 3-D slicer keyboard shortcuts (Shift + …) -------------------------
 
-        Lazy so the OpenGL context is only created when the user actually
-        opens a 3-D mode — importing PyOpenGL / creating a QOpenGLWidget is
-        deferred out of the module import graph and the common path.
+    def _slicer_active(self) -> bool:
+        """Slicer shortcuts apply only while a 3-D render is on screen."""
+        return (self._three_d or self._combo_view) and self._gl_controls is not None
+
+    def _kbd_toggle_slicer(self) -> None:
+        """Shift+Z — activate / deactivate the clip-plane slicer.
+
+        While the slicer is on, Shift+drag orients the cut (azimuth/elevation)
+        and Shift+scroll moves it through the volume.
         """
-        if self._gl_view is not None:
-            return self._gl_view
-        from .nifti_gl_view import Nifti3DView
-        self._gl_view = Nifti3DView()
-        self._gl_view.set_show_cube(self._show_orient_labels)
-        self._gl_page_index = self._image_stack.addWidget(self._gl_view)
-        return self._gl_view
+        if self._slicer_active():
+            self._gl_controls.kbd_toggle_clip()
 
-    def _ensure_combo_view(self):
-        """Build the Ortho-3D (2×2 slices + render) page on first use."""
-        if self._combo_page_index is not None:
+    def _kbd_clip_axial(self) -> None:
+        """Shift+A — axial cut (plane normal along S–I)."""
+        if self._slicer_active():
+            self._gl_controls.kbd_set_axis(0, 90)
+
+    def _kbd_clip_sagittal(self) -> None:
+        """Shift+S — sagittal cut (plane normal along L–R)."""
+        if self._slicer_active():
+            self._gl_controls.kbd_set_axis(90, 0)
+
+    def _kbd_clip_coronal(self) -> None:
+        """Shift+C — coronal cut (plane normal along A–P)."""
+        if self._slicer_active():
+            self._gl_controls.kbd_set_axis(0, 0)
+
+    def _kbd_clip_invert(self) -> None:
+        """Shift+X — invert the cut direction."""
+        if self._slicer_active():
+            self._gl_controls.kbd_invert()
+
+    def _ensure_gl(self):
+        """Build the shared GL render + controls and both 3-D pages once.
+
+        A single :class:`RaycastGLWidget` + :class:`Nifti3DControls` back BOTH
+        the "3D" page and the "Multi-Planar 3D" page; they are reparented into
+        whichever page is active (:meth:`_mount_gl`). That keeps the two views
+        identical — same effect, lighting, clip and camera — rather than two
+        independent renders.
+        """
+        if self._gl is not None:
             return
-        page = self._build_combo_image()
-        self._combo_page_index = self._image_stack.addWidget(page)
+        from .nifti_gl_view import Nifti3DControls, RaycastGLWidget
+        self._gl = RaycastGLWidget()
+        self._gl.set_show_cube(self._show_orient_labels)
+        self._gl_controls = Nifti3DControls(self._gl, vertical=True)
+        self._gl_controls_scroll = QScrollArea()
+        self._gl_controls_scroll.setWidgetResizable(True)
+        self._gl_controls_scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self._gl_controls_scroll.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self._gl_controls_scroll.setWidget(self._gl_controls)
+        self._gl_controls_scroll.setFixedWidth(224)
+
+        (self._page_3d, self._gl_slot_3d,
+         self._ctrl_slot_3d) = self._build_3d_page()
+        (self._page_combo, self._gl_slot_combo,
+         self._ctrl_slot_combo) = self._build_combo_page()
+        self._gl_page_index = self._image_stack.addWidget(self._page_3d)
+        self._combo_page_index = self._image_stack.addWidget(self._page_combo)
+        self._mount_gl("3d")   # park it in the pure-3-D page by default
+
+    @staticmethod
+    def _slot() -> QWidget:
+        w = QWidget()
+        lay = QVBoxLayout(w)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(0)
+        return w
+
+    def _mount_gl(self, mode: str) -> None:
+        """Reparent the shared render + controls into the active page's slots."""
+        if self._gl is None:
+            return
+        if mode == "combo":
+            gl_slot, ctrl_slot = self._gl_slot_combo, self._ctrl_slot_combo
+        else:
+            gl_slot, ctrl_slot = self._gl_slot_3d, self._ctrl_slot_3d
+        # addWidget reparents (auto-removing from the previous slot). Same
+        # top-level window on both sides, so the GL context is preserved.
+        gl_slot.layout().addWidget(self._gl)
+        ctrl_slot.layout().addWidget(self._gl_controls_scroll)
+
+    def _build_3d_page(self):
+        """The pure "3D" page: full-width render + right-hand controls slot."""
+        page = QWidget()
+        page.setObjectName("pane-dark")
+        h = QHBoxLayout(page)
+        h.setContentsMargins(0, 0, 0, 0)
+        h.setSpacing(2)
+        gl_slot = self._slot()
+        ctrl_slot = self._slot()
+        ctrl_slot.setFixedWidth(226)
+        h.addWidget(gl_slot, 1)
+        h.addWidget(ctrl_slot)
+        return page, gl_slot, ctrl_slot
 
     def _volume_spacing(self) -> tuple[float, float, float]:
         """Voxel spacing (mm) of the loaded image, defaulting to isotropic."""
@@ -1302,22 +1383,13 @@ class NiftiViewerPane(QWidget):
             return (1.0, 1.0, 1.0)
 
     def _push_volume_to_3d(self) -> None:
-        """Send the current (4-D-aware) 3-D volume to the active GL view.
-
-        The pure-3-D page owns a :class:`Nifti3DView` (``set_volume`` windows
-        internally); the Ortho-3D page owns a bare
-        :class:`RaycastGLWidget` (``set_volume_float`` windows for it).
-        """
-        if self._data is None:
+        """Send the current (4-D-aware) 3-D volume to the shared GL render."""
+        if self._data is None or self._gl is None:
             return
         vol = self._current_volume()
         if getattr(vol, "ndim", 0) != 3:
             return
-        spacing = self._volume_spacing()
-        if self._three_d and self._gl_view is not None:
-            self._gl_view.set_volume(vol, spacing)
-        elif self._combo_view and self._combo_gl is not None:
-            self._combo_gl.set_volume_float(vol, spacing)
+        self._gl.set_volume_float(vol, self._volume_spacing())
 
     # ------------------------------------------------------------------
     # Orientation labels
@@ -1340,11 +1412,9 @@ class NiftiViewerPane(QWidget):
         for group in groups:
             for lbl in group.values():
                 lbl.setVisible(self._show_orient_labels)
-        # The same toggle drives the 3-D orientation cube on both GL views.
-        if self._gl_view is not None:
-            self._gl_view.set_show_cube(self._show_orient_labels)
-        if self._combo_gl is not None:
-            self._combo_gl.set_show_cube(self._show_orient_labels)
+        # The same toggle drives the 3-D orientation cube on the shared render.
+        if self._gl is not None:
+            self._gl.set_show_cube(self._show_orient_labels)
 
     def _on_labels_toggled(self, checked: bool) -> None:
         self._show_orient_labels = checked
@@ -1406,6 +1476,13 @@ class NiftiViewerPane(QWidget):
             ("O", self._toggle_orient_labels),
             ("D", self._toggle_3d),
             ("P", self._toggle_combo),
+            # 3-D slicer (clip plane). Shift + drag/scroll while active orients
+            # and navigates the cut.
+            ("Shift+Z", self._kbd_toggle_slicer),
+            ("Shift+A", self._kbd_clip_axial),
+            ("Shift+S", self._kbd_clip_sagittal),
+            ("Shift+C", self._kbd_clip_coronal),
+            ("Shift+X", self._kbd_clip_invert),
         )
         for key, handler in specs:
             sc = QShortcut(QKeySequence(key), self)
@@ -1430,16 +1507,25 @@ class NiftiViewerPane(QWidget):
                 ("Axial view", "A"),
                 ("Sagittal view", "S"),
                 ("Coronal view", "C"),
-                ("Multi view (toggle)", "M"),
+                ("Multi-Planar (toggle)", "M"),
                 ("3D volume render (toggle)", "D"),
-                ("Ortho 3D — planes + render (toggle)", "P"),
+                ("Multi-Planar 3D — planes + render (toggle)", "P"),
                 ("Graph / time-series (toggle)", "G"),
                 ("Orientation labels (toggle)", "O"),
             ]),
             ("3D view", [
                 ("Rotate the volume", "Drag"),
+                ("Pan", "Right-drag"),
                 ("Zoom in / out", "Scroll"),
-                ("Slice into the volume", "Clip plane controls"),
+            ]),
+            ("3D slicer (clip plane)", [
+                ("Activate / deactivate slicer", "Shift+Z"),
+                ("Orient the cut freely", "Shift+drag"),
+                ("Navigate the slice", "Shift+scroll"),
+                ("Axial cut", "Shift+A"),
+                ("Sagittal cut", "Shift+S"),
+                ("Coronal cut", "Shift+C"),
+                ("Invert the cut", "Shift+X"),
             ]),
         ]
 
@@ -2203,9 +2289,8 @@ class NiftiViewerPane(QWidget):
             btn.setEnabled(False)
             btn.blockSignals(was)
         self._image_stack.setCurrentIndex(0)
-        for view in (self._gl_view, self._combo_gl):
-            if view is not None:
-                view.clear()
+        if self._gl is not None:
+            self._gl.clear()
         self._toolbar.setVisible(False)
         self._footer.setVisible(False)
         self._footer_path.setText("")

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -290,15 +290,26 @@ def scan_dicoms_long(
     # submission order, so the collected list is identical to the eager
     # ``Parallel(...)(...)`` form when not cancelled.
     from ..util.cancel import OperationCancelled, is_cancelled
-    _gen = Parallel(n_jobs=n_jobs, return_as="generator")(
-        delayed(_read_one)(fp, root_dir) for fp in file_list
+    from ..util.parallel import run_parallel
+
+    def _collect(gen):
+        collected = []
+        for _i, _res in enumerate(gen):
+            # Poll periodically (every 64 reads) to keep the check cheap.
+            if (_i & 63) == 0 and is_cancelled(cancel_check):
+                raise OperationCancelled("scan cancelled by user")
+            collected.append(_res)
+        return collected
+
+    # run_parallel picks a working backend (worker processes everywhere except
+    # Windows + Python 3.14, where loky kills its own workers) and retries on
+    # threads if a pool dies anyway.
+    results = run_parallel(
+        lambda: (delayed(_read_one)(fp, root_dir) for fp in file_list),
+        n_jobs=n_jobs,
+        consume=_collect,
+        return_as="generator",
     )
-    results = []
-    for _i, _res in enumerate(_gen):
-        # Poll periodically (every 64 reads) to keep the check cheap.
-        if (_i & 63) == 0 and is_cancelled(cancel_check):
-            raise OperationCancelled("scan cancelled by user")
-        results.append(_res)
     for res in results:
         if not res:
             continue

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -34,7 +34,7 @@ from typing import Optional
 
 import pandas as pd
 import pydicom
-from joblib import Parallel, delayed
+from joblib import delayed  # pools are built by bidsmgr.util.parallel
 from pydicom.multival import MultiValue
 
 from ..classifier.sequence_dict import (

--- a/bidsmgr/inventory/probe_convert.py
+++ b/bidsmgr/inventory/probe_convert.py
@@ -48,7 +48,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional
 
-from joblib import Parallel, delayed
+from joblib import delayed  # pools are built by bidsmgr.util.parallel
 
 from bidsmgr.util.paths import long_path
 

--- a/bidsmgr/inventory/probe_convert.py
+++ b/bidsmgr/inventory/probe_convert.py
@@ -363,9 +363,15 @@ def probe_rows(
     # arguments must be picklable. Path / str / list[str] all are. nibabel
     # is imported lazily inside collect_probe_stats so cold workers don't
     # pay the import cost when no NIfTI 4D check is needed.
-    results = Parallel(n_jobs=n_jobs)(
-        delayed(_probe_one_series)(uid, files, series_workdir, bin_path)
-        for uid, files, series_workdir in tasks
+    from ..util.parallel import run_parallel
+
+    results = run_parallel(
+        lambda: (
+            delayed(_probe_one_series)(uid, files, series_workdir, bin_path)
+            for uid, files, series_workdir in tasks
+        ),
+        n_jobs=n_jobs,
+        consume=list,
     )
 
     out: dict[str, ProbeFileStats] = {}

--- a/bidsmgr/main.py
+++ b/bidsmgr/main.py
@@ -66,6 +66,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     # (bidsmgr.gui.widgets.nifti_gl_view) gets a context its #version 330
     # shaders can compile against — on macOS the compatibility profile is
     # stuck at GL 2.1. Harmless for the rest of the (raster) GUI.
+    from PyQt6.QtCore import Qt
+    # Share GL contexts across the app's QOpenGLWidgets. Required before the
+    # QApplication is built; it lets the raycaster survive the detachable
+    # Viewer being re-docked without losing its context.
+    QApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts, True)
     from .gui.widgets.nifti_gl_view import request_gl_format
     request_gl_format()
 

--- a/bidsmgr/main.py
+++ b/bidsmgr/main.py
@@ -61,6 +61,14 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     from PyQt6.QtWidgets import QApplication
 
+    # Register an OpenGL 3.3 core default surface format *before* the
+    # QApplication is constructed so the NIfTI viewer's GPU raycaster
+    # (bidsmgr.gui.widgets.nifti_gl_view) gets a context its #version 330
+    # shaders can compile against — on macOS the compatibility profile is
+    # stuck at GL 2.1. Harmless for the rest of the (raster) GUI.
+    from .gui.widgets.nifti_gl_view import request_gl_format
+    request_gl_format()
+
     from .gui.main_window import MainWindow
     from .gui.theme_manager import ThemeManager
 

--- a/bidsmgr/util/parallel.py
+++ b/bidsmgr/util/parallel.py
@@ -4,74 +4,94 @@ joblib's default ``loky`` backend runs each task in a worker *process*, which
 is what we want for DICOM header reads and dcm2niix probes: they are CPU- and
 IO-heavy and sidestep the GIL entirely.
 
-On **Windows with Python 3.14** that backend is unusable. loky's Windows spawn
-path (``loky.backend.popen_loky_win32``) starts workers that die during
-bootstrap, and joblib surfaces the corpse as::
+Some environments cannot run it. The known case is **Windows with Python
+3.14**, where loky's Windows spawn path starts workers that die during
+bootstrap and joblib reports::
 
     joblib.externals.loky.process_executor.TerminatedWorkerError: A worker
     process managed by the executor was unexpectedly terminated. ...
 
-so a scan that works everywhere else fails outright there. joblib 1.5.3 /
-loky 3.5.6 are the newest releases at the time of writing and both still carry
-the bug, so there is no version to upgrade to — we have to route around it.
+which takes the whole scan down. joblib 1.5.3 / loky 3.5.6 are the newest
+releases at the time of writing and both still carry the bug, so there is no
+version to upgrade to.
 
-Two layers of defence:
+Rather than trying to enumerate the affected (OS, Python) pairs — we only ever
+confirmed one, and hard-coding a guess would both punish machines that are
+fine and miss ones that are not — the policy is **detect, don't predict**:
 
-* :func:`preferred_backend` picks ``"threading"`` up front on the affected
-  combination, so users never hit the crash. Threads are slower than processes
-  for this work (the GIL is only released around IO and inside pydicom /
-  subprocess calls) but they are correct and keep the UI responsive.
-* :func:`run_parallel` retries with threads if a process pool dies anyway.
-  That covers the same failure appearing on a platform we did not predict,
-  turning a hard failure into a slow success.
+1. Always start with the fast process backend.
+2. If a pool dies, fall back to threads for that run *and remember it*, so the
+   rest of the session goes straight to threads instead of paying the failed
+   start-up again. The memory is per-process, so a fixed joblib picks the fast
+   path back up on the next launch with no code change here.
+
+Threads are slower for this work (the GIL is only released around IO and inside
+pydicom / subprocess calls) but they are correct, use less memory than a
+process pool, and keep the UI responsive.
+
+Set ``BIDSMGR_PARALLEL_BACKEND=threading`` to skip the process backend
+entirely — useful for confirming a support hunch without a code change.
 """
 
 from __future__ import annotations
 
 import logging
-import sys
+import os
+import threading
 from typing import Any, Callable, Iterable, Optional
 
 from joblib import Parallel
 
 log = logging.getLogger(__name__)
 
+#: Set to ``"threading"`` to force the safe backend for the whole process.
+BACKEND_ENV_VAR = "BIDSMGR_PARALLEL_BACKEND"
 
-def loky_is_broken() -> bool:
-    """True where joblib's process backend cannot be trusted.
+#: Fallback backend: in-process threads, no worker spawning to go wrong.
+SAFE_BACKEND = "threading"
 
-    Windows + Python 3.14: loky's spawn path kills its own workers during
-    bootstrap. Kept as a narrow, explicitly-versioned check so the fast
-    process backend is given up only where it is actually broken — revisit
-    when a joblib/loky release fixes it.
-    """
-    return sys.platform == "win32" and sys.version_info >= (3, 14)
+# Flipped to True the first time a process pool dies in this interpreter, so
+# the failed start-up is paid once per session rather than once per pool
+# (scan, probe and convert each build their own).
+_process_pool_broken = False
+_lock = threading.Lock()
+
+
+def _forced_backend() -> Optional[str]:
+    value = os.environ.get(BACKEND_ENV_VAR, "").strip()
+    return value or None
+
+
+def process_backend_disabled() -> bool:
+    """Whether the process backend has been ruled out for this session."""
+    with _lock:
+        return _process_pool_broken
+
+
+def _disable_process_backend() -> None:
+    global _process_pool_broken
+    with _lock:
+        _process_pool_broken = True
+
+
+def reset_backend_state() -> None:
+    """Forget a previous pool failure (test helper)."""
+    global _process_pool_broken
+    with _lock:
+        _process_pool_broken = False
 
 
 def preferred_backend() -> Optional[str]:
     """Backend for :class:`joblib.Parallel`, or ``None`` for joblib's default.
 
-    ``None`` means loky (worker processes). ``"threading"`` is returned only
-    where processes are known to be broken.
+    ``None`` means loky (worker processes) and is the normal answer on every
+    platform. ``"threading"`` is returned only after a process pool has
+    actually died in this session, or when the environment variable forces it.
     """
-    return "threading" if loky_is_broken() else None
-
-
-def _is_dead_worker_error(exc: BaseException) -> bool:
-    """Whether ``exc`` means the process pool died rather than a task failing.
-
-    Matched by name so importing joblib's private executor module (and pulling
-    in its vendored loky) is not required, and so sibling errors from other
-    joblib versions are still caught.
-    """
-    names = {type(exc).__name__ for exc in _causes(exc)}
-    return bool(names & {
-        "TerminatedWorkerError",     # worker segfaulted / was killed
-        "BrokenProcessPool",         # pool unusable
-        "BrokenExecutor",
-        "WorkerInterrupt",
-        "ProcessTerminatedError",
-    })
+    forced = _forced_backend()
+    if forced:
+        return forced
+    return SAFE_BACKEND if process_backend_disabled() else None
 
 
 def _causes(exc: BaseException) -> Iterable[BaseException]:
@@ -82,6 +102,24 @@ def _causes(exc: BaseException) -> Iterable[BaseException]:
         seen.add(id(cur))
         yield cur
         cur = cur.__cause__ or cur.__context__
+
+
+def _is_dead_worker_error(exc: BaseException) -> bool:
+    """Whether ``exc`` means the pool itself died rather than a task failing.
+
+    Matched by class name so joblib's private executor module (and its vendored
+    loky) needn't be imported, and so equivalents from other joblib versions
+    are still recognised. A task raising is NOT this: that error belongs to the
+    caller and is re-raised untouched.
+    """
+    names = {type(e).__name__ for e in _causes(exc)}
+    return bool(names & {
+        "TerminatedWorkerError",     # worker segfaulted / was killed
+        "BrokenProcessPool",         # pool unusable
+        "BrokenExecutor",
+        "WorkerInterrupt",
+        "ProcessTerminatedError",
+    })
 
 
 def run_parallel(
@@ -95,27 +133,37 @@ def run_parallel(
     """Run ``tasks`` through :class:`joblib.Parallel`, falling back to threads.
 
     ``tasks`` is a *factory* returning a fresh iterable of ``delayed(...)``
-    calls: a generator is consumed by the first attempt, so the retry needs to
-    build its own. ``consume`` receives whatever ``Parallel`` returns (a list,
-    or a generator when ``return_as="generator"``) and drives the iteration,
-    which is what lets callers poll for cancellation.
+    calls: the first attempt consumes the iterable, so a retry needs its own.
+    ``consume`` receives whatever ``Parallel`` returns (a list, or a generator
+    when ``return_as="generator"``) and drives the iteration — that is what
+    lets callers poll for cancellation while results stream in.
 
-    If the process pool dies, the whole run is retried on the threading
-    backend. The retry restarts from the beginning — the failure happens as
-    workers start up, so little work is lost, and a partial result would be
-    worse than a slow one.
+    If the pool dies, the run is retried on threads and the process backend is
+    disabled for the rest of the session. The retry restarts from the
+    beginning: pools normally die as they start up, so little is lost, and a
+    silently partial result would be worse than a slow complete one.
+
+    Only pool-death counts. An exception raised by a task — or
+    ``OperationCancelled`` from ``consume`` — propagates untouched.
     """
     chosen = backend if backend is not None else preferred_backend()
+    if chosen != SAFE_BACKEND and process_backend_disabled():
+        # A pool already died this session; don't pay for it again.
+        chosen = SAFE_BACKEND
+
     try:
         return consume(Parallel(n_jobs=n_jobs, backend=chosen, **kwargs)(tasks()))
     except Exception as exc:
-        if chosen == "threading" or not _is_dead_worker_error(exc):
+        if chosen == SAFE_BACKEND or not _is_dead_worker_error(exc):
             raise
+        _disable_process_backend()
         log.warning(
-            "Parallel worker processes died (%s); retrying with threads. "
-            "This is slower but avoids the failure.",
-            type(exc).__name__,
+            "Parallel worker processes died (%s); falling back to the %r "
+            "backend for the rest of this session. This is slower but avoids "
+            "the failure. Known to affect Windows with Python 3.14.",
+            type(exc).__name__, SAFE_BACKEND,
         )
+
     return consume(
-        Parallel(n_jobs=n_jobs, backend="threading", **kwargs)(tasks())
+        Parallel(n_jobs=n_jobs, backend=SAFE_BACKEND, **kwargs)(tasks())
     )

--- a/bidsmgr/util/parallel.py
+++ b/bidsmgr/util/parallel.py
@@ -1,0 +1,121 @@
+"""Backend selection for the joblib pools used by scan / probe / convert.
+
+joblib's default ``loky`` backend runs each task in a worker *process*, which
+is what we want for DICOM header reads and dcm2niix probes: they are CPU- and
+IO-heavy and sidestep the GIL entirely.
+
+On **Windows with Python 3.14** that backend is unusable. loky's Windows spawn
+path (``loky.backend.popen_loky_win32``) starts workers that die during
+bootstrap, and joblib surfaces the corpse as::
+
+    joblib.externals.loky.process_executor.TerminatedWorkerError: A worker
+    process managed by the executor was unexpectedly terminated. ...
+
+so a scan that works everywhere else fails outright there. joblib 1.5.3 /
+loky 3.5.6 are the newest releases at the time of writing and both still carry
+the bug, so there is no version to upgrade to — we have to route around it.
+
+Two layers of defence:
+
+* :func:`preferred_backend` picks ``"threading"`` up front on the affected
+  combination, so users never hit the crash. Threads are slower than processes
+  for this work (the GIL is only released around IO and inside pydicom /
+  subprocess calls) but they are correct and keep the UI responsive.
+* :func:`run_parallel` retries with threads if a process pool dies anyway.
+  That covers the same failure appearing on a platform we did not predict,
+  turning a hard failure into a slow success.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any, Callable, Iterable, Optional
+
+from joblib import Parallel
+
+log = logging.getLogger(__name__)
+
+
+def loky_is_broken() -> bool:
+    """True where joblib's process backend cannot be trusted.
+
+    Windows + Python 3.14: loky's spawn path kills its own workers during
+    bootstrap. Kept as a narrow, explicitly-versioned check so the fast
+    process backend is given up only where it is actually broken — revisit
+    when a joblib/loky release fixes it.
+    """
+    return sys.platform == "win32" and sys.version_info >= (3, 14)
+
+
+def preferred_backend() -> Optional[str]:
+    """Backend for :class:`joblib.Parallel`, or ``None`` for joblib's default.
+
+    ``None`` means loky (worker processes). ``"threading"`` is returned only
+    where processes are known to be broken.
+    """
+    return "threading" if loky_is_broken() else None
+
+
+def _is_dead_worker_error(exc: BaseException) -> bool:
+    """Whether ``exc`` means the process pool died rather than a task failing.
+
+    Matched by name so importing joblib's private executor module (and pulling
+    in its vendored loky) is not required, and so sibling errors from other
+    joblib versions are still caught.
+    """
+    names = {type(exc).__name__ for exc in _causes(exc)}
+    return bool(names & {
+        "TerminatedWorkerError",     # worker segfaulted / was killed
+        "BrokenProcessPool",         # pool unusable
+        "BrokenExecutor",
+        "WorkerInterrupt",
+        "ProcessTerminatedError",
+    })
+
+
+def _causes(exc: BaseException) -> Iterable[BaseException]:
+    """``exc`` plus its ``__cause__`` / ``__context__`` chain (bounded)."""
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    while cur is not None and id(cur) not in seen and len(seen) < 10:
+        seen.add(id(cur))
+        yield cur
+        cur = cur.__cause__ or cur.__context__
+
+
+def run_parallel(
+    tasks: Callable[[], Iterable],
+    *,
+    n_jobs: int,
+    consume: Callable[[Any], Any],
+    backend: Optional[str] = None,
+    **kwargs: Any,
+) -> Any:
+    """Run ``tasks`` through :class:`joblib.Parallel`, falling back to threads.
+
+    ``tasks`` is a *factory* returning a fresh iterable of ``delayed(...)``
+    calls: a generator is consumed by the first attempt, so the retry needs to
+    build its own. ``consume`` receives whatever ``Parallel`` returns (a list,
+    or a generator when ``return_as="generator"``) and drives the iteration,
+    which is what lets callers poll for cancellation.
+
+    If the process pool dies, the whole run is retried on the threading
+    backend. The retry restarts from the beginning — the failure happens as
+    workers start up, so little work is lost, and a partial result would be
+    worse than a slow one.
+    """
+    chosen = backend if backend is not None else preferred_backend()
+    try:
+        return consume(Parallel(n_jobs=n_jobs, backend=chosen, **kwargs)(tasks()))
+    except Exception as exc:
+        if chosen == "threading" or not _is_dead_worker_error(exc):
+            raise
+        log.warning(
+            "Parallel worker processes died (%s); retrying with threads. "
+            "This is slower but avoids the failure.",
+            type(exc).__name__,
+        )
+    return consume(
+        Parallel(n_jobs=n_jobs, backend="threading", **kwargs)(tasks())
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.4.2"
+version = "1.2.5"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
     {name = "Karel Lopez Vilaret", email = "karel.mauricio.lopez.vilaret@uni-oldenburg.de"},
+    {name = "Karel Lopez Vilaret"},
     {name = "Jochem Rieger"},
 ]
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.5"
+version = "1.2.5.1"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -1,0 +1,394 @@
+"""Tests for the NIfTI viewer's 3-D GPU raycast integration.
+
+These exercise the *wiring* — the 3D toolbar toggle, mutual exclusion
+with Multi view, control enable/disable, and the data path into the GL
+view — without requiring a live OpenGL context. The ``RaycastGLWidget``
+is created (a ``QOpenGLWidget``) but never shown, so ``initializeGL`` /
+rendering don't run; the volume is stashed as ``pending`` and observed
+via :meth:`RaycastGLWidget.has_volume`. This keeps the suite green under
+the headless ``offscreen`` Qt platform used in CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+nib = pytest.importorskip("nibabel")
+pytest.importorskip("OpenGL")
+
+from bidsmgr.gui.widgets.nifti_viewer_pane import NiftiViewerPane
+from bidsmgr.gui.widgets.nifti_gl_view import Nifti3DView, request_gl_format
+
+
+pytestmark = pytest.mark.gui
+
+
+def _write_nifti(path: Path, arr: np.ndarray) -> None:
+    nib.save(nib.Nifti1Image(arr, affine=np.eye(4)), str(path))
+
+
+@pytest.fixture
+def bids_root_with_nifti(tmp_path: Path) -> Path:
+    root = tmp_path / "Studyname"
+    anat = root / "sub-01" / "ses-01" / "anat"
+    anat.mkdir(parents=True)
+    arr_3d = np.arange(10 * 12 * 8, dtype=np.float32).reshape(10, 12, 8)
+    _write_nifti(anat / "sub-01_ses-01_T1w.nii.gz", arr_3d)
+    func = root / "sub-01" / "ses-01" / "func"
+    func.mkdir(parents=True)
+    arr_4d = np.random.default_rng(0).random((6, 6, 4, 3), dtype=np.float32)
+    _write_nifti(func / "sub-01_ses-01_task-rest_bold.nii.gz", arr_4d)
+    return root
+
+
+def _t1(root: Path) -> Path:
+    return root / "sub-01" / "ses-01" / "anat" / "sub-01_ses-01_T1w.nii.gz"
+
+
+def _bold(root: Path) -> Path:
+    return root / "sub-01" / "ses-01" / "func" / "sub-01_ses-01_task-rest_bold.nii.gz"
+
+
+def _load_and_wait(pane, path, root, qtbot, timeout_ms: int = 5000):
+    with qtbot.waitSignal(pane.loaded, timeout=timeout_ms):
+        pane.set_file(path, root)
+
+
+# ---------------------------------------------------------------------------
+# request_gl_format
+# ---------------------------------------------------------------------------
+
+
+def test_request_gl_format_is_33_core(qapp) -> None:
+    from PyQt6.QtGui import QSurfaceFormat
+
+    fmt = request_gl_format()
+    assert fmt.majorVersion() == 3 and fmt.minorVersion() == 3
+    assert fmt.profile() == QSurfaceFormat.OpenGLContextProfile.CoreProfile
+
+
+# ---------------------------------------------------------------------------
+# 3D button enablement
+# ---------------------------------------------------------------------------
+
+
+def test_3d_button_disabled_before_load(qapp, isolated_settings) -> None:
+    pane = NiftiViewerPane()
+    assert pane._td_btn.isEnabled() is False
+
+
+def test_3d_button_enabled_for_3d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._td_btn.isEnabled() is True
+
+
+def test_3d_button_enabled_for_4d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _bold(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._td_btn.isEnabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Toggle behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_3d_toggle_switches_stack_and_disables_2d_controls(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._three_d is True
+    # The GL page was created and is now current.
+    assert pane._gl_page_index is not None
+    assert pane._image_stack.currentIndex() == pane._gl_page_index
+    # 2-D-only controls greyed out.
+    for btn in (pane._sa_btn, pane._co_btn, pane._ax_btn):
+        assert not btn.isEnabled()
+    assert not pane._slice_slider.isEnabled()
+    assert not pane._bright_slider.isEnabled()
+    assert not pane._contrast_slider.isEnabled()
+    # Multi view stays live so the user can switch straight to it.
+    assert pane._tri_btn.isEnabled()
+
+    # Toggle off restores the single-pane view + controls.
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._three_d is False
+    assert pane._image_stack.currentIndex() == 0
+    assert pane._sa_btn.isEnabled()
+    assert pane._slice_slider.isEnabled()
+    assert pane._bright_slider.isEnabled()
+
+
+def test_3d_toggle_feeds_volume_to_gl_view(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._gl_view is not None
+    # Volume was handed to the GL widget (stashed as pending until first paint).
+    assert pane._gl_view.gl.has_volume() is True
+
+
+def test_3d_and_multiview_mutually_exclusive(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+
+    # Multi view on, then 3D on → Multi view turns off.
+    pane._tri_btn.click()
+    qapp.processEvents()
+    assert pane._tri_view is True
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._three_d is True
+    assert pane._tri_view is False
+    assert pane._image_stack.currentIndex() == pane._gl_page_index
+
+    # Multi view on again → 3D turns off.
+    pane._tri_btn.click()
+    qapp.processEvents()
+    assert pane._tri_view is True
+    assert pane._three_d is False
+    assert pane._image_stack.currentIndex() == 1
+
+
+def test_volume_slider_repushes_in_3d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    """Changing the 4-D volume while 3-D is open re-feeds the GL view."""
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _bold(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    # Moving the volume slider should not raise and keeps a volume bound.
+    pane._vol_slider.setValue(2)
+    qapp.processEvents()
+    assert pane._gl_view.gl.has_volume() is True
+
+
+def test_set_file_none_clears_3d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._three_d is True
+
+    pane.set_file(None, None)
+    qapp.processEvents()
+    assert pane._three_d is False
+    assert pane._td_btn.isEnabled() is False
+    assert pane._image_stack.currentIndex() == 0
+
+
+def test_orientation_shortcut_exits_3d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    from bidsmgr.gui.widgets.nifti_viewer_pane import _AXIS_SAGITTAL
+
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._three_d is True
+    # Pressing a plane shortcut leaves 3-D and shows that plane in 2-D.
+    pane._shortcut_orientation(_AXIS_SAGITTAL)
+    qapp.processEvents()
+    assert pane._three_d is False
+    assert pane._orientation == _AXIS_SAGITTAL
+    assert pane._image_stack.currentIndex() == 0
+
+
+# ---------------------------------------------------------------------------
+# Nifti3DView unit
+# ---------------------------------------------------------------------------
+
+
+def test_nifti3dview_normalises_and_binds(qapp) -> None:
+    view = Nifti3DView()
+    vol = np.linspace(0, 1000, 8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8)
+    view.set_volume(vol, (1.0, 1.0, 1.0))
+    assert view.gl.has_volume() is True
+    # Effect combo drives the GL widget's effect field.
+    view.controls._effect.setCurrentIndex(1)   # MIP
+    assert view.gl.effect == 1
+
+
+def test_effect_and_lighting_selectors(qapp) -> None:
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, LIGHTINGS
+
+    view = Nifti3DView()
+    assert len(EFFECTS) >= 5 and len(LIGHTINGS) >= 5
+    view.controls._effect.setCurrentIndex(2)   # Glass
+    assert view.gl.effect == 2
+    view.controls._light.setCurrentIndex(3)    # a different matcap
+    assert view.gl.matcap_name == LIGHTINGS[3]
+
+
+def test_threshold_sliders_cannot_invert(qapp) -> None:
+    """Regression: lo dragged above hi used to paint the whole box black."""
+    view = Nifti3DView()
+    c = view.controls
+    c._hi.setValue(300)
+    c._lo.setValue(900)                        # shove lo past hi
+    # The coupling keeps hi strictly above lo, so the shader window is valid.
+    assert view.gl.thresh_hi > view.gl.thresh_lo
+    assert c._hi.value() > c._lo.value()
+
+
+def test_clip_controls_drive_gl(qapp) -> None:
+    """MRIcroGL-style oblique clip: enable + azimuth/elevation/depth/thick."""
+    view = Nifti3DView()
+    c = view.controls
+    assert view.gl.clip_active == 0
+    assert not c._az.isEnabled()               # az/el/depth/thick off until enabled
+    c._clip_enable.setChecked(True)
+    assert view.gl.clip_active == 1
+    assert c._az.isEnabled() and c._el.isEnabled()
+    # Elevation 90° -> axial normal (0,0,1); az=0 el=0 -> coronal (0,1,0).
+    c._el.setValue(90)
+    assert view.gl.clip_normal[2] > 0.99
+    c._el.setValue(0); c._az.setValue(0)
+    assert abs(view.gl.clip_normal[1] - 1.0) < 1e-3
+    c._clip_enable.setChecked(False)
+    assert view.gl.clip_active == 0
+    assert not c._az.isEnabled()
+
+
+def test_volume_retained_for_context_loss(qapp) -> None:
+    """Regression: detach/re-attach recreates the GL context; the widget must
+    keep the volume so ``initializeGL`` can re-upload it (else 3-D goes blank).
+    """
+    w = RaycastGLWidget()
+    vol = np.random.default_rng(0).random((8, 8, 8), dtype=np.float32)
+    w.set_volume_float(vol, (1.0, 1.0, 1.0))
+    assert w._volume is not None            # retained, not consumed on upload
+    assert w.has_volume() is True
+
+
+def test_pan_moves_target(qapp) -> None:
+    from PyQt6.QtCore import QPoint, QPointF, Qt
+    from PyQt6.QtGui import QMouseEvent
+
+    w = RaycastGLWidget()
+    t0 = w._target.copy()
+    press = QMouseEvent(
+        QMouseEvent.Type.MouseButtonPress, QPointF(0, 0), QPointF(0, 0),
+        Qt.MouseButton.RightButton, Qt.MouseButton.RightButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    w.mousePressEvent(press)
+    assert w._drag == "pan"
+    move = QMouseEvent(
+        QMouseEvent.Type.MouseMove, QPointF(30, 10), QPointF(30, 10),
+        Qt.MouseButton.RightButton, Qt.MouseButton.RightButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    w.mouseMoveEvent(move)
+    assert not np.allclose(w._target, t0)      # pan shifted the camera target
+    w.reset_view()
+    assert np.allclose(w._target, 0.0)         # reset recentres it
+
+
+def test_refresh_and_reset_params(qapp) -> None:
+    view = Nifti3DView()
+    c = view.controls
+    c._effect.setCurrentIndex(2)
+    c._bright.setValue(260)
+    c._clip_enable.setChecked(True)
+    assert view.gl.effect == 2 and view.gl.clip_active == 1
+    c.reset_params()
+    assert view.gl.effect == 0
+    assert view.gl.clip_active == 0
+    assert c._bright.value() == 140
+    view.gl.refresh()                          # no-op without a live context, must not raise
+
+
+def test_drag_right_increases_azimuth(qapp) -> None:
+    """Regression: left-right drag was inverted."""
+    from PyQt6.QtCore import QPoint, QPointF, Qt
+    from PyQt6.QtGui import QMouseEvent
+
+    w = RaycastGLWidget()
+    az0 = w._az
+    w._last = QPoint(0, 0)
+    ev = QMouseEvent(
+        QMouseEvent.Type.MouseMove, QPointF(10, 0), QPointF(10, 0),
+        Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    w.mouseMoveEvent(ev)
+    assert w._az > az0
+
+
+# ---------------------------------------------------------------------------
+# Ortho 3D (3 planes + render) combined mode
+# ---------------------------------------------------------------------------
+
+
+def test_ortho3d_enabled_for_3d(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._quad_btn.isEnabled() is True
+
+
+def test_ortho3d_toggle_shows_grid_and_keeps_slice_controls(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+
+    pane._quad_btn.click()
+    qapp.processEvents()
+    assert pane._combo_view is True
+    assert pane._combo_page_index is not None
+    assert pane._image_stack.currentIndex() == pane._combo_page_index
+    # The render got the volume, and all three slice panels exist.
+    assert pane._combo_gl.has_volume() is True
+    assert pane._combo_controls is not None
+    assert len(pane._combo_labels) == 3
+    # Slices are shown, so brightness/contrast/crosshair stay live...
+    assert pane._bright_slider.isEnabled()
+    assert pane._crosshair_swatch.isEnabled()
+    # ...but the single-pane-only controls do not.
+    assert not pane._sa_btn.isEnabled()
+    assert not pane._slice_slider.isEnabled()
+
+
+def test_three_3d_modes_mutually_exclusive(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+
+    pane._quad_btn.click(); qapp.processEvents()
+    assert pane._combo_view and not pane._three_d and not pane._tri_view
+
+    pane._td_btn.click(); qapp.processEvents()
+    assert pane._three_d and not pane._combo_view
+
+    pane._tri_btn.click(); qapp.processEvents()
+    assert pane._tri_view and not pane._three_d and not pane._combo_view
+
+    pane._tri_btn.click(); qapp.processEvents()
+    assert not (pane._tri_view or pane._three_d or pane._combo_view)
+    assert pane._image_stack.currentIndex() == 0

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -258,18 +258,64 @@ def test_clip_controls_drive_gl(qapp) -> None:
     view = Nifti3DView()
     c = view.controls
     assert view.gl.clip_active == 0
-    assert not c._az.isEnabled()               # az/el/depth/thick off until enabled
-    c._clip_enable.setChecked(True)
+    assert not c._caz.isEnabled()              # az/el/depth/thick off until enabled
+    c._clip_en.setChecked(True)
     assert view.gl.clip_active == 1
-    assert c._az.isEnabled() and c._el.isEnabled()
+    assert c._caz.isEnabled() and c._cel.isEnabled()
     # Elevation 90° -> axial normal (0,0,1); az=0 el=0 -> coronal (0,1,0).
-    c._el.setValue(90)
+    c._cel.setValue(90)
     assert view.gl.clip_normal[2] > 0.99
-    c._el.setValue(0); c._az.setValue(0)
+    c._cel.setValue(0); c._caz.setValue(0)
     assert abs(view.gl.clip_normal[1] - 1.0) < 1e-3
-    c._clip_enable.setChecked(False)
+    c._clip_en.setChecked(False)
     assert view.gl.clip_active == 0
-    assert not c._az.isEnabled()
+    assert not c._caz.isEnabled()
+
+
+def test_effect_param_graying(qapp) -> None:
+    """Per-effect the panel shows only the relevant parameter rows."""
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS
+
+    view = Nifti3DView()
+    c = view.controls
+    c._effect.setCurrentIndex(EFFECTS.index("Glass"))
+    assert c._rows["brighten"].isHidden()      # Glass: no matcap brightness
+    assert not c._rows["specular"].isHidden()  # Glass: Phong specular shown
+    c._effect.setCurrentIndex(EFFECTS.index("MIP"))
+    assert c._rows["density"].isHidden()        # MIP: nothing but window + quality
+    c._effect.setCurrentIndex(EFFECTS.index("Opacity peeling"))
+    assert not c._rows["peel"].isHidden()       # peeling: peel layers shown
+
+
+def test_slice_overlay_per_effect_default(qapp) -> None:
+    """The cut-face intensity slice defaults on for surface effects only."""
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, SLICE_DEFAULT_ON
+
+    view = Nifti3DView()
+    c = view.controls
+    for name in SLICE_DEFAULT_ON:                 # Default / Matte / Topography
+        c._effect.setCurrentIndex(EFFECTS.index(name))
+        assert view.gl.slice_overlay == 1
+        assert not c._rows["overlaydepth"].isHidden()
+    for name in ("Glass", "Shell", "Opacity peeling", "MIP"):
+        c._effect.setCurrentIndex(EFFECTS.index(name))
+        assert view.gl.slice_overlay == 0
+        assert c._rows["overlaydepth"].isHidden()
+    c._effect.setCurrentIndex(0)
+    c._odepth.setValue(70)                        # overlay-depth slider drives gl
+    assert abs(view.gl.slice_depth - 0.70) < 1e-6
+
+
+def test_gpu_available_and_cube(qapp) -> None:
+    from bidsmgr.gui.widgets import nifti_gl_view as M
+
+    # Probe returns a bool and is cached; cube geometry/atlas build.
+    assert isinstance(M.gpu_available(), bool)
+    assert M._cube_geometry().shape == (36, 8)
+    view = Nifti3DView()
+    assert view.gl._show_cube is True
+    view.set_show_cube(False)
+    assert view.gl._show_cube is False
 
 
 def test_volume_retained_for_context_loss(qapp) -> None:
@@ -312,12 +358,13 @@ def test_refresh_and_reset_params(qapp) -> None:
     c = view.controls
     c._effect.setCurrentIndex(2)
     c._bright.setValue(260)
-    c._clip_enable.setChecked(True)
+    c._clip_en.setChecked(True)
     assert view.gl.effect == 2 and view.gl.clip_active == 1
     c.reset_params()
+    from bidsmgr.gui.widgets.nifti_gl_view import DEFAULTS
     assert view.gl.effect == 0
     assert view.gl.clip_active == 0
-    assert c._bright.value() == 140
+    assert c._bright.value() == DEFAULTS["brighten"]
     view.gl.refresh()                          # no-op without a live context, must not raise
 
 

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -578,31 +578,45 @@ def test_effect_params_are_independent(qapp) -> None:
     assert c._den.value() == EFFECT_PRESET["Skull"]["density"]
 
 
-def test_juicy_shiny_effect(qapp) -> None:
-    """Juicy shiny is a Standard (flat Phong) preset placed after Matte, and
-    Jelly / Skull sit after X-ray."""
+def test_juicy_shiny_effects(qapp) -> None:
+    """Juicy shiny / Juicy shiny 2 are Standard (flat Phong) presets placed
+    after Matte, and Jelly / Skull sit after X-ray."""
     from bidsmgr.gui.widgets.nifti_gl_view import (
         EFFECTS, EFFECT_FX, EFFECT_PRESET, SLICE_DEFAULT_ON,
     )
 
     assert EFFECTS.index("Juicy shiny") == EFFECTS.index("Matte") + 1
+    assert EFFECTS.index("Juicy shiny 2") == EFFECTS.index("Juicy shiny") + 1
     assert EFFECTS.index("Jelly") == EFFECTS.index("X-ray") + 1
     assert EFFECTS.index("Skull") == EFFECTS.index("Jelly") + 1
-    assert EFFECT_FX["Juicy shiny"] == EFFECT_FX["Standard"]
-    assert "Juicy shiny" in SLICE_DEFAULT_ON
 
     view = Nifti3DView()
     c = view.controls
-    c._effect.setCurrentText("Juicy shiny")
-    preset = EFFECT_PRESET["Juicy shiny"]
-    assert c._lo.value() == preset["lo"]
-    assert c._hi.value() == preset["hi"]
-    assert c._den.value() == preset["density"]
-    assert c._amb.value() == preset["ambient"]
-    assert c._shin.value() == preset["shininess"]
-    assert c._odepth.value() == preset["overlaydepth"]
-    assert view.gl.effect == EFFECT_FX["Juicy shiny"]
-    assert view.gl.slice_overlay == 1               # cut-face slice on
+    for name in ("Juicy shiny", "Juicy shiny 2"):
+        assert EFFECT_FX[name] == EFFECT_FX["Standard"]
+        assert name in SLICE_DEFAULT_ON
+        c._effect.setCurrentText(name)
+        preset = EFFECT_PRESET[name]
+        assert c._lo.value() == preset["lo"]
+        assert c._hi.value() == preset["hi"]
+        assert c._den.value() == preset["density"]
+        assert c._amb.value() == preset["ambient"]
+        assert c._dif.value() == preset["diffuse"]
+        assert c._spec.value() == preset["specular"]
+        assert c._shin.value() == preset["shininess"]
+        assert c._odepth.value() == preset["overlaydepth"]
+        assert view.gl.effect == EFFECT_FX[name]
+        assert view.gl.slice_overlay == 1           # cut-face slice on
+
+    # The two are independent presets, not the same values.
+    assert EFFECT_PRESET["Juicy shiny 2"] != EFFECT_PRESET["Juicy shiny"]
+
+
+def test_render_background_is_black(qapp) -> None:
+    """The GL clear / empty-space colour is pure black, matching the 2-D
+    canvas (#nifti-canvas in theme.qss)."""
+    w = RaycastGLWidget()
+    assert w._bg == (0.0, 0.0, 0.0)
 
 
 def test_drag_right_increases_azimuth(qapp) -> None:

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -401,31 +401,37 @@ def test_pan_moves_target(qapp) -> None:
     assert np.allclose(w._target, 0.0)         # reset recentres it
 
 
-def test_mouse_wheel_zoom_discrete(qapp) -> None:
-    """A mouse wheel zooms one discrete step per notch, whether the platform
-    reports it as angleDelta (classic) or pixelDelta / sub-notch (Linux)."""
+def test_wheel_zoom_and_slice_nav(qapp) -> None:
+    """Vertical wheel zooms; Shift+wheel (or a horizontal scroll — the X11 /
+    macOS remap of Shift+wheel) navigates the slice while the clip is active."""
     from PyQt6.QtCore import QPointF, QPoint, Qt
     from PyQt6.QtGui import QWheelEvent
 
-    def wheel(ay, ax, py, px):   # synthetic events default to a Mouse device
+    def wheel(ay, ax, shift=False):
         return QWheelEvent(
-            QPointF(10, 10), QPointF(10, 10), QPoint(px, py), QPoint(ax, ay),
-            Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier,
+            QPointF(10, 10), QPointF(10, 10), QPoint(0, 0), QPoint(ax, ay),
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.ShiftModifier if shift else Qt.KeyboardModifier.NoModifier,
             Qt.ScrollPhase.NoScrollPhase, False,
         )
 
     w = RaycastGLWidget()
     d0 = w._dist
-    w.wheelEvent(wheel(120, 0, 0, 0))            # classic notch
+    w.wheelEvent(wheel(120, 0))                  # vertical -> zoom one notch
     assert abs(w._dist / d0 - 0.9) < 1e-6
-    # Linux mouse reporting only pixelDelta accumulates to a notch (thresh 50).
-    w = RaycastGLWidget()
+
+    w.clip_active = 1
+    p = w.clip_pos
+    w.wheelEvent(wheel(120, 0, shift=True))      # Shift+vertical -> slice nav
+    assert abs(w.clip_pos - (p + 0.02)) < 1e-6
+    p = w.clip_pos
+    w.wheelEvent(wheel(0, 120))                  # horizontal (Shift remap) -> slice nav
+    assert abs(w.clip_pos - (p + 0.02)) < 1e-6
+
+    w.clip_active = 0                            # horizontal without clip -> zoom
     d0 = w._dist
-    for _ in range(3):
-        w.wheelEvent(wheel(0, 0, 15, 0))         # 45 < 50 -> no step yet
-    assert w._dist == d0
-    w.wheelEvent(wheel(0, 0, 15, 0))             # 60 -> one step
-    assert abs(w._dist / d0 - 0.9) < 1e-6
+    w.wheelEvent(wheel(0, 120))
+    assert w._dist != d0
 
 
 def test_reset_params_current_effect_only(qapp) -> None:

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -401,6 +401,33 @@ def test_pan_moves_target(qapp) -> None:
     assert np.allclose(w._target, 0.0)         # reset recentres it
 
 
+def test_mouse_wheel_zoom_discrete(qapp) -> None:
+    """A mouse wheel zooms one discrete step per notch, whether the platform
+    reports it as angleDelta (classic) or pixelDelta / sub-notch (Linux)."""
+    from PyQt6.QtCore import QPointF, QPoint, Qt
+    from PyQt6.QtGui import QWheelEvent
+
+    def wheel(ay, ax, py, px):   # synthetic events default to a Mouse device
+        return QWheelEvent(
+            QPointF(10, 10), QPointF(10, 10), QPoint(px, py), QPoint(ax, ay),
+            Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier,
+            Qt.ScrollPhase.NoScrollPhase, False,
+        )
+
+    w = RaycastGLWidget()
+    d0 = w._dist
+    w.wheelEvent(wheel(120, 0, 0, 0))            # classic notch
+    assert abs(w._dist / d0 - 0.9) < 1e-6
+    # Linux mouse reporting only pixelDelta accumulates to a notch (thresh 50).
+    w = RaycastGLWidget()
+    d0 = w._dist
+    for _ in range(3):
+        w.wheelEvent(wheel(0, 0, 15, 0))         # 45 < 50 -> no step yet
+    assert w._dist == d0
+    w.wheelEvent(wheel(0, 0, 15, 0))             # 60 -> one step
+    assert abs(w._dist / d0 - 0.9) < 1e-6
+
+
 def test_reset_params_current_effect_only(qapp) -> None:
     """Reset parameters resets ONLY the current effect's params; the effect,
     clip and unrelated params are left alone."""

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -674,6 +674,34 @@ def test_render_background_is_black(qapp) -> None:
     assert w._bg == (0.0, 0.0, 0.0)
 
 
+def test_controls_column_is_opaque(qapp, isolated_settings) -> None:
+    """Regression: the black image canvas showed through the 3-D controls
+    scroll gutter as a stripe. Every layer of that column must be nameable by
+    the stylesheet so it paints the panel colour."""
+    from bidsmgr.gui.widgets.nifti_gl_view import Nifti3DControls, RaycastGLWidget
+
+    # The panel used to borrow "sidecar-toolbar" — a QFrame rule that never
+    # matched this QWidget, so it painted nothing.
+    controls = Nifti3DControls(RaycastGLWidget())
+    assert controls.objectName() == "nifti-3d-controls"
+
+    pane = NiftiViewerPane()
+    if not pane._gpu_ok:
+        return                                    # 3-D pages are not built
+    pane._ensure_gl()
+    assert pane._gl_controls_scroll.objectName() == "nifti-ctrl-scroll"
+    # The viewport can't be selected from a stylesheet, so it is named here.
+    assert pane._gl_controls_scroll.viewport().objectName() == "nifti-ctrl-viewport"
+    assert pane._ctrl_slot_3d.objectName() == "nifti-ctrl-slot"
+    assert pane._ctrl_slot_combo.objectName() == "nifti-ctrl-slot"
+
+    qss = (Path(__file__).resolve().parents[2]
+           / "bidsmgr" / "gui" / "theme.qss").read_text()
+    for name in ("nifti-ctrl-slot", "nifti-ctrl-scroll",
+                 "nifti-ctrl-viewport", "nifti-3d-controls"):
+        assert f"#{name}" in qss, f"{name} has no stylesheet rule"
+
+
 def test_drag_right_increases_azimuth(qapp) -> None:
     """Regression: left-right drag was inverted."""
     from PyQt6.QtCore import QPoint, QPointF, Qt

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -178,6 +178,35 @@ def test_ras_and_radiological_drive_shared_render(
     assert pane._display_labels(_AXIS_AXIAL)["left"] == "R"  # labels swap too
 
 
+def test_first_scan_opens_in_default_view(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    """The first volume of a session opens in Multi-Planar 3D with a GPU (plain
+    Multi-Planar without one); later scans keep whatever view the user is in."""
+    pane = NiftiViewerPane()
+    pane._gpu_ok = True
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._combo_view is True                 # landed in Multi-Planar 3D
+
+    # The user picks a different view; a later scan must not override it.
+    pane._set_view_mode("single")
+    qapp.processEvents()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._combo_view is False
+    assert pane._tri_view is False                  # user's choice persisted
+
+
+def test_first_scan_default_view_without_gpu(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    """Without a GPU the default is the 2-D three-plane Multi-Planar view."""
+    pane = NiftiViewerPane()
+    pane._gpu_ok = False
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    assert pane._tri_view is True
+    assert pane._combo_view is False
+
+
 def test_3d_and_multiview_mutually_exclusive(
     qapp, qtbot, bids_root_with_nifti, isolated_settings,
 ) -> None:
@@ -612,6 +641,32 @@ def test_juicy_shiny_effects(qapp) -> None:
     assert EFFECT_PRESET["Juicy shiny 2"] != EFFECT_PRESET["Juicy shiny"]
 
 
+def test_quality_defaults_to_half(qapp) -> None:
+    """Every effect starts at 50% quality (the user raises it when they want).
+    Quality is a performance knob, so no preset pins it."""
+    from bidsmgr.gui.widgets.nifti_gl_view import (
+        DEFAULTS, EFFECTS, EFFECT_PRESET, QUALITY_MAX,
+    )
+
+    assert DEFAULTS["quality"] == QUALITY_MAX // 2
+    assert not any("quality" in p for p in EFFECT_PRESET.values())
+
+    view = Nifti3DView()
+    c = view.controls
+    for name in EFFECTS:
+        c._effect.setCurrentText(name)
+        assert c._q.value() == DEFAULTS["quality"]
+        assert view.gl.steps == DEFAULTS["quality"]
+
+    # Raising it is per-effect, like every other parameter.
+    c._effect.setCurrentText("Jelly")
+    c._q.setValue(QUALITY_MAX)
+    c._effect.setCurrentText("Skull")
+    assert c._q.value() == DEFAULTS["quality"]
+    c._effect.setCurrentText("Jelly")
+    assert c._q.value() == QUALITY_MAX
+
+
 def test_render_background_is_black(qapp) -> None:
     """The GL clear / empty-space colour is pure black, matching the 2-D
     canvas (#nifti-canvas in theme.qss)."""
@@ -654,6 +709,10 @@ def test_ortho3d_toggle_shows_grid_and_keeps_slice_controls(
 ) -> None:
     pane = NiftiViewerPane()
     _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    # The first scan of a session lands in a GPU-dependent default view; start
+    # from a known state so clicking the toggle below always turns it ON.
+    pane._set_view_mode("single")
+    qapp.processEvents()
 
     pane._quad_btn.click()
     qapp.processEvents()
@@ -677,6 +736,9 @@ def test_three_3d_modes_mutually_exclusive(
 ) -> None:
     pane = NiftiViewerPane()
     _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    # Known starting point — see the session-default view above.
+    pane._set_view_mode("single")
+    qapp.processEvents()
 
     pane._quad_btn.click(); qapp.processEvents()
     assert pane._combo_view and not pane._three_d and not pane._tri_view

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -178,6 +178,37 @@ def test_ras_and_radiological_drive_shared_render(
     assert pane._display_labels(_AXIS_AXIAL)["left"] == "R"  # labels swap too
 
 
+def test_colour_fa_is_3d_capable(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings, tmp_path,
+) -> None:
+    """Colour-FA volumes render in 3-D (tinted), like MRIcroGL.
+
+    They used to be excluded: the raycaster only understood a scalar density
+    field. The shader now takes the RGB vector length as the density and the
+    hue as the surface colour.
+    """
+    import nibabel as nib
+
+    rgb = np.zeros((8, 9, 10), dtype=[("R", "u1"), ("G", "u1"), ("B", "u1")])
+    rgb["R"][2:6] = 220
+    rgb["G"][:, 3:7] = 180
+    path = tmp_path / "sub-01_ses-01_colFA.nii.gz"
+    nib.save(nib.Nifti1Image(rgb, np.diag([2.0, 2.0, 2.0, 1.0])), str(path))
+
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, path, tmp_path, qtbot)
+    assert pane._is_rgb is True
+    assert pane._is_3d_capable is True
+    if not pane._gpu_ok:
+        return
+    assert pane._td_btn.isEnabled() is True
+
+    pane._td_btn.click()
+    qapp.processEvents()
+    assert pane._gl.has_volume() is True
+    assert pane._gl.is_rgb_volume() is True      # uploaded as colour
+
+
 def test_first_scan_opens_in_default_view(
     qapp, qtbot, bids_root_with_nifti, isolated_settings,
 ) -> None:
@@ -665,6 +696,48 @@ def test_quality_defaults_to_half(qapp) -> None:
     assert c._q.value() == DEFAULTS["quality"]
     c._effect.setCurrentText("Jelly")
     assert c._q.value() == QUALITY_MAX
+
+
+def test_rgb_volume_upload(qapp) -> None:
+    """Colour volumes (colour-FA) upload as colour, not as a scalar field."""
+    w = RaycastGLWidget()
+    assert w.is_rgb_volume() is False
+
+    rgb = np.zeros((4, 5, 6, 3), np.uint8)
+    rgb[..., 0] = 200
+    w.set_volume(rgb, (1.0, 1.0, 1.0))
+    assert w.is_rgb_volume() is True
+
+    # RGBA is accepted; alpha is dropped (the shader samples .rgb).
+    rgba = np.zeros((4, 5, 6, 4), np.uint8)
+    w.set_volume(rgba, (1.0, 1.0, 1.0))
+    assert w._volume[0].shape == (4, 5, 6, 3)
+
+    # A scalar volume still takes the scalar path.
+    w.set_volume(np.zeros((4, 5, 6), np.uint8), (1.0, 1.0, 1.0))
+    assert w.is_rgb_volume() is False
+
+    for bad in (np.zeros((4, 5, 6, 2), np.uint8), np.zeros((4, 5), np.uint8)):
+        with pytest.raises(ValueError):
+            w.set_volume(bad, (1.0, 1.0, 1.0))
+
+
+def test_rgb_volume_float_keeps_hue(qapp) -> None:
+    """Colour channels share ONE window, so per-voxel hue survives.
+
+    Windowing each channel separately would recolour the data — a colour-FA
+    map's direction encoding (red = L-R, green = A-P, blue = S-I) would be lost.
+    """
+    w = RaycastGLWidget()
+    vol = np.zeros((2, 2, 2, 3), np.float32)
+    vol[..., 0] = 1.0        # red at full
+    vol[..., 1] = 0.5        # green at half
+    w.set_volume_float(vol, (1.0, 1.0, 1.0))
+    stored = w._volume[0]
+    assert stored.shape == (2, 2, 2, 3)
+    assert stored[..., 0].max() == 255
+    assert abs(int(stored[..., 1].max()) - 128) <= 1     # ratio preserved
+    assert stored[..., 2].max() == 0
 
 
 def test_render_background_is_black(qapp) -> None:

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -740,6 +740,37 @@ def test_rgb_volume_float_keeps_hue(qapp) -> None:
     assert stored[..., 2].max() == 0
 
 
+def test_realistic_effect(qapp) -> None:
+    """Realistic is a living-tissue variant of Juicy shiny 2, sitting after it
+    and driven by its own shader branch (not the flat-Phong one)."""
+    from bidsmgr.gui.widgets.nifti_gl_view import (
+        EFFECTS, EFFECT_FX, EFFECT_PRESET, SLICE_DEFAULT_ON,
+    )
+
+    assert EFFECTS.index("Realistic") == EFFECTS.index("Juicy shiny 2") + 1
+    assert "Realistic" in SLICE_DEFAULT_ON
+    # Its own shader branch — the tissue colour ramp can't live in Standard's.
+    assert EFFECT_FX["Realistic"] not in (
+        EFFECT_FX["Standard"], EFFECT_FX["Matte"],
+    )
+
+    preset, parent = EFFECT_PRESET["Realistic"], EFFECT_PRESET["Juicy shiny 2"]
+    # Inherits the window / density from its parent...
+    for key in ("lo", "hi", "density", "overlaydepth"):
+        assert preset[key] == parent[key]
+    # ...but leans on directional light instead of ambient, or a coloured
+    # surface flattens into a featureless pink card.
+    assert preset["ambient"] < parent["ambient"]
+    assert preset["diffuse"] > parent["diffuse"]
+
+    view = Nifti3DView()
+    c = view.controls
+    c._effect.setCurrentText("Realistic")
+    assert view.gl.effect == EFFECT_FX["Realistic"]
+    assert c._amb.value() == preset["ambient"]
+    assert view.gl.slice_overlay == 1
+
+
 def test_render_background_is_black(qapp) -> None:
     """The GL clear / empty-space colour is pure black, matching the 2-D
     canvas (#nifti-canvas in theme.qss)."""

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -20,7 +20,11 @@ nib = pytest.importorskip("nibabel")
 pytest.importorskip("OpenGL")
 
 from bidsmgr.gui.widgets.nifti_viewer_pane import NiftiViewerPane
-from bidsmgr.gui.widgets.nifti_gl_view import Nifti3DView, request_gl_format
+from bidsmgr.gui.widgets.nifti_gl_view import (
+    Nifti3DView,
+    RaycastGLWidget,
+    request_gl_format,
+)
 
 
 pytestmark = pytest.mark.gui
@@ -142,6 +146,36 @@ def test_3d_toggle_feeds_volume_to_gl_view(
     assert pane._gl is not None
     # Volume was handed to the GL widget (stashed as pending until first paint).
     assert pane._gl.has_volume() is True
+
+
+def test_ras_and_radiological_drive_shared_render(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    """The RAS and Radiological toggles fold into one display flip that reaches
+    both the 2-D labels and the shared 3-D render."""
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    from bidsmgr.gui.widgets.nifti_viewer_pane import _AXIS_AXIAL
+    assert pane._ras_btn.isChecked() is True
+    assert pane._radio_btn.isChecked() is False
+
+    # The 3-D flip carries a constant extra L/R mirror vs the 2-D flip so the
+    # rendered volume's left/right lines up with the 2-D slices.
+    def _aligned():
+        d = pane._display_flip()
+        assert pane._gl_flip() == (-d[0], d[1], d[2])
+        assert np.allclose(pane._gl._flip, pane._gl_flip())
+    _aligned()
+    assert pane._display_labels(0)["left"] == "P"          # sagittal unaffected
+    assert pane._display_labels(_AXIS_AXIAL)["left"] == "L"  # neurological
+
+    pane._radio_btn.setChecked(True)
+    qapp.processEvents()
+    _aligned()                                              # still aligned
+    assert pane._display_flip()[0] == -1.0                  # 2-D mirrored L/R
+    assert pane._display_labels(_AXIS_AXIAL)["left"] == "R"  # labels swap too
 
 
 def test_3d_and_multiview_mutually_exclusive(
@@ -432,6 +466,62 @@ def test_wheel_zoom_and_slice_nav(qapp) -> None:
     d0 = w._dist
     w.wheelEvent(wheel(0, 120))
     assert w._dist != d0
+
+
+def test_render_flip_and_cube_atlas(qapp) -> None:
+    """set_flip mirrors the render along canonical axes, and the orientation
+    cube swaps its letters (not its geometry) to match."""
+    from bidsmgr.gui.widgets.nifti_gl_view import _make_cube_atlas
+
+    w = RaycastGLWidget()
+    assert np.allclose(w._flip, [1.0, 1.0, 1.0])   # neurological RAS default
+
+    w.set_flip(-1, 1, 1)
+    assert np.allclose(w._flip, [-1.0, 1.0, 1.0])
+    w.set_flip(1, -1, -1)
+    assert np.allclose(w._flip, [1.0, -1.0, -1.0])
+
+    # Flipping an axis swaps that axis's letter pair in the atlas (L<->R here),
+    # so a mirrored render still reads upright.
+    a0 = _make_cube_atlas(16, (1.0, 1.0, 1.0))
+    a1 = _make_cube_atlas(16, (-1.0, 1.0, 1.0))
+    assert a0.shape == a1.shape
+    assert not np.array_equal(a0, a1)
+
+
+def test_native_flip_from_affine(qapp) -> None:
+    """The native storage flip is (1,1,1) for RAS and flags reversed axes."""
+    from bidsmgr.gui.widgets.nifti_viewer_pane import _native_flip_from_affine
+
+    assert _native_flip_from_affine(np.diag([2, 2, 2, 1.0])) == (1.0, 1.0, 1.0)
+    # LAS: L increases along +i -> the R/L axis is stored reversed.
+    assert _native_flip_from_affine(np.diag([-2, 2, 2, 1.0])) == (-1.0, 1.0, 1.0)
+    # RAI: S/I reversed.
+    assert _native_flip_from_affine(np.diag([2, 2, -2, 1.0])) == (1.0, 1.0, -1.0)
+
+
+def test_show_values_reflects_slider(qapp) -> None:
+    """The 'Show values' option appends each slider's live value to its label,
+    and updates when a preset changes the sliders."""
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECT_PRESET
+
+    view = Nifti3DView()
+    c = view.controls
+    chips = {base: chip for (_s, chip, base) in c._value_rows}
+    sliders = {base: s for (s, _c, base) in c._value_rows}
+
+    # Off: labels are the plain base text.
+    assert chips["Threshold low"].text() == "Threshold low"
+
+    c._values_en.setChecked(True)
+    assert chips["Threshold low"].text().endswith(str(sliders["Threshold low"].value()))
+
+    # A preset moves sliders; the label tracks the new value live.
+    c._effect.setCurrentText("Jelly")
+    assert chips["Density"].text().endswith(str(EFFECT_PRESET["Jelly"]["density"]))
+
+    c._values_en.setChecked(False)
+    assert chips["Density"].text() == "Density"
 
 
 def test_reset_params_current_effect_only(qapp) -> None:

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -527,7 +527,7 @@ def test_show_values_reflects_slider(qapp) -> None:
 def test_reset_params_current_effect_only(qapp) -> None:
     """Reset parameters resets ONLY the current effect's params; the effect,
     clip and unrelated params are left alone."""
-    from bidsmgr.gui.widgets.nifti_gl_view import DEFAULTS, EFFECTS
+    from bidsmgr.gui.widgets.nifti_gl_view import DEFAULTS, EFFECTS, EFFECT_FX
 
     view = Nifti3DView()
     c = view.controls
@@ -536,11 +536,73 @@ def test_reset_params_current_effect_only(qapp) -> None:
     c._spec.setValue(95)          # a Glass parameter
     c._bright.setValue(260)       # NOT a Glass parameter
     c.reset_params()
-    assert view.gl.effect == EFFECTS.index("Glass")   # effect unchanged
+    assert view.gl.effect == EFFECT_FX["Glass"]        # effect unchanged
     assert view.gl.clip_active == 1                    # clip left as-is
     assert c._spec.value() == DEFAULTS["specular"]     # Glass param reset
     assert c._bright.value() == 260                    # unrelated param untouched
     view.gl.refresh()             # no-op without a live context, must not raise
+
+
+def test_effect_params_are_independent(qapp) -> None:
+    """Each effect owns its parameters: tweaking one never leaks into another,
+    and switching back restores what was left behind."""
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECT_PRESET
+
+    view = Nifti3DView()
+    c = view.controls
+
+    c._effect.setCurrentText("Jelly")
+    assert c._den.value() == EFFECT_PRESET["Jelly"]["density"]   # starts at preset
+    c._den.setValue(88)                                          # tweak Jelly
+
+    c._effect.setCurrentText("Skull")
+    # Skull starts from ITS preset, not Jelly's edited value.
+    assert c._den.value() == EFFECT_PRESET["Skull"]["density"]
+    c._den.setValue(11)                                          # tweak Skull
+
+    c._effect.setCurrentText("Jelly")
+    assert c._den.value() == 88                                  # Jelly remembered
+    c._effect.setCurrentText("Skull")
+    assert c._den.value() == 11                                  # Skull remembered
+
+    # Resetting one effect leaves the others' values alone.
+    c.reset_params()
+    assert c._den.value() == EFFECT_PRESET["Skull"]["density"]
+    c._effect.setCurrentText("Jelly")
+    assert c._den.value() == 88
+
+    # Reset-all clears every effect back to its baseline.
+    c.reset_all_params()
+    assert c._den.value() == EFFECT_PRESET["Jelly"]["density"]
+    c._effect.setCurrentText("Skull")
+    assert c._den.value() == EFFECT_PRESET["Skull"]["density"]
+
+
+def test_juicy_shiny_effect(qapp) -> None:
+    """Juicy shiny is a Standard (flat Phong) preset placed after Matte, and
+    Jelly / Skull sit after X-ray."""
+    from bidsmgr.gui.widgets.nifti_gl_view import (
+        EFFECTS, EFFECT_FX, EFFECT_PRESET, SLICE_DEFAULT_ON,
+    )
+
+    assert EFFECTS.index("Juicy shiny") == EFFECTS.index("Matte") + 1
+    assert EFFECTS.index("Jelly") == EFFECTS.index("X-ray") + 1
+    assert EFFECTS.index("Skull") == EFFECTS.index("Jelly") + 1
+    assert EFFECT_FX["Juicy shiny"] == EFFECT_FX["Standard"]
+    assert "Juicy shiny" in SLICE_DEFAULT_ON
+
+    view = Nifti3DView()
+    c = view.controls
+    c._effect.setCurrentText("Juicy shiny")
+    preset = EFFECT_PRESET["Juicy shiny"]
+    assert c._lo.value() == preset["lo"]
+    assert c._hi.value() == preset["hi"]
+    assert c._den.value() == preset["density"]
+    assert c._amb.value() == preset["ambient"]
+    assert c._shin.value() == preset["shininess"]
+    assert c._odepth.value() == preset["overlaydepth"]
+    assert view.gl.effect == EFFECT_FX["Juicy shiny"]
+    assert view.gl.slice_overlay == 1               # cut-face slice on
 
 
 def test_drag_right_increases_azimuth(qapp) -> None:

--- a/tests/gui/test_nifti_3d_view.py
+++ b/tests/gui/test_nifti_3d_view.py
@@ -139,9 +139,9 @@ def test_3d_toggle_feeds_volume_to_gl_view(
     _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
     pane._td_btn.click()
     qapp.processEvents()
-    assert pane._gl_view is not None
+    assert pane._gl is not None
     # Volume was handed to the GL widget (stashed as pending until first paint).
-    assert pane._gl_view.gl.has_volume() is True
+    assert pane._gl.has_volume() is True
 
 
 def test_3d_and_multiview_mutually_exclusive(
@@ -179,7 +179,7 @@ def test_volume_slider_repushes_in_3d(
     # Moving the volume slider should not raise and keeps a volume bound.
     pane._vol_slider.setValue(2)
     qapp.processEvents()
-    assert pane._gl_view.gl.has_volume() is True
+    assert pane._gl.has_volume() is True
 
 
 def test_set_file_none_clears_3d(
@@ -222,24 +222,40 @@ def test_orientation_shortcut_exits_3d(
 
 
 def test_nifti3dview_normalises_and_binds(qapp) -> None:
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, EFFECT_FX
+
     view = Nifti3DView()
     vol = np.linspace(0, 1000, 8 * 8 * 8, dtype=np.float32).reshape(8, 8, 8)
     view.set_volume(vol, (1.0, 1.0, 1.0))
     assert view.gl.has_volume() is True
-    # Effect combo drives the GL widget's effect field.
-    view.controls._effect.setCurrentIndex(1)   # MIP
-    assert view.gl.effect == 1
+    # The effect combo maps its label to the shader effect index.
+    view.controls._effect.setCurrentIndex(EFFECTS.index("MIP"))
+    assert view.gl.effect == EFFECT_FX["MIP"]
 
 
 def test_effect_and_lighting_selectors(qapp) -> None:
-    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, LIGHTINGS
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, EFFECT_FX, LIGHTINGS
 
     view = Nifti3DView()
     assert len(EFFECTS) >= 5 and len(LIGHTINGS) >= 5
-    view.controls._effect.setCurrentIndex(2)   # Glass
-    assert view.gl.effect == 2
+    view.controls._effect.setCurrentIndex(EFFECTS.index("Glass"))
+    assert view.gl.effect == EFFECT_FX["Glass"]
     view.controls._light.setCurrentIndex(3)    # a different matcap
     assert view.gl.matcap_name == LIGHTINGS[3]
+
+
+def test_preset_effects_apply(qapp) -> None:
+    """Jelly / Skull are Opacity-peeling presets that apply parameter values."""
+    from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS, EFFECT_FX, EFFECT_PRESET
+
+    view = Nifti3DView()
+    c = view.controls
+    for name in ("Jelly", "Skull"):
+        c._effect.setCurrentIndex(EFFECTS.index(name))
+        assert view.gl.effect == EFFECT_FX[name]          # underlying shader fx
+        preset = EFFECT_PRESET[name]
+        assert c._den.value() == preset["density"]        # preset value applied
+        assert abs(view.gl.density - preset["density"] / 100.0) < 1e-6
 
 
 def test_threshold_sliders_cannot_invert(qapp) -> None:
@@ -272,6 +288,38 @@ def test_clip_controls_drive_gl(qapp) -> None:
     assert not c._caz.isEnabled()
 
 
+def test_slicer_shortcuts(
+    qapp, qtbot, bids_root_with_nifti, isolated_settings,
+) -> None:
+    """Shift+Y/A/S/C/X drive the clip plane and stay in sync with the panel."""
+    pane = NiftiViewerPane()
+    _load_and_wait(pane, _t1(bids_root_with_nifti), bids_root_with_nifti, qtbot)
+    pane._td_btn.click()
+    qapp.processEvents()
+    gl, c = pane._gl, pane._gl_controls
+
+    pane._kbd_toggle_slicer()                       # Shift+Y
+    assert gl.clip_active == 1 and c._clip_en.isChecked()
+    pane._kbd_clip_axial()                          # Shift+A -> normal ~Z
+    assert abs(gl.clip_normal[2]) > 0.99
+    assert c._caz.value() == 0 and c._cel.value() == 90
+    pane._kbd_clip_sagittal()                       # Shift+S -> normal ~X
+    assert abs(gl.clip_normal[0]) > 0.99
+    pane._kbd_clip_coronal()                        # Shift+C -> normal ~Y
+    assert abs(gl.clip_normal[1]) > 0.99
+    n = gl.clip_normal
+    pane._kbd_clip_invert()                         # Shift+X -> flip
+    assert gl.clip_flip
+    assert all(abs(gl.clip_normal[i] + n[i]) < 1e-5 for i in range(3))
+    # Shift+drag / Shift+scroll equivalents mirror into the sliders.
+    gl.drag_clip_azel(20, -5)
+    assert c._caz.value() == int(round(gl.clip_az))
+    gl.nudge_clip_pos(0.05)
+    assert c._cdepth.value() == int(round(gl.clip_pos * 1000))
+    pane._kbd_toggle_slicer()                       # Shift+Y off
+    assert gl.clip_active == 0
+
+
 def test_effect_param_graying(qapp) -> None:
     """Per-effect the panel shows only the relevant parameter rows."""
     from bidsmgr.gui.widgets.nifti_gl_view import EFFECTS
@@ -293,7 +341,7 @@ def test_slice_overlay_per_effect_default(qapp) -> None:
 
     view = Nifti3DView()
     c = view.controls
-    for name in SLICE_DEFAULT_ON:                 # Default / Matte / Topography
+    for name in SLICE_DEFAULT_ON:                 # Standard / Matte / Topography
         c._effect.setCurrentIndex(EFFECTS.index(name))
         assert view.gl.slice_overlay == 1
         assert not c._rows["overlaydepth"].isHidden()
@@ -353,19 +401,23 @@ def test_pan_moves_target(qapp) -> None:
     assert np.allclose(w._target, 0.0)         # reset recentres it
 
 
-def test_refresh_and_reset_params(qapp) -> None:
+def test_reset_params_current_effect_only(qapp) -> None:
+    """Reset parameters resets ONLY the current effect's params; the effect,
+    clip and unrelated params are left alone."""
+    from bidsmgr.gui.widgets.nifti_gl_view import DEFAULTS, EFFECTS
+
     view = Nifti3DView()
     c = view.controls
-    c._effect.setCurrentIndex(2)
-    c._bright.setValue(260)
+    c._effect.setCurrentIndex(EFFECTS.index("Glass"))
     c._clip_en.setChecked(True)
-    assert view.gl.effect == 2 and view.gl.clip_active == 1
+    c._spec.setValue(95)          # a Glass parameter
+    c._bright.setValue(260)       # NOT a Glass parameter
     c.reset_params()
-    from bidsmgr.gui.widgets.nifti_gl_view import DEFAULTS
-    assert view.gl.effect == 0
-    assert view.gl.clip_active == 0
-    assert c._bright.value() == DEFAULTS["brighten"]
-    view.gl.refresh()                          # no-op without a live context, must not raise
+    assert view.gl.effect == EFFECTS.index("Glass")   # effect unchanged
+    assert view.gl.clip_active == 1                    # clip left as-is
+    assert c._spec.value() == DEFAULTS["specular"]     # Glass param reset
+    assert c._bright.value() == 260                    # unrelated param untouched
+    view.gl.refresh()             # no-op without a live context, must not raise
 
 
 def test_drag_right_increases_azimuth(qapp) -> None:
@@ -410,8 +462,8 @@ def test_ortho3d_toggle_shows_grid_and_keeps_slice_controls(
     assert pane._combo_page_index is not None
     assert pane._image_stack.currentIndex() == pane._combo_page_index
     # The render got the volume, and all three slice panels exist.
-    assert pane._combo_gl.has_volume() is True
-    assert pane._combo_controls is not None
+    assert pane._gl.has_volume() is True
+    assert pane._gl_controls is not None
     assert len(pane._combo_labels) == 3
     # Slices are shown, so brightness/contrast/crosshair stay live...
     assert pane._bright_slider.isEnabled()

--- a/tests/gui/test_nifti_viewer.py
+++ b/tests/gui/test_nifti_viewer.py
@@ -35,18 +35,28 @@ def _load_and_wait(pane, path, root, qtbot=None, timeout_ms: int = 5000):
     for the ``loaded`` signal before inspecting ``_data`` /
     ``_grid_cells`` / etc. Falls back to blocking on the worker
     directly when no qtbot is supplied.
+
+    The first scan of a session opens in a GPU-dependent default view
+    (Multi-Planar 3D with a GPU, Multi-Planar without). This module tests
+    single-pane 2-D behaviour, so the view is normalised back to ``single``
+    afterwards — otherwise every test here would depend on whether the
+    machine running it happens to have a GPU.
     """
     from PyQt6.QtWidgets import QApplication
 
     if qtbot is not None:
         with qtbot.waitSignal(pane.loaded, timeout=timeout_ms):
             pane.set_file(path, root)
+        pane._set_view_mode("single")
+        QApplication.processEvents()
         return
     pane.set_file(path, root)
     worker = pane._loader
     if worker is not None:
         worker.wait(timeout_ms)
     QApplication.processEvents()
+    QApplication.processEvents()
+    pane._set_view_mode("single")
     QApplication.processEvents()
 
 
@@ -97,6 +107,35 @@ def test_load_nifti_returns_array_and_meta(tmp_path: Path) -> None:
     assert data.shape == (2, 3, 4)
     assert not meta.get("is_rgb")
     assert img is not None
+
+
+def test_load_nifti_reads_structured_rgb(tmp_path: Path) -> None:
+    """Regression: colour-FA volumes (record dtype R/G/B) failed to open.
+
+    ``get_fdata()`` can't cast a record dtype to float64; the RGB path used to
+    be reached by matching the resulting exception's class/message, which
+    numpy 2.x changed to a plain TypeError, so these files errored out. The
+    dtype is now inspected up front instead.
+    """
+    import nibabel as nib
+
+    p = tmp_path / "colfa.nii.gz"
+    rgb = np.zeros((4, 5, 6), dtype=[("R", "u1"), ("G", "u1"), ("B", "u1")])
+    rgb["R"][:] = 200
+    rgb["G"][:] = 100
+    # LAS on disk, so the canonical reorientation also has to survive the
+    # structured dtype (colour-FA is commonly stored non-RAS).
+    nib.save(nib.Nifti1Image(rgb, np.diag([-2.0, 2.0, 2.0, 1.0])), str(p))
+
+    img, data, meta = _load_nifti(p)
+    assert meta["is_rgb"] is True
+    assert meta["vector_length"] == 3
+    assert data.shape == (4, 5, 6, 3)
+    assert data.dtype == np.float32
+    assert data[..., 0].max() == 200 and data[..., 1].max() == 100
+    # The structured path must report the storage flip too (LAS -> L/R
+    # reversed), else the RAS toggle would be a no-op for these files.
+    assert meta["native_flip"] == (-1.0, 1.0, 1.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_parallel_backend.py
+++ b/tests/unit/test_parallel_backend.py
@@ -1,0 +1,124 @@
+"""Backend selection / fallback for the joblib pools (bidsmgr.util.parallel).
+
+Regression cover for the Windows + Python 3.14 failure, where loky's worker
+processes die during bootstrap and joblib raises ``TerminatedWorkerError``,
+taking a whole DICOM scan down with them.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from joblib import delayed
+
+from bidsmgr.util import parallel as P
+
+
+def _square(i: int) -> int:
+    return i * i
+
+
+class TestBackendSelection:
+    def test_loky_is_used_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert P.loky_is_broken() is False
+        assert P.preferred_backend() is None       # None == joblib's loky
+
+    def test_windows_py314_avoids_loky(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(sys, "version_info", (3, 14, 0))
+        assert P.loky_is_broken() is True
+        assert P.preferred_backend() == "threading"
+
+    @pytest.mark.parametrize(
+        ("platform", "version"),
+        [("win32", (3, 13, 0)), ("linux", (3, 14, 0)), ("darwin", (3, 14, 0))],
+    )
+    def test_only_the_broken_combination_is_downgraded(
+        self, monkeypatch: pytest.MonkeyPatch, platform: str, version: tuple,
+    ) -> None:
+        """Windows alone or 3.14 alone must keep the fast process backend."""
+        monkeypatch.setattr(sys, "platform", platform)
+        monkeypatch.setattr(sys, "version_info", version)
+        assert P.loky_is_broken() is False
+        assert P.preferred_backend() is None
+
+
+class TestRunParallel:
+    def test_runs_and_collects(self) -> None:
+        out = P.run_parallel(
+            lambda: (delayed(_square)(i) for i in range(6)),
+            n_jobs=2, consume=list,
+        )
+        assert out == [0, 1, 4, 9, 16, 25]
+
+    def test_generator_mode(self) -> None:
+        """return_as="generator" is how the scan polls for cancellation."""
+        out = P.run_parallel(
+            lambda: (delayed(_square)(i) for i in range(4)),
+            n_jobs=2, consume=lambda gen: [x for x in gen],
+            return_as="generator",
+        )
+        assert out == [0, 1, 4, 9]
+
+    def test_dead_pool_retries_on_threads(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from joblib.externals.loky.process_executor import TerminatedWorkerError
+
+        real = P.Parallel
+        seen: list = []
+
+        class FlakyParallel:
+            def __init__(self, n_jobs=1, backend=None, **kw):
+                self.backend, self.kw = backend, kw
+                seen.append(backend)
+
+            def __call__(self, tasks):
+                if self.backend != "threading":
+                    raise TerminatedWorkerError("worker died")
+                return real(n_jobs=1, backend="threading", **self.kw)(tasks)
+
+        monkeypatch.setattr(P, "Parallel", FlakyParallel)
+        out = P.run_parallel(
+            lambda: (delayed(_square)(i) for i in range(4)),
+            n_jobs=2, consume=list,
+        )
+        assert out == [0, 1, 4, 9]
+        assert seen[-1] == "threading"      # fell back
+        assert len(seen) == 2               # tried once, then retried
+
+    def test_task_errors_are_not_swallowed(self) -> None:
+        """Only a dead pool triggers the retry — real failures propagate."""
+        def boom(_i: int) -> None:
+            raise RuntimeError("task failed")
+
+        with pytest.raises(RuntimeError, match="task failed"):
+            P.run_parallel(
+                lambda: (delayed(boom)(i) for i in range(2)),
+                n_jobs=1, consume=list,
+            )
+
+    def test_threading_backend_does_not_retry(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Already on threads, a failure must surface rather than loop."""
+        from joblib.externals.loky.process_executor import TerminatedWorkerError
+
+        calls: list = []
+
+        class AlwaysDead:
+            def __init__(self, n_jobs=1, backend=None, **kw):
+                calls.append(backend)
+
+            def __call__(self, tasks):
+                raise TerminatedWorkerError("worker died")
+
+        monkeypatch.setattr(P, "Parallel", AlwaysDead)
+        with pytest.raises(TerminatedWorkerError):
+            P.run_parallel(
+                lambda: (delayed(_square)(i) for i in range(2)),
+                n_jobs=2, consume=list, backend="threading",
+            )
+        assert calls == ["threading"]

--- a/tests/unit/test_parallel_backend.py
+++ b/tests/unit/test_parallel_backend.py
@@ -2,12 +2,14 @@
 
 Regression cover for the Windows + Python 3.14 failure, where loky's worker
 processes die during bootstrap and joblib raises ``TerminatedWorkerError``,
-taking a whole DICOM scan down with them.
+taking a whole DICOM scan down with it.
+
+The policy under test is *detect, don't predict*: always try the fast process
+backend, and only downgrade to threads once a pool has actually died — then
+remember that for the rest of the session.
 """
 
 from __future__ import annotations
-
-import sys
 
 import pytest
 from joblib import delayed
@@ -19,30 +21,60 @@ def _square(i: int) -> int:
     return i * i
 
 
-class TestBackendSelection:
-    def test_loky_is_used_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sys, "platform", "linux")
-        assert P.loky_is_broken() is False
-        assert P.preferred_backend() is None       # None == joblib's loky
+@pytest.fixture(autouse=True)
+def _clean_backend_state(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with the process backend considered healthy."""
+    monkeypatch.delenv(P.BACKEND_ENV_VAR, raising=False)
+    P.reset_backend_state()
+    yield
+    P.reset_backend_state()
 
-    def test_windows_py314_avoids_loky(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(sys, "platform", "win32")
-        monkeypatch.setattr(sys, "version_info", (3, 14, 0))
-        assert P.loky_is_broken() is True
+
+class _DeadPool:
+    """Stand-in for Parallel whose process pools always die."""
+
+    def __init__(self, seen: list, real):
+        self._seen, self._real = seen, real
+
+    def __call__(self, n_jobs=1, backend=None, **kw):
+        self._seen.append(backend)
+        outer = self
+
+        class _P:
+            def __call__(self, tasks):
+                from joblib.externals.loky.process_executor import (
+                    TerminatedWorkerError,
+                )
+                if backend != P.SAFE_BACKEND:
+                    raise TerminatedWorkerError("worker died")
+                return outer._real(n_jobs=1, backend=P.SAFE_BACKEND, **kw)(tasks)
+
+        return _P()
+
+
+class TestBackendSelection:
+    def test_process_backend_is_the_default_everywhere(self) -> None:
+        """No OS/version guessing — the fast backend is always tried first."""
+        assert P.process_backend_disabled() is False
+        assert P.preferred_backend() is None          # None == joblib's loky
+
+    def test_env_var_can_force_the_safe_backend(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(P.BACKEND_ENV_VAR, "threading")
         assert P.preferred_backend() == "threading"
 
-    @pytest.mark.parametrize(
-        ("platform", "version"),
-        [("win32", (3, 13, 0)), ("linux", (3, 14, 0)), ("darwin", (3, 14, 0))],
-    )
-    def test_only_the_broken_combination_is_downgraded(
-        self, monkeypatch: pytest.MonkeyPatch, platform: str, version: tuple,
+    def test_downgrades_only_after_a_real_failure(
+        self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Windows alone or 3.14 alone must keep the fast process backend."""
-        monkeypatch.setattr(sys, "platform", platform)
-        monkeypatch.setattr(sys, "version_info", version)
-        assert P.loky_is_broken() is False
         assert P.preferred_backend() is None
+        monkeypatch.setattr(P, "Parallel", _DeadPool([], P.Parallel))
+        P.run_parallel(
+            lambda: (delayed(_square)(i) for i in range(3)),
+            n_jobs=2, consume=list,
+        )
+        assert P.process_backend_disabled() is True
+        assert P.preferred_backend() == "threading"
 
 
 class TestRunParallel:
@@ -57,7 +89,7 @@ class TestRunParallel:
         """return_as="generator" is how the scan polls for cancellation."""
         out = P.run_parallel(
             lambda: (delayed(_square)(i) for i in range(4)),
-            n_jobs=2, consume=lambda gen: [x for x in gen],
+            n_jobs=2, consume=lambda gen: list(gen),
             return_as="generator",
         )
         assert out == [0, 1, 4, 9]
@@ -65,29 +97,28 @@ class TestRunParallel:
     def test_dead_pool_retries_on_threads(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from joblib.externals.loky.process_executor import TerminatedWorkerError
-
-        real = P.Parallel
         seen: list = []
-
-        class FlakyParallel:
-            def __init__(self, n_jobs=1, backend=None, **kw):
-                self.backend, self.kw = backend, kw
-                seen.append(backend)
-
-            def __call__(self, tasks):
-                if self.backend != "threading":
-                    raise TerminatedWorkerError("worker died")
-                return real(n_jobs=1, backend="threading", **self.kw)(tasks)
-
-        monkeypatch.setattr(P, "Parallel", FlakyParallel)
+        monkeypatch.setattr(P, "Parallel", _DeadPool(seen, P.Parallel))
         out = P.run_parallel(
             lambda: (delayed(_square)(i) for i in range(4)),
             n_jobs=2, consume=list,
         )
-        assert out == [0, 1, 4, 9]
-        assert seen[-1] == "threading"      # fell back
-        assert len(seen) == 2               # tried once, then retried
+        assert out == [0, 1, 4, 9]                 # complete, not partial
+        assert seen == [None, "threading"]         # tried fast, then fell back
+
+    def test_failure_is_remembered_across_runs(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The dead-pool cost is paid once per session, not once per pool."""
+        seen: list = []
+        monkeypatch.setattr(P, "Parallel", _DeadPool(seen, P.Parallel))
+        for _ in range(3):
+            P.run_parallel(
+                lambda: (delayed(_square)(i) for i in range(2)),
+                n_jobs=2, consume=list,
+            )
+        # First run probes and falls back; later runs go straight to threads.
+        assert seen == [None, "threading", "threading", "threading"]
 
     def test_task_errors_are_not_swallowed(self) -> None:
         """Only a dead pool triggers the retry — real failures propagate."""
@@ -99,6 +130,23 @@ class TestRunParallel:
                 lambda: (delayed(boom)(i) for i in range(2)),
                 n_jobs=1, consume=list,
             )
+        # A failing task must not be mistaken for a broken pool.
+        assert P.process_backend_disabled() is False
+
+    def test_consume_errors_propagate(self) -> None:
+        """Cancellation is raised from consume() and must not be retried."""
+        class Cancelled(Exception):
+            pass
+
+        def cancel(_gen):
+            raise Cancelled("cancelled by user")
+
+        with pytest.raises(Cancelled):
+            P.run_parallel(
+                lambda: (delayed(_square)(i) for i in range(2)),
+                n_jobs=1, consume=cancel,
+            )
+        assert P.process_backend_disabled() is False
 
     def test_threading_backend_does_not_retry(
         self, monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# BIDS Manager: GPU 3-D volume rendering, worker-pool robustness, and rounded-popup fixes (v1.2.4.2 to v1.2.5.1)

## Summary

This PR brings `ANCPLabOldenburg/BIDS-Manager:main` from **v1.2.4.2 up to
v1.2.5.1**. It is purely additive: the source branch
(`karellopez/BIDS-Manager:main`) is a clean content superset of upstream's
current `main` (merge base `feat(gui): round hover tooltips and add an Update
notes card`), so nothing existing is removed or rewritten. Net change across the
19 commits: **14 files, +3,976 / -76 lines**, of which a large share is new
tests (about 1,100 lines).

The headline is a **GPU-accelerated 3-D volume renderer for the NIfTI viewer**,
in the spirit of MRIcroGL, built as a single-pass GLSL ray-caster with **zero new
dependencies**. Alongside it are two robustness fixes that surfaced during the
work: the scanner and converter now **survive a broken parallel worker pool**
(Windows with Python 3.14), and the rounded hover tooltips and pop-up menus no
longer leave a **black corner sliver on Windows and Linux**.

All of it stays inside the original architecture: the BIDS schema is the engine,
the only Qt-coupled subtree is `gui/` (plus the `workers/` thread bridge), and
there is no `Pipeline` orchestrator and no `core/` package.

## Highlights

1. GPU 3-D volume renderer for the Editor's NIfTI viewer: a native single-pass
   GLSL ray-caster in a `QOpenGLWidget` with PyOpenGL. A dozen rendering effects
   and materials, controllable lighting, an oblique clip plane and slicer with a
   cut-face overlay, an orientation cube, shared RAS / radiological orientation
   toggles, and colour-FA (RGB) support. It adds no new dependencies (PyQt6 and
   PyOpenGL already ship) and appears automatically only where the GPU supports
   it.
2. Worker-pool robustness: joblib's default process (loky) backend dies during
   bootstrap on Windows with Python 3.14, taking the whole scan down. A new
   `util/parallel` module detects a dead pool at run time and falls back to
   threads for the rest of the session, instead of trying to predict which
   platforms are affected.
3. Rounded pop-up corners on Windows and Linux: the rounded tooltips and menus no
   longer show a thin black sliver at their corners on uncomposited or
   fractionally-scaled (HiDPI) displays.

## 1. GPU 3-D volume renderer (`bidsmgr/gui/widgets/nifti_gl_view.py`, new)

The Editor's NIfTI viewer already offered fast 2-D single-plane, multi-planar and
4-D time-series views. This PR adds two 3-D modes on top: **3D** (render only) and
**Multi-Planar 3D** (three orthogonal slices plus the render). Both share one GL
canvas and one control column, so switching between them keeps the same effect,
lighting, clip and camera.

Why a native ray-caster (over VTK, niivue-in-QWebEngine, or pyqtgraph): it adds
**zero new dependencies** (PyQt6 and PyOpenGL are already declared), and it can
follow MRIcroGL's shaders closely for a familiar look. Verified on Apple M1 Pro
(OpenGL 4.1 via Metal) and on Windows and Linux.

- **Renderer.** `RaycastGLWidget` uploads the volume as an R8 3-D texture
  (percentile-windowed), does an analytic ray-box intersection and a jittered
  front-to-back march. One fragment shader switches on an effect index. The
  uploaded volume is retained and re-uploaded in `initializeGL`, so the render
  survives GL context loss when a panel is detached and re-attached.
- **A dozen looks.** Standard and Matte surfaces, Juicy shiny and Juicy shiny 2,
  Glass, X-ray, Jelly, Skull, maximum-intensity projection, Edges, opacity
  peeling (Rezk-Salama), Shell and Topography. Effect labels are decoupled from
  shader indices, so several presets can share one shader path. Every effect
  keeps its own independent parameter values, with Reset-parameters (current
  effect) and Reset-all-effects buttons.
- **Lighting you control.** Matcap materials (Shiny White, Clay, Bone, Titanium,
  Gold, Blue) for the surface effects, plus ambient, diffuse, specular and
  shininess sliders and a light-direction control.
- **Cut into the volume.** An oblique clip plane and a slicer cut at any angle,
  with keyboard shortcuts (toggle, axial / sagittal / coronal, invert, and
  Shift-drag to orient the cut). A cut-face overlay shows a clean windowed
  cross-section at the plane while the shaded volume fills the space behind it, so
  a ventricle reads as real lit depth rather than a flat dark hole.
- **Always know your orientation.** An orientation cube (S/I, A/P, L/R) tracks the
  camera, and two toolbar toggles, RAS (canonical vs the file's on-disk
  orientation) and Radiological (mirror L/R), drive a single flip shared by the
  2-D slices and the 3-D render so the two never disagree.
- **Colour-FA diffusion maps.** RGB NIfTIs load and render in 3-D as well as in
  2-D.
- **Quality** defaults to 50 percent (a performance knob, per effect), and the
  first volume of a session opens directly in Multi-Planar 3D when a GPU is
  present.

**GPU gate.** `gpu_available()` probes an offscreen OpenGL 3.3 core context and
rejects software renderers (llvmpipe, GDI). When it fails, or when PyOpenGL is
missing, the two 3-D buttons are hidden and the viewer stays a fast 2-D tool. A
partial or broken install therefore degrades gracefully to 2-D rather than
erroring.

**Cross-platform GL setup (`bidsmgr/main.py`).** `AA_ShareOpenGLContexts` and a
3.3-core default format are requested before the `QApplication` is built. On
Windows and Linux, adding the first `QOpenGLWidget` to an already-shown window
makes Qt recreate the native window (the window appears to close and reopen on the
first 3-D click); this is avoided by constructing the GL widget eagerly while the
pane is built, before the main window is shown.

The canvas backgrounds are pure black, scoped by object name in `theme.qss`
(`#nifti-canvas`) so the shared panel style is untouched.

## 2. Worker-pool robustness (`bidsmgr/util/parallel.py`, new)

joblib's default `loky` backend runs each task in a worker process, which is what
we want for DICOM header reads, convertibility probes and conversion: they are CPU
and IO heavy and sidestep the GIL. On **Windows with Python 3.14**, loky's spawn
path starts workers that die during bootstrap and joblib raises
`TerminatedWorkerError`, which previously took the whole scan down. joblib 1.5.3 /
loky 3.5.6 (the newest at the time of writing) still carry the bug, so there is no
version to upgrade to.

Rather than hard-coding a guess at the affected (OS, Python) pairs, which would
both punish machines that are fine and miss ones that are not, the policy is
**detect, do not predict**:

- `run_parallel` always starts with the fast process backend.
- If the pool dies with a dead-worker error, it falls back to in-process threads
  for that run and remembers it, so the rest of the session goes straight to
  threads instead of paying the failed start-up again. The memory is per process,
  so a fixed joblib picks the fast path back up on the next launch with no code
  change here.
- `BIDSMGR_PARALLEL_BACKEND=threading` forces the safe backend for the whole
  process, useful for confirming a support hunch without a code change.

The three call sites, `inventory/mri_dicom` (scan), `inventory/probe_convert`
(convertibility probe) and `cli/convert` (conversion), now build their pools
through `run_parallel` / `preferred_backend`. Threads are slower for this work
(the GIL is only released around IO and inside pydicom and subprocess calls) but
they are correct, use less memory, and keep the UI responsive. On every platform
except the broken one, behaviour is unchanged: real worker processes as before.

## 3. Rounded pop-up corners on Windows and Linux (`bidsmgr/gui/combo_popup.py`)

The rounded hover tooltips, combo pop-ups and context menus are frameless,
translucent windows so the QSS `border-radius` can render without a square OS
frame behind them. On macOS the compositor always paints clean antialiased
corners. On Windows and on uncomposited X11 / Wayland, the pixels outside the
rounded border are left black, so the corners must be clipped out of the window
with a mask. Two issues remained:

- The clip region was built from a flattened path
  (`QPainterPath.toFillPolygon().toPolygon()`), whose coarse, integer-rounded
  corners still let a few desktop pixels show as black. It is now assembled from
  two rectangles plus four ellipse corner regions, the exact way to build a
  rounded-rect region.
- Masks are given in logical pixels and Qt rescales them to device pixels. On
  fractionally-scaled HiDPI displays that rescale could land the mask arc a device
  pixel or two inside the painted arc, leaving a thin black ring. And the mask
  radius was hard-coded to 6 while combo pop-ups and menus paint at 8, so their
  corners were clipped too square. The mask now tracks the painted radius per
  surface (6 for tooltips, 8 for pop-ups and menus) and is cut a couple of logical
  pixels rounder, which keeps it a strict subset of the painted corner. Every
  pixel the mask keeps is painted, so no black corner survives, at the cost of a
  cosmetically negligible clip of the outermost corner border.

macOS keeps the translucent path (no mask) and looks exactly as before.

## Version

`pyproject.toml` moves from **1.2.4.2 to 1.2.5.1**. 1.2.5 shipped the 3-D renderer
and the worker-pool fix; 1.2.5.1 is the small follow-up that fully clips the pop-up
corners. Both are already released on PyPI.

## Tests

New and extended tests, run under `QT_QPA_PLATFORM=offscreen` for the GUI suite:

- `tests/gui/test_nifti_3d_view.py` (new, about 890 lines): effect / shader
  decoupling, per-effect parameter isolation, clip and slicer state, orientation
  flip round-tripping, the GPU gate, and the pane's view-mode routing.
- `tests/gui/test_nifti_viewer.py` (extended): the session-default view and the
  2-D and 3-D mode toggles.
- `tests/unit/test_parallel_backend.py` (new, about 170 lines): the
  detect-and-remember fallback, the forced-backend env var, and the dead-worker
  error classification.

The existing unit and GUI suites pass. Real GPU rendering was verified headlessly
with an offscreen surface and framebuffer grab (the `offscreen` Qt platform plugin
has no GL), and the viewer was exercised on real MRI volumes including colour-FA
maps.

## Architecture compliance

- The 3-D renderer lives entirely under `gui/widgets/`, the only Qt-coupled
  subtree. The schema keystone, inventory, classifier, planner, converter,
  metadata and validation layers are untouched by the viewer work.
- `util/parallel` is pure, Qt-free, and imports nothing from `gui/`. It is a
  policy helper the engine call sites opt into; the scan, probe and convert code
  paths are otherwise unchanged.
- No new runtime dependencies. PyOpenGL and pyqtgraph were already declared;
  matplotlib is still not required.
- No `Pipeline` orchestrator and no `core/` package were introduced.

## Commits

```
48ee7f4 chore: bump version to 1.2.5.1
3823720 fix(gui): clip the last black corner sliver on HiDPI Windows/Linux popups
c83cbde fix(gui): eliminate residual black tooltip corners on Windows/Linux
af576db chore: bump version to 1.2.5
28c379f fix(gui): mask rounded popups off-macOS; add Realistic tissue effect
f073348 chore: drop now-unused Parallel imports
3e518f3 feat(viewer): render colour-FA volumes in 3-D, like MRIcroGL
dc4a8a8 refactor(parallel): detect a broken worker pool instead of guessing at it
ddf2294 fix(scan): work around joblib worker crash on Windows + Python 3.14
630611f fix(viewer): open colour-FA (RGB) NIfTIs; stop black leaking into 3-D controls
4f9587d feat(viewer): default 3-D quality to 50%; open first scan in a default view
5f4bd26 feat(viewer): add Juicy shiny 2 effect; pure-black visualization canvas
8e3a685 feat(viewer): per-effect parameters, Juicy shiny effect, reordered effect list
a648de5 feat(viewer): RAS/Radiological orientation toggles, aligned 2D+3D, slider values
57bb06e fix(viewer): revert 3D wheel device-type change; fix only Linux Shift+wheel
1ed4e23 fix(viewer): 3D mouse-wheel zoom on Linux (device-type aware scroll)
318fa38 feat(viewer): unify the two 3D views, add slicer shortcuts, effects & fixes
9ce82cb feat(viewer): expand 3D effects, lighting, clip slicing and orientation cube
ae5d3e9 feat(viewer): GPU volume rendering for the NIfTI viewer
```
