### PR TITLE
fix rounded popup corners on Windows and Linux without a clip mask (v1.2.5.1 to v1.2.5.2)

### DIFF
--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -1,25 +1,35 @@
-"""Round ``QComboBox`` popups and hover tooltips application-wide.
+"""Round ``QComboBox`` popups, hover tooltips and menus application-wide.
 
-Two things are needed for a combo dropdown to look like the header project
-menu (rounded corners, no square frame):
+Every rounded popup in the app uses ONE recipe, the same one the project
+switcher menu sets on itself in ``main_window`` (which renders clean rounded
+corners on macOS, Windows and Linux): make the top-level popup window
+**frameless + translucent + shadowless** so the QSS ``border-radius`` shows
+without a square OS frame or a black background behind it.
 
-1. The QSS rule ``QComboBox { combobox-popup: 0; }`` (in ``theme.qss``)
-   forces Qt's own ``QListView`` popup instead of the native macOS
-   ``NSMenu``, which ignores every stylesheet rule. With it the popup view
-   honours ``QComboBox QAbstractItemView`` (rounded list + rounded
-   selection).
+Two kinds of popup need help reaching that recipe:
 
-2. The popup still lives in a top-level window with a square OS frame +
-   shadow behind the rounded view. This installs an application event
-   filter that makes that container frameless + translucent + shadowless
-   (the exact recipe the project menu uses), so only the rounded view
-   shows. Geometry is captured and restored around the flag change so the
-   popup stays anchored under its combo.
+1. ``QComboBox`` dropdowns. The QSS rule ``QComboBox { combobox-popup: 0; }``
+   (in ``theme.qss``) forces Qt's own ``QListView`` popup instead of the
+   native macOS ``NSMenu``, which ignores every stylesheet rule. With it the
+   popup view honours ``QComboBox QAbstractItemView`` (rounded list + rounded
+   selection). The popup still lives in a top-level container with a square OS
+   frame, so the application event filter below makes that container frameless
+   and translucent.
 
-The same filter also rounds hover tooltips: the ``QToolTip`` QSS carries a
-``border-radius`` but its ``QTipLabel`` window otherwise shows square OS
-corners, so it gets the identical frameless + translucent + shadowless
-treatment to stay consistent with the rounded GUI.
+2. Hover tooltips (``QTipLabel``). Same treatment so the ``QToolTip``
+   border-radius renders without square OS corners.
+
+Menus that the app constructs itself get the recipe directly through
+:func:`round_menu` (no event filter needed, since we own the widget).
+
+Why no clip mask: an earlier version clipped these windows to a rounded
+``QRegion`` on Windows / Linux, on the theory that a translucent window goes
+black in the corners without a compositor. On composited desktops (the norm)
+that is unnecessary, and the mask had to read the popup's size the instant it
+was shown, before Qt had laid a tooltip out, so it clipped popups to a stale,
+tiny rectangle and reintroduced exactly the black corners it meant to remove.
+The project switcher menu carries no mask and looks correct everywhere, so the
+whole app now relies on translucency alone.
 
 Defensive: any failure is swallowed so a dropdown or tooltip can never be
 broken by this cosmetic pass. Call :func:`install` once, after the
@@ -29,41 +39,12 @@ QApplication and theme are set up.
 from __future__ import annotations
 
 import logging
-import sys
 
 from PyQt6.QtCore import QEvent, QObject, Qt
-from PyQt6.QtGui import QRegion
 
 log = logging.getLogger(__name__)
 
 _FLAG = "_bidsmgr_round_popup"
-
-# Painted corner radius of each rounded surface, mirroring the ``border-radius``
-# in theme.qss: 6px for ``QToolTip`` but 8px for ``QComboBox QAbstractItemView``
-# and ``QMenu#rounded-menu``. They differ, so the mask must use the right base
-# per surface (a 6px mask on an 8px popup would leave the 6..8 corner ring
-# unclipped and black).
-_TOOLTIP_RADIUS = 6
-_POPUP_RADIUS = 8
-
-# The mask is specified in logical pixels and Qt rescales it to device pixels.
-# On HiDPI / fractionally-scaled Windows and X11 that rescale can land the
-# mask's arc a device pixel or two INSIDE the painted border-radius arc,
-# leaving a thin ring of the translucent (black) corner unclipped - the
-# "still a bit of black" sliver. Cutting the mask a couple of logical pixels
-# ROUNDER makes it a strict subset of the painted shape, so every pixel the
-# mask keeps is painted and none of the black corner survives. The only cost
-# is a cosmetically negligible clip of the outermost corner border.
-_MASK_CUSHION = 2
-
-# A translucent window only yields clean rounded corners where the platform
-# COMPOSITES it. macOS always does, so the corners there are transparent and
-# antialiased. On Windows and on X11/Wayland sessions without a compositor the
-# pixels outside the rounded border are left unpainted and come out BLACK —
-# the "picky black background" behind the rounded tooltip. Masking cuts those
-# pixels out of the window entirely so nothing can show through; the trade-off
-# is aliased (hard) edges, which is why macOS keeps the nicer translucent path.
-_NEEDS_MASK = sys.platform != "darwin"
 
 
 class _PopupRounder(QObject):
@@ -71,26 +52,16 @@ class _PopupRounder(QObject):
 
     def eventFilter(self, obj, event):  # noqa: N802 - Qt signature
         try:
-            etype = event.type()
-            # Resize matters as much as Show: Qt REUSES one QTipLabel for every
-            # tooltip and just re-texts/resizes it, often without a fresh Show.
-            # A mask left at the previous tooltip's size would stop clipping
-            # the corners of a narrower one (black corners return) or clip the
-            # content of a wider one.
-            if etype not in (QEvent.Type.Show, QEvent.Type.Resize):
+            if event.type() != QEvent.Type.Show or obj.property(_FLAG):
                 return False
             cls = obj.metaObject().className()
-            if cls not in ("QComboBoxPrivateContainer", "QTipLabel"):
-                return False
-            if etype == QEvent.Type.Show and not obj.property(_FLAG):
-                if cls == "QComboBoxPrivateContainer":
-                    obj.setObjectName("combo-popup")
-                # Same recipe for both so the QSS border-radius renders
-                # without a square OS frame behind it.
+            if cls == "QComboBoxPrivateContainer":
+                obj.setObjectName("combo-popup")
                 self._round(obj)
-            # Tooltips paint at 6px, combo popups at 8px - mask each to match.
-            base = _TOOLTIP_RADIUS if cls == "QTipLabel" else _POPUP_RADIUS
-            _mask(obj, base)
+            elif cls == "QTipLabel":
+                # Hover tooltips: same recipe so the QToolTip border-radius
+                # renders without square OS corners, matching the rounded GUI.
+                self._round(obj)
         except Exception as exc:  # noqa: BLE001 - never break a popup/tooltip
             log.debug("popup round failed: %s", exc)
         return False
@@ -112,48 +83,6 @@ class _PopupRounder(QObject):
         obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         obj.setGeometry(geo)
         obj.show()  # re-show so the new window flags take effect
-
-
-def _mask(obj, radius: int) -> None:
-    """Clip *obj*'s window to a rounded rectangle a touch rounder than the paint.
-
-    *radius* is the surface's PAINTED ``border-radius``; the mask itself is cut
-    at ``radius + _MASK_CUSHION`` so it stays a strict subset of the painted
-    shape (see ``_MASK_CUSHION``) and no black corner sliver can survive DPR
-    rescaling.
-
-    No-op on macOS, where the translucent window already composites clean
-    antialiased corners. Elsewhere this removes the corner pixels from the
-    window so an uncomposited desktop cannot paint them black.
-
-    The region is assembled from two overlapping rectangles (a plus/cross
-    shape) plus four ``Ellipse`` corner regions. That is the precise way to
-    build a rounded-rect ``QRegion``: the earlier ``QPainterPath`` ->
-    ``toFillPolygon().toPolygon()`` route flattened the arcs to a coarse,
-    integer-rounded polygon, so a few desktop pixels still peeked through the
-    corners as black on uncomposited Windows / X11. Rectangles + ellipses give
-    exact corners with none of that residue.
-    """
-    if not _NEEDS_MASK:
-        return
-    rect = obj.rect()
-    w, h = rect.width(), rect.height()
-    if w <= 0 or h <= 0:
-        return
-    x, y = rect.x(), rect.y()
-    r = max(0, min(radius + _MASK_CUSHION, w // 2, h // 2))
-    if r == 0:
-        obj.clearMask()
-        return
-    d = 2 * r
-    Ellipse = QRegion.RegionType.Ellipse
-    region = QRegion(x + r, y, w - d, h)             # full-height centre band
-    region = region.united(QRegion(x, y + r, w, h - d))  # full-width centre band
-    region = region.united(QRegion(x, y, d, d, Ellipse))                  # top-left
-    region = region.united(QRegion(x + w - d, y, d, d, Ellipse))          # top-right
-    region = region.united(QRegion(x, y + h - d, d, d, Ellipse))          # bottom-left
-    region = region.united(QRegion(x + w - d, y + h - d, d, d, Ellipse))  # bottom-right
-    obj.setMask(region)
 
 
 _instance: _PopupRounder | None = None
@@ -182,10 +111,6 @@ def round_menu(menu) -> None:
         | Qt.WindowType.NoDropShadowWindowHint
     )
     menu.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-    # Same uncomposited-desktop guard as the tooltips: mask once the menu has
-    # been laid out, so its corners can't paint black on Windows / X11.
-    if _NEEDS_MASK:
-        menu.aboutToShow.connect(lambda m=menu: _mask(m, _POPUP_RADIUS))
 
 
 __all__ = ["install", "round_menu"]

--- a/bidsmgr/gui/combo_popup.py
+++ b/bidsmgr/gui/combo_popup.py
@@ -1,39 +1,40 @@
 """Round ``QComboBox`` popups, hover tooltips and menus application-wide.
 
 Every rounded popup in the app uses ONE recipe, the same one the project
-switcher menu sets on itself in ``main_window`` (which renders clean rounded
-corners on macOS, Windows and Linux): make the top-level popup window
-**frameless + translucent + shadowless** so the QSS ``border-radius`` shows
-without a square OS frame or a black background behind it.
+switcher menu sets on itself in ``main_window``: make the top-level popup
+window **frameless + translucent + shadowless** so the QSS ``border-radius``
+shows without a square OS frame or a black background behind it.
 
-Two kinds of popup need help reaching that recipe:
+The subtlety is *when* the translucent attribute is set. A window only gets a
+real alpha channel on Windows and X11 if transparency is requested **before the
+OS window is created**; you cannot add an alpha channel to a window that already
+exists there (macOS composites every window with alpha regardless, which is why
+it never showed the problem). The menus get this for free: we build the
+``QMenu`` and set the attribute on it before it is ever shown, so its window is
+born translucent.
 
-1. ``QComboBox`` dropdowns. The QSS rule ``QComboBox { combobox-popup: 0; }``
-   (in ``theme.qss``) forces Qt's own ``QListView`` popup instead of the
-   native macOS ``NSMenu``, which ignores every stylesheet rule. With it the
-   popup view honours ``QComboBox QAbstractItemView`` (rounded list + rounded
-   selection). The popup still lives in a top-level container with a square OS
-   frame, so the application event filter below makes that container frameless
-   and translucent.
+Qt's own combo dropdown (``QComboBoxPrivateContainer``) and hover tooltip
+(``QTipLabel``) are created internally, so an application event filter is the
+only way to reach them. The key is to reach them on the ``Polish`` event, which
+Qt delivers **before** the native window is created (verified: the widget's
+``WA_WState_Created`` attribute is False at Polish and True by Show), not on the
+``Show`` event, which fires after. Setting the flags at Polish means the window
+is created translucent, with clean transparent corners on every platform, and
+needs no clip mask.
 
-2. Hover tooltips (``QTipLabel``). Same treatment so the ``QToolTip``
-   border-radius renders without square OS corners.
+An earlier version instead set the attribute at Show (too late off-macOS, so the
+corners came out black) and tried to paper over it with a rounded clip mask,
+which also mis-clipped tooltips whose size was not laid out yet. Both are gone:
+one Polish-time recipe now serves combos, tooltips and menus alike.
 
-Menus that the app constructs itself get the recipe directly through
-:func:`round_menu` (no event filter needed, since we own the widget).
-
-Why no clip mask: an earlier version clipped these windows to a rounded
-``QRegion`` on Windows / Linux, on the theory that a translucent window goes
-black in the corners without a compositor. On composited desktops (the norm)
-that is unnecessary, and the mask had to read the popup's size the instant it
-was shown, before Qt had laid a tooltip out, so it clipped popups to a stale,
-tiny rectangle and reintroduced exactly the black corners it meant to remove.
-The project switcher menu carries no mask and looks correct everywhere, so the
-whole app now relies on translucency alone.
+The QSS rule ``QComboBox { combobox-popup: 0; }`` (in ``theme.qss``) is still
+required so Qt uses its own stylesheet-aware ``QListView`` popup instead of the
+native macOS ``NSMenu``.
 
 Defensive: any failure is swallowed so a dropdown or tooltip can never be
-broken by this cosmetic pass. Call :func:`install` once, after the
-QApplication and theme are set up.
+broken by this cosmetic pass. Call :func:`install` once, right after the
+QApplication is created and before any window is built (so no combo or tooltip
+is polished before the filter is watching).
 """
 
 from __future__ import annotations
@@ -52,7 +53,12 @@ class _PopupRounder(QObject):
 
     def eventFilter(self, obj, event):  # noqa: N802 - Qt signature
         try:
-            if event.type() != QEvent.Type.Show or obj.property(_FLAG):
+            # Polish, NOT Show: Polish is delivered BEFORE the widget's native
+            # window is created, so the translucent attribute we set here is in
+            # place when the OS creates the window and it gets a real alpha
+            # channel (clean corners on Windows / X11). At Show the window
+            # already exists and translucency can no longer be added off-macOS.
+            if event.type() != QEvent.Type.Polish or obj.property(_FLAG):
                 return False
             cls = obj.metaObject().className()
             if cls == "QComboBoxPrivateContainer":
@@ -68,21 +74,20 @@ class _PopupRounder(QObject):
 
     @staticmethod
     def _round(obj) -> None:
-        """Make *obj* a frameless, translucent, shadowless top-level window.
+        """Make *obj* frameless + translucent + shadowless before its window exists.
 
-        Geometry is captured and restored around the flag change so the popup
-        stays exactly where Qt placed it, then re-shown so the flags apply.
+        Called on Polish, so no native window has been created yet: we just set
+        the flags and the attribute and let Qt create the window translucent. No
+        geometry capture and no re-show are needed (the widget is not visible
+        yet), unlike the old Show-time path.
         """
         obj.setProperty(_FLAG, True)
-        geo = obj.geometry()
         obj.setWindowFlags(
             obj.windowFlags()
             | Qt.WindowType.FramelessWindowHint
             | Qt.WindowType.NoDropShadowWindowHint
         )
         obj.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
-        obj.setGeometry(geo)
-        obj.show()  # re-show so the new window flags take effect
 
 
 _instance: _PopupRounder | None = None
@@ -101,8 +106,10 @@ def round_menu(menu) -> None:
     """Give a ``QMenu`` rounded corners (the project-menu recipe).
 
     Frameless + translucent + no-shadow so the QSS ``QMenu#rounded-menu``
-    border-radius renders without a square OS frame behind it. Use for any
-    context / popup menu (e.g. the Welcome recents right-click menu).
+    border-radius renders without a square OS frame behind it. Call this right
+    after building the menu and before it is shown, so its window is created
+    translucent. Use for any context / popup menu (e.g. the Welcome recents
+    right-click menu).
     """
     menu.setObjectName("rounded-menu")
     menu.setWindowFlags(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bids-manager"
-version = "1.2.5.1"
+version = "1.2.5.2"
 description = "Schema-driven BIDS converter, curator, and editor (re-imagination of BIDS-Manager v0.2.5)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
# BIDS Manager: fix rounded popup corners on Windows and Linux without a clip mask (v1.2.5.1 to v1.2.5.2)

## Summary

This PR brings `ANCPLabOldenburg/BIDS-Manager:main` from **v1.2.5.1 up to
v1.2.5.2**. It is a small, focused follow-up to the popup-rounding code that
shipped in 1.2.5.1: **3 commits, 2 files, +57 / -125 lines** (a net removal, the
GUI file gets simpler).

1.2.5.1 rounded the hover tooltips and menus and, on Windows and Linux, clipped
their corners to a rounded region (a mask) to hide the black background that a
translucent window shows on those platforms. That mask turned out to cause more
trouble than it solved: it clipped the scan / 3D-effect combo dropdowns and the
tooltips to a stale, tiny size (their geometry is not laid out at the instant the
mask read it), so those popups broke on Windows and Linux while the menus, which
never went through that path, stayed clean.

This PR removes the mask entirely and fixes the corners the right way: it makes
each popup window **translucent before its OS window is created**, so the window
is born with a real alpha channel and its corners are genuinely transparent on
every platform. Verified on Windows and Linux (clean corners, all popups) and on
macOS (unchanged).

## The root cause

A frameless popup only shows clean rounded corners if the pixels outside the
rounded border are transparent, and that requires the window to have an **alpha
channel**. On Windows and X11 a window gets an alpha channel only if transparency
is requested **before the OS window is created**; you cannot add one to a window
that already exists. macOS composites every window with alpha unconditionally,
which is why it never showed the problem and why the mask was always a no-op
there.

The project switcher menu and the editor right-click menu are `QMenu`s that the
app builds itself, so they set `WA_TranslucentBackground` before they are ever
shown, their window is born translucent, and their corners are clean. Qt's own
combo dropdown (`QComboBoxPrivateContainer`) and tooltip (`QTipLabel`) are
created internally, and the application event filter was configuring them on
their **Show** event, by which point the opaque OS window already existed, so the
translucent attribute had no effect and the corners came out black. The 1.2.5.1
mask was a workaround for that black, and it is what broke the combos.

## The fix

The application event filter now configures the combo and tooltip windows on the
**Polish** event instead of Show. Qt delivers `Polish` **before** it creates the
widget's native window, and `Show` after. This was verified against the widget
lifecycle: a popup's `WA_WState_Created` attribute is `False` at Polish and
`True` by Show. Because that lifecycle is Qt's own and platform independent, the
same ordering holds on Windows and Linux.

Setting frameless + translucent at Polish therefore means the OS creates the
window translucent, with a real alpha channel, exactly like the menus. The
result:

- Combo dropdowns, tooltips and menus all reach one recipe (translucent before
  creation), so every rounded popup is consistent.
- No clip mask, so nothing to mis-size, and the corners are compositor
  antialiased rather than hard-clipped.
- The old geometry-capture and re-show dance is gone, since the window does not
  exist yet when we configure it.

`bidsmgr/gui/combo_popup.py` is the only code file touched (plus the version bump
in `pyproject.toml`); it gets net smaller because the mask machinery
(`QRegion` building, per-resize re-masking, the platform branch) is deleted.

## Limitations

The translucent-before-creation approach needs a **compositor** on Linux/X11 (a
32-bit ARGB visual and a running compositor to blend it). On a bare X11 session
with no compositor, the transparent corners would have nothing to blend against.
This is the one case the removed mask handled that translucency does not, but it
is rare in practice: every modern desktop (GNOME, KDE, all of Wayland, Windows
DWM, macOS) composites, which is why the fix works on the tested Windows and
Linux machines.

The filter also relies on two Qt internals: the private class names
`QComboBoxPrivateContainer` and `QTipLabel`, and Polish being delivered before
window creation. Both are long-standing and stable; if a future Qt changed
either, the rounding would silently fall back to square (still functional)
windows rather than error, since the whole pass is wrapped in a try/except.

## Testing

- The Polish-before-creation timing and the resulting attribute state were
  verified programmatically (combo container and tooltip both report
  `WA_TranslucentBackground = True` and frameless, set while the native window
  did not yet exist).
- Real GUI check on Windows and Linux: combo dropdowns, tooltips and menus all
  render clean transparent rounded corners.
- macOS is unaffected (it always used the translucent path; the mask never ran
  there, and window alpha is available regardless of timing).
- ruff clean.

## Architecture compliance

The change is confined to `bidsmgr/gui/combo_popup.py`, inside the only
Qt-coupled subtree. No engine, schema, converter, or validation code is touched.
No new dependencies. No `Pipeline` orchestrator and no `core/` package.

## Commits

```
34ea9c5 chore: bump version to 1.2.5.2
8dcc56d fix(gui): round popups translucently by acting at Polish, not Show
3276969 fix(gui): drop the popup corner mask, round with translucency only
```
